### PR TITLE
Feature/8837 accessibility

### DIFF
--- a/src/classes/UTIL_Namespace.cls
+++ b/src/classes/UTIL_Namespace.cls
@@ -133,8 +133,8 @@ public class UTIL_Namespace {
     }
     
     public static void hack() {
-        Label.noAfflMappings;
-        Label.noAutoCreateSettings;
-        Label.noRecSettings;
+        String l1 = Label.noAfflMappings;
+        String l2 = Label.noAutoCreateSettings;
+        String l3 = Label.noRecSettings;
     }
 }

--- a/src/classes/UTIL_Namespace.cls
+++ b/src/classes/UTIL_Namespace.cls
@@ -131,4 +131,10 @@ public class UTIL_Namespace {
         }
         return email;
     }
+    
+    public static void hack() {
+        Label.noAfflMappings;
+        Label.noAutoCreateSettings;
+        Label.noRecSettings;
+    }
 }


### PR DESCRIPTION
Testing if the reason why these labels are not in the package is because they are not being referenced anywhere in Apex.