### PR TITLE
Feature/acc record types

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -469,6 +469,7 @@ public with sharing class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                 }*/               
                 a.Type = CAO_Constants.isHHAccountModel() ? CAO_Constants.HH_TYPE : '';
                 a.SYSTEMISINDIVIDUAL__c = true;
+                
                 accountInserts.add(a);
                 listContactNewAcct.add(c);
             }
@@ -485,6 +486,11 @@ public with sharing class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             for (Contact c : listContactNewAcct) {
                 // for each success, write the new AccountId to the Contact.
                 c.AccountId = accountInserts[i].Id;
+                
+                //Populate the primary household lookup field
+                System.debug('****Populating the primary household field');
+                c.Primary_Household__c = accountInserts[i].Id;
+                
                 /**** 
                 if (lsr[i].isSuccess() == true) {
                     c.AccountId = lsr[i].getId();
@@ -493,6 +499,7 @@ public with sharing class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                     // DJH:UNDONE - need to use error class to log DML errors
                 }
                 *****/
+
                 i += 1;
             }
         }

--- a/src/classes/AFFL_MultiRecordType_TDTM.cls
+++ b/src/classes/AFFL_MultiRecordType_TDTM.cls
@@ -88,72 +88,95 @@ public with sharing class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 			 //WARNING: NOT BULK SAFE! WE'LL NEED TO OPTIMIZE IT, IF WE GO FOR THIS DESIGN!
 			 
 			 Integer i = 0;
-	    	 for (SObject so : newlist) {
-	            Affiliation__c affl = (Affiliation__c)so;
-
-	            //BEFORE INSERT - so we don't get the affiliation we just created when we query for affls of the same type
-	            if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
-	            	
+			 if(newlist != null && newlist.size() > 0) {
+		    	 for (SObject so : newlist) {
+		            Affiliation__c affl = (Affiliation__c)so;
+					
 					System.debug('****MRT: affl type: ' + affl.Affiliation_Type__c);
 					String lookupFieldLabel = mappingsRecTypesToLabels.get(affl.Affiliation_Type__c);
 					System.debug('****MRT: lookup field label: ' + lookupFieldLabel);
 					String lookupFieldName = contactLabelNames.get(lookupFieldLabel);
-					System.debug('****MRT: lookup field nane: ' + lookupFieldName);
-				
-	            	List<Affiliation__c> otherPrimaries;
-	            	
-	            	//If the account doesn't have a record type, find any other primary affiliations with no record type for this contact.
-	            	if(affl.Affiliation_Type__c == null) {
-						otherPrimaries = [select ID, Organization__c, Primary__c from Affiliation__c 
-														where Affiliation_Type__c = null 
-														and Contact__c = :affl.Contact__c and Primary__c = true];
-	            	//If the account has a record type, find any other primary affiliations of this record type for this contact.
-	            	} else {
-						otherPrimaries = [select ID, Organization__c, Primary__c from Affiliation__c 
-														where Affiliation_Type__c = :affl.Affiliation_Type__c 
-														and Contact__c = :affl.Contact__c and Primary__c = true];
-	            	}
-					System.debug('****MRT: Number of existing primary affiliations with the same record type: ' + otherPrimaries.size());
+					System.debug('****MRT: lookup field name: ' + lookupFieldName);
 					
 					//Query all the primary affiliation lookup fields on the contact - they are not available in the trigger.
 					Contact relatedContact = queryAfflLookupFields(affl);
-	            	
-	                if (affl.Primary__c && affl.Contact__c != null && affl.Organization__c != null) {
-	                    List<ID> oldLookups = new List<ID>();
-	                    //If the newly created affiliation is the primary, uncheck other primary affiliations of the same type.
-	                    for(Affiliation__c otherAffl : otherPrimaries) {
-	                		otherAffl.Primary__c = false;
-	                		dmlWrapper.objectsToUpdate.add(otherAffl);
-	                		oldLookups.add(otherAffl.Organization__c);
-	                    }
-	                    System.debug('****MRT: Number of lookups of this type:' + oldLookups.size());
-	                    
-	                    //If there is no affiliation lookup of this type and we have a mapping, populate the lookup field
-	                    //defined in the mapping. 
-	                    if((oldLookups.size() == 0 || oldLookups.size() == 1) && !String.isBlank(lookupFieldName)) {
-	                    	System.debug('****MRT: populating lookup field ' + lookupFieldName + ' on contact');
-							relatedContact.put(lookupFieldName, affl.Organization__c);
-		                    dmlWrapper.objectsToUpdate.add(relatedContact); 
-	                    //If there's more than one, throw an error.
-	                    } else if(oldLookups.size() > 1) {
-	                    	affl.addError('Multiple primary affiliations of the same type to the same contact exist. Leave only one before proceeding.');
-	                    }
-	                }
-	            }
-	            
-	            // AFTER UPDATE
-	            if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
-	                Affiliation__c afflOld = (Affiliation__c)oldlist[i];
-	                if (affl.Primary__c != afflOld.Primary__c) {
-	                                       
-	                }
-	            }
-	            
-	            //AFTER DELETE - delete lookup relationship, if necessary
-	            if (triggerAction == TDTM_Runnable.Action.AfterDelete) {
-	            	
-	            }         
-	        	i++;
+						
+		            //BEFORE INSERT - so we don't get the affiliation we just created when we query for affls of the same type
+		            if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
+		            	
+		            	List<Affiliation__c> otherPrimaries;
+		            	
+		            	//If the account doesn't have a record type, find any other primary affiliations with no record type for this contact.
+		            	if(affl.Affiliation_Type__c == null) {
+							otherPrimaries = [select ID, Organization__c, Primary__c from Affiliation__c 
+															where Affiliation_Type__c = null 
+															and Contact__c = :affl.Contact__c and Primary__c = true];
+		            	//If the account has a record type, find any other primary affiliations of this record type for this contact.
+		            	} else {
+							otherPrimaries = [select ID, Organization__c, Primary__c from Affiliation__c 
+															where Affiliation_Type__c = :affl.Affiliation_Type__c 
+															and Contact__c = :affl.Contact__c and Primary__c = true];
+		            	}
+						System.debug('****MRT: Number of existing primary affiliations with the same record type: ' + otherPrimaries.size());
+						
+		                if (affl.Primary__c && affl.Contact__c != null && affl.Organization__c != null) {
+		                    List<ID> oldLookups = new List<ID>();
+		                    //If the newly created affiliation is the primary, uncheck other primary affiliations of the same type.
+		                    for(Affiliation__c otherAffl : otherPrimaries) {
+		                		otherAffl.Primary__c = false;
+		                		dmlWrapper.objectsToUpdate.add(otherAffl);
+		                		oldLookups.add(otherAffl.Organization__c);
+		                    }
+		                    System.debug('****MRT: Number of lookups of this type:' + oldLookups.size());
+		                    
+		                    //If there is no affiliation lookup of this type and we have a mapping, populate the lookup field
+		                    //defined in the mapping. 
+		                    if((oldLookups.size() == 0 || oldLookups.size() == 1) && !String.isBlank(lookupFieldName)) {
+		                    	System.debug('****MRT: populating lookup field ' + lookupFieldName + ' on contact');
+								relatedContact.put(lookupFieldName, affl.Organization__c);
+			                    dmlWrapper.objectsToUpdate.add(relatedContact); 
+		                    //If there's more than one, throw an error.
+		                    } else if(oldLookups.size() > 1) {
+		                    	affl.addError('Multiple primary affiliations of the same type to the same contact exist. Leave only one before proceeding.');
+		                    }
+		                }
+		            }
+		            
+		            // AFTER UPDATE
+		            if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+		                Affiliation__c afflOld = (Affiliation__c)oldlist[i];
+		                if (affl.Primary__c != afflOld.Primary__c) {
+		                                       
+		                }
+		            }      
+		        	i++;
+		    	 }
+			 }
+	    	 
+	    	 if(oldlist != null && oldlist.size() > 0) {
+		    	 for(SObject so : oldlist) {
+		    	 	Affiliation__c affl = (Affiliation__c)so;
+		    	 	
+		    	 	System.debug('****MRT: affl type: ' + affl.Affiliation_Type__c);
+					String lookupFieldLabel = mappingsRecTypesToLabels.get(affl.Affiliation_Type__c);
+					System.debug('****MRT: lookup field label: ' + lookupFieldLabel);
+					String lookupFieldName = contactLabelNames.get(lookupFieldLabel);
+					System.debug('****MRT: lookup field name: ' + lookupFieldName);
+					
+		    	 	//Query all the primary affiliation lookup fields on the contact - they are not available in the trigger.
+					Contact relatedContact = queryAfflLookupFields(affl);
+					
+		    	 	//AFTER DELETE - delete lookup relationship, if necessary
+		            if (triggerAction == TDTM_Runnable.Action.AfterDelete) {
+		            	System.debug('****MRT: after delete');
+		            	//If the affl is primary, and the lookup field of this type is pointing to the account that is part of the affl ==> clear the lookup
+		            	if(affl.Primary__c && relatedContact.get(lookupFieldName) == affl.Organization__c) {
+		            		System.debug('****MRT: clearing lookup field');
+		            		relatedContact.put(lookupFieldName, null);
+		            		dmlWrapper.objectsToUpdate.add(relatedContact);
+		            	}
+		            }
+		    	 }
 	    	 }
 	    	 afflMultiHasRun = true;  
         } 

--- a/src/classes/AFFL_MultiRecordType_TEST.cls
+++ b/src/classes/AFFL_MultiRecordType_TEST.cls
@@ -2,7 +2,9 @@
 public with sharing class AFFL_MultiRecordType_TEST {
 	
 	@isTest
-	public static void createPrimaryAffl() {    
+	public static void createPrimaryAffl() {
+		UTIL_CustomSettingsFacade.getAffiliationsSettingsForTests(new Affiliations_Settings__c(Automatic_Affiliation_Creation_Turned_On__c = true));
+		
 		List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
     	mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = 'Primary Business Organization'));	
     	mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = 'Primary Household'));
@@ -13,6 +15,15 @@ public with sharing class AFFL_MultiRecordType_TEST {
     	
     	Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
     	insert contact;
+    	
+    	contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
+    	
+    	//Verify default household account has been created for the contact
+    	System.assertNotEquals(null, contact.Account.ID);
+    	
+    	//Verify the primary household field was populated
+    	System.assertEquals(contact.Account.ID, contact.Primary_Household__c);
+    	
     	Account acc1 = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
     	insert acc1;
     	

--- a/src/classes/AFFL_MultiRecordType_TEST.cls
+++ b/src/classes/AFFL_MultiRecordType_TEST.cls
@@ -1,8 +1,14 @@
 @isTest
 public with sharing class AFFL_MultiRecordType_TEST {
 	
-	@isTest
-	public static void createPrimaryAffl() {
+	private static ID orgRecTypeID;
+	private static ID householdRecTypeID;
+	
+	// if you only want to run one test in this class, fill in its name here.
+    // if you want to run all tests, then use '*'
+    private static string strTestOnly = '*';
+    
+	private static void setup() {
 		UTIL_CustomSettingsFacade.getAffiliationsSettingsForTests(new Affiliations_Settings__c(Automatic_Affiliation_Creation_Turned_On__c = true));
 		
 		List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
@@ -10,9 +16,16 @@ public with sharing class AFFL_MultiRecordType_TEST {
     	mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = 'Primary Household'));
     	insert mappings;
     	
-    	ID orgRecTypeID = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get('Business Organization').getRecordTypeId();
-    	ID householdRecTypeID = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get('Household Account').getRecordTypeId();
-    	
+    	orgRecTypeID = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get('Business Organization').getRecordTypeId();
+    	householdRecTypeID = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get('Household Account').getRecordTypeId();
+	}
+	
+	@isTest
+	public static void createPrimaryAffl() {
+		if (strTestOnly != '*' && strTestOnly != 'createPrimaryAffl') return;
+		
+		setup();
+
     	Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
     	insert contact;
     	
@@ -57,5 +70,34 @@ public with sharing class AFFL_MultiRecordType_TEST {
 		//The business organization lookup should point to the account that is part of the second affiliation we created
 		contact = [select Primary_Organization__c from Contact where ID = :contact.ID];
 		System.assertEquals(acc2.ID, Contact.Primary_Organization__c);
+	}
+	
+	@isTest
+	public static void deletePrimaryAffl() {
+		if (strTestOnly != '*' && strTestOnly != 'deletePrimaryAffl') return;
+		
+		setup();
+
+    	Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
+    	insert contact;
+    	
+    	Account acc1 = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
+    	insert acc1;
+    	
+    	//Create primary affiliation
+		Affiliation__c affl1 = new Affiliation__c(Contact__c = contact.ID, Organization__c = acc1.ID, Primary__c = true);
+		insert affl1;
+    	
+    	contact = [select Primary_Organization__c from Contact where ID = :contact.ID];
+		System.assertEquals(acc1.ID, Contact.Primary_Organization__c);
+		
+		Test.startTest();
+		AFFL_MultiRecordType_TDTM.afflMultiHasRun = false;
+		System.debug('****About to delete affiliation.');
+		delete affl1;
+		Test.stopTest();
+		
+		contact = [select Primary_Organization__c from Contact where ID = :contact.ID];
+		System.assertEquals(null, Contact.Primary_Organization__c);
 	}
 }

--- a/src/classes/TDTM_TriggerHandler.cls
+++ b/src/classes/TDTM_TriggerHandler.cls
@@ -118,6 +118,7 @@ public with sharing class TDTM_TriggerHandler {
 	        }
 	    } catch(Exception e) {
 	    	UTIL_Debug.debug(LoggingLevel.WARN, '****Exception caught in run method of TDTM_TriggerHandler: ' + e.getMessage());
+	    	UTIL_Debug.debug(LoggingLevel.WARN, '\n****Stack Trace:\n' + e.getStackTraceString() + '\n');
             if(!UTIL_CustomSettingsFacade.getErrorSettings().Disable_Error_Handling__c) {
                 Database.rollback(sp);
                 //Store error record and send error email notification


### PR DESCRIPTION
- Populating key household affiliation when a Contact of Household Account model is created
- Deleting matching key affiliation in Contact when a primary Affiliation record is deleted