### PR TITLE
Feature/8899 no admin affl

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -178,7 +178,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             updateAccountPrimaryContact(mapAccountIdContactId, dmlWrapper);
             //we also need to create affiliations for those contacts that have been created as children of existing accounts, 
             //and we have to populate the key affiliation field on those contacts
-            createAfflsToExistingAccs(mapAccountIdContactId, dmlWrapper);
+            //createAfflsToExistingAccs(mapAccountIdContactId, dmlWrapper);
         }
 
         if (listAccountIdHHToUpdate.size() > 0) {
@@ -215,11 +215,14 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
     
     /*******************************************************************************************************
     * @description Creates affiliations for those contacts that have been created as children of existing accounts, 
-    * and populates the key affiliation field on thse contacts.
+    * and populates the key affiliation field on those contacts.
     * @param mapAccountIdContactId a map of AccountId's to ContactId's which specifies which accounts need updating.
     * @param dmlWrapper to hold the Accounts that need updating.
     * @return void
-    */
+    *
+    * Functionality Change --> commenting out this method because we don't want an affiliation automatically created
+    * from a Contact to its parent Account. 
+    * 
     private void createAfflsToExistingAccs(Map<Id, Id> mapAccountIdContactId, DmlWrapper dmlWrapper) {
     	List<SObject> afflsToInsert = new List<Affiliation__c>();
     	for(ID accountId : mapAccountIdContactId.keySet()) {
@@ -227,7 +230,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
 								Primary__c = true, Status__c = 'Current'));
     	}
     	dmlWrapper.objectsToInsert.addAll(afflsToInsert);
