### PR TITLE
Everywhere else in our Lightning components we are using the namespac…

### DIFF
--- a/src/aura/STG_CMP_Base/STG_CMP_BaseHelper.js
+++ b/src/aura/STG_CMP_Base/STG_CMP_BaseHelper.js
@@ -127,7 +127,7 @@
 		if(!namespacePrefix || namespacePrefix.length == 0) {
 			prefix = "c";
 		} else {
-			prefix = namespacePrefix;
+			prefix = namespacePrefix.replace('__', '');
 		}
 		component.set(messageElement, labels[prefix][label]);
 	},

--- a/src/classes/UTIL_Namespace.cls
+++ b/src/classes/UTIL_Namespace.cls
@@ -132,6 +132,11 @@ public class UTIL_Namespace {
         return email;
     }
     
+    /*******************************************************************************************************
+    * @description We need this method because labels that are nowhere in the codebase are now not included in
+    * the package, even if explicitly listed in package.xml.
+    * @return void.
+    ********************************************************************************************************/
     public static void hack() {
         String l1 = Label.noAfflMappings;
         String l2 = Label.noAutoCreateSettings;


### PR DESCRIPTION
…e prefix with the double underscore.