-    }
+    }*/
 
     /*******************************************************************************************************
     * @description Updates an Account's naming, primary contact, and rollups
@@ -377,9 +380,10 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                 c.AccountId = accountInserts[i].Id;
                 contactsToUpdate.add(c);
                 
-                //Creating affiliation
-				afflsToInsert.add(new Affiliation__c(Contact__c = c.Id, Account__c = accountInserts[i].Id, 
-								Primary__c = true, Status__c = 'Current'));
+                //Creating affiliation - Functionality Change --> commenting out this code because we 
+                //don't want an affiliation automatically created from a Contact to its parent Account. 
+				//afflsToInsert.add(new Affiliation__c(Contact__c = c.Id, Account__c = accountInserts[i].Id, 
+				//				Primary__c = true, Status__c = 'Current'));
 				
                 i += 1;
             }

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -234,9 +234,11 @@ private class ACCT_IndividualAccounts_TEST {
         con2 = [select AccountId, Primary_Household__c from Contact where id=:con2.id];       
         system.assertEquals(accountId, con2.AccountId);  
         
-        List<Affiliation__c> con2affls = [select Primary__c from Affiliation__c where Contact__c =:con2.Id and Account__c =:accountId];
-        system.assertEquals(1, con2affls.size());
-        system.assertEquals(true, con2affls[0].Primary__c);
+        //We changed the functionality so no Affiliation gets created when a Contact is created either as a child of an existing
+        //Account or by itself (in which case an Account is automatically created for it).
+        //List<Affiliation__c> con2affls = [select Primary__c from Affiliation__c where Contact__c =:con2.Id and Account__c =:accountId];
+        //system.assertEquals(1, con2affls.size());
+        //system.assertEquals(true, con2affls[0].Primary__c);
         
         //system.assertEquals(accountId, con2.Primary_Household__c); In this case the field is not populated because we are dealing with Administrative accounts.
     }

--- a/src/classes/AFFL_AccRecordType_TEST.cls
+++ b/src/classes/AFFL_AccRecordType_TEST.cls
@@ -62,9 +62,14 @@ public with sharing class AFFL_AccRecordType_TEST {
         //Verify default household account has been created for the contact
         contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
         System.assertNotEquals(null, contact.Account.ID);
+        System.assertEquals(null, contact.Primary_Household__c);
         
+        //Manually create an Affiliation to the household, since we are not automatically doing so any more.
+        insert new Affiliation__c(Contact__c = contact.ID, Account__c = contact.Account.ID, Primary__c = true);
+
         //Verify the primary household field was populated
-        System.assertEquals(contact.Account.ID, contact.Primary_Household__c);
+        contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
+        System.assertNotEquals(null, contact.Primary_Household__c);
         
         Account acc = [select RecordTypeId from Account where ID=:contact.Account.ID];
         //Change the account record type to Business Organization
@@ -91,9 +96,14 @@ public with sharing class AFFL_AccRecordType_TEST {
         //Verify default household account has been created for the contact
         contact = [select Account.ID, Primary_Household__c, Primary_Organization__c from Contact where ID =:Contact.ID];
         System.assertNotEquals(null, contact.Account.ID);
+        System.assertEquals(null, contact.Primary_Household__c);
         
+        //Manually create an Affiliation to the household, since we are not automatically doing so any more.
+        insert new Affiliation__c(Contact__c = contact.ID, Account__c = contact.Account.ID, Primary__c = true);
+
         //Verify the primary household field was populated
-        System.assertEquals(contact.Account.ID, contact.Primary_Household__c);
+        contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
+        System.assertNotEquals(null, contact.Primary_Household__c);
         
         //Create primary Affl to a Business Organization
         Account bizOrg = new Account(Name = 'BizOrg', RecordTypeId = orgRecTypeID);
@@ -132,9 +142,14 @@ public with sharing class AFFL_AccRecordType_TEST {
         //Verify default household account has been created for the contact
         contact = [select Account.ID, Primary_Household__c, Primary_Organization__c from Contact where ID =:Contact.ID];
         System.assertNotEquals(null, contact.Account.ID);
+        System.assertEquals(null, contact.Primary_Household__c);
         
+        //Manually create an Affiliation to the household, since we are not automatically doing so any more
+        insert new Affiliation__c(Contact__c = contact.ID, Account__c = contact.Account.ID, Primary__c = true);
+
         //Verify the primary household field was populated
-        System.assertEquals(contact.Account.ID, contact.Primary_Household__c);
+        contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
+        System.assertNotEquals(null, contact.Primary_Household__c);
         
         //Create primary Affl to a Business Organization
         Account bizOrg = new Account(Name = 'BizOrg', RecordTypeId = orgRecTypeID);

--- a/src/classes/AFFL_MultiRecordType_TEST.cls
+++ b/src/classes/AFFL_MultiRecordType_TEST.cls
@@ -67,15 +67,14 @@ public with sharing class AFFL_MultiRecordType_TEST {
     	//Verify default household account has been created for the contact
     	contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
     	System.assertNotEquals(null, contact.Account.ID);
-    	
-    	//Verify the primary household field was populated
-    	System.assertEquals(contact.Account.ID, contact.Primary_Household__c);
-    	
-    	//Verify key household affiliation has been automatically created
-    	List<Affiliation__c> affls = [select Affiliation_Type__c, Account__c from Affiliation__c where Contact__c = :contact.ID];
-    	System.assertEquals(1, affls.size());
-    	System.assertEquals('Household Account', affls[0].Affiliation_Type__c);
-    	System.assertEquals(contact.Account.ID, affls[0].Account__c);
+    	System.assertEquals(null, contact.Primary_Household__c);
+        
+        //Manually create an Affiliation to the household, since we are not automatically doing so any more.
+        insert new Affiliation__c(Contact__c = contact.ID, Account__c = contact.Account.ID, Primary__c = true);
+
+        //Verify the primary household field was populated
+        contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
+        System.assertNotEquals(null, contact.Primary_Household__c);
     	
     	//Create account of Business Organization record type
     	Account bizOrg1 = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
@@ -125,15 +124,14 @@ public with sharing class AFFL_MultiRecordType_TEST {
     	//Verify default household account has been created for the contact
     	contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
     	System.assertNotEquals(null, contact.Account.ID);
-    	
-    	//Verify the primary household field was populated
-    	System.assertEquals(contact.Account.ID, contact.Primary_Household__c);
-    	
-    	//Verify key household affiliation has been automatically created
-    	List<Affiliation__c> affls = [select Affiliation_Type__c, Account__c from Affiliation__c where Contact__c = :contact.ID];
-    	System.assertEquals(1, affls.size());
-    	System.assertEquals('Household Account', affls[0].Affiliation_Type__c);
-    	System.assertEquals(contact.Account.ID, affls[0].Account__c);
+    	System.assertEquals(null, contact.Primary_Household__c);
+        
+        //Manually create an Affiliation to the household, since we are not automatically doing so any more.
+        insert new Affiliation__c(Contact__c = contact.ID, Account__c = contact.Account.ID, Primary__c = true);
+
+        //Verify the primary household field was populated
+        contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
+        System.assertNotEquals(null, contact.Primary_Household__c);
     	
     	//Craete account of Business Organization record type
     	Account acc1 = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
@@ -172,22 +170,21 @@ public with sharing class AFFL_MultiRecordType_TEST {
     	contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
     	System.assertNotEquals(null, contact.Account.ID);
     	ID parentAccountId = contact.Account.ID;
-    	
-    	//Verify the primary household field was populated
-    	System.assertEquals(parentAccountId, contact.Primary_Household__c);
-    	
-    	//Verify key household affiliation has been automatically created
-    	List<Affiliation__c> affls = [select Affiliation_Type__c, Account__c, Primary__c from Affiliation__c where Contact__c = :contact.ID];
-    	System.assertEquals(1, affls.size());
-    	System.assertEquals('Household Account', affls[0].Affiliation_Type__c);
-    	System.assertEquals(contact.Account.ID, affls[0].Account__c);
-    	System.assertEquals(true, affls[0].Primary__c);
-    	
+    	System.assertEquals(null, contact.Primary_Household__c);
+        
+        //Manually create an Affiliation to the household, since we are not automatically doing so any more.
+        Affiliation__c affl = new Affiliation__c(Contact__c = contact.ID, Account__c = contact.Account.ID, Primary__c = true);
+        insert affl;
+
+        //Verify the primary household field was populated
+        contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
+        System.assertNotEquals(null, contact.Primary_Household__c);
+
     	//Make the affiliation not primary
-    	affls[0].Primary__c = false;
+    	affl.Primary__c = false;
     	Test.startTest();
     	AFFL_MultiRecordType_TDTM.afflMultiHasRunBefore = false;
-    	update affls[0];
+    	update affl;
     	Test.stopTest();
     	
     	//Verify Primary_Household__c field has been cleared

--- a/src/classes/COFF_Affiliation_TDTM.cls
+++ b/src/classes/COFF_Affiliation_TDTM.cls
@@ -259,7 +259,7 @@ public class COFF_Affiliation_TDTM extends TDTM_Runnable {
     }
     
    /*******************************************************************************************************
-    * @description Returns a map with each the Contact ID of each faculty member as the key, and all its Affiliations
+    * @description Returns a map with the Contact ID of each faculty member as the key, and all its Affiliations
     * as the values. Public only so it can be called from the tests.
     ********************************************************************************************************/
     public Map<ID, List<Affiliation__c>> getAfflsForContact(List<ID> newFacultyIDs) {

--- a/src/classes/COFF_Affiliation_TDTM.cls
+++ b/src/classes/COFF_Affiliation_TDTM.cls
@@ -266,23 +266,27 @@ public class COFF_Affiliation_TDTM extends TDTM_Runnable {
     	UTIL_Debug.debug('****Number of newly assigned faculty: ' + newFacultyIDs.size());
     	//Find all Affls for all Faculty members in the trigger.
         Map<ID, List<Affiliation__c>> facultyIDtoAffls = new Map<ID, List<Affiliation__c>>();
-        List<Affiliation__c> affls = [select Account__c, Contact__c from Affiliation__c where Contact__c in :newFacultyIDs order by Contact__c];
+        List<Affiliation__c> affls = [select Account__c, Contact__c from Affiliation__c where Contact__c in :newFacultyIDs 
+                                        order by Contact__c];
         UTIL_Debug.debug('****Number of affls for existing faculty: ' + affls.size());
+        
         if(affls.size() > 0) {
 	        //Set initial values, to compare against
 	        Affiliation__c affl = affls[0];
 	        ID contactID = affls[0].Contact__c;
 	        List<Affiliation__c> facultyAffls = new Affiliation__c[] {affl};
 	        facultyIDtoAffls.put(contactID, facultyAffls);
-	        //Iterate through the other values
+	        
+	        //Iterate through the rest of the affiliations
 	        for(Integer i = 1; i < affls.size(); i++) { 
-	            if(affls[i].Contact__c != contactID) {
-	                facultyAffls = new List<Affiliation__c>();
-	                facultyIDtoAffls.put(affls[i].Contact__c, facultyAffls);
+	            if(affls[i].Contact__c == contactID) {
+	                facultyAffls.add(affls[i]);   
 	            } else {
-	                facultyAffls.add(affls[i]);
+	                contactID = affls[i].Contact__c;
+                    facultyAffls = new List<Affiliation__c>();
+                    facultyAffls.add(affls[i]);
+                    facultyIDtoAffls.put(contactID, facultyAffls);
 	            }
-	            contactID = affls[i].Contact__c;
 	        }
         }
         return facultyIDtoAffls;

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -56,7 +56,6 @@ global without sharing class STG_InstallScript implements InstallHandler {
     	List<Affl_Mappings__c> mappings = [select ID from Affl_Mappings__c where Account_Record_Type__c != null AND Primary_Affl_Field__c != null];
     	if(mappings.size() == 0) {
 			mappings.add(new Affl_Mappings__c(Name = 'Academic Program', Account_Record_Type__c = 'Academic Program', Primary_Affl_Field__c = 'Primary Academic Program'));
-    		mappings.add(new Affl_Mappings__c(Name = 'Administrative', Account_Record_Type__c = 'Administrative', Primary_Affl_Field__c = 'Primary Administrative Account'));
 	    	mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = 'Primary Business Organization'));	
 	    	mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = 'Primary Household'));
 	    	mappings.add(new Affl_Mappings__c(Name = 'Educational Institution', Account_Record_Type__c = 'Educational Institution', Primary_Affl_Field__c = 'Primary Educational Institution'));

--- a/src/classes/STG_InstallScript_TEST.cls
+++ b/src/classes/STG_InstallScript_TEST.cls
@@ -41,7 +41,7 @@ public with sharing class STG_InstallScript_TEST {
 		//Run the install script
         Test.testInstall(new STG_InstallScript(), null); 
         List<Affl_Mappings__c> mappings = [select Account_Record_Type__c, Primary_Affl_Field__c from Affl_Mappings__c];
-        System.assertEquals(7, mappings.size());
+        System.assertEquals(6, mappings.size());
 	}
 	
 	//If the handlers in our default TDTM config are different from what it's in the org (either action or load order),

--- a/unpackaged/pre/contact_key_affl_fields/objects/Contact.object
+++ b/unpackaged/pre/contact_key_affl_fields/objects/Contact.object
@@ -13,18 +13,6 @@
         <type>Lookup</type>
     </fields>
 	<fields>
-        <fullName>Primary_Administrative_Account__c</fullName>
-        <deleteConstraint>SetNull</deleteConstraint>
-        <externalId>false</externalId>
-        <label>Primary Administrative Account</label>
-        <referenceTo>Account</referenceTo>
-        <relationshipLabel>Contacts</relationshipLabel>
-        <relationshipName>Admin_Account_Members</relationshipName>
-        <required>false</required>
-        <trackFeedHistory>false</trackFeedHistory>
-        <type>Lookup</type>
-    </fields>
-	<fields>
         <fullName>Primary_Department__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
         <externalId>false</externalId>


### PR DESCRIPTION
I have commented out the code that automatically creates an Affiliation to its parent Account when a Contact is created, and I have fixed the tests to not assume that Affiliation will be there (and also fixed a bug in an unrelated area which surfaced due to these changes). 

In addition to what is done here, we could make it configurable, and let the administrator decide whether the Affiliation will be created.

Also, this made me realize that none of the Account record types are in the package. We should consider including at least Organizational and Household, specially because many tests depend on these. Installation of managed package will fail if they aren't there.