### PR TITLE
Feature/9281 master lookup

### DIFF
--- a/src/applications/HEDAP.app
+++ b/src/applications/HEDAP.app
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomApplication xmlns="http://soap.sforce.com/2006/04/metadata">
     <defaultLandingTab>standard-home</defaultLandingTab>
-    <description>Higher Education Data Architecture Prototype</description>
+    <description>Higher Education Data Architecture</description>
     <label>HEDA</label>
     <tab>standard-Account</tab>
     <tab>standard-Contact</tab>

--- a/src/layouts/Account-HEDA Household Layout.layout
+++ b/src/layouts/Account-HEDA Household Layout.layout
@@ -117,8 +117,7 @@
     </relatedLists>
     <relatedLists>
         <fields>NAME</fields>
-        <fields>Contact.CNTC_FIRST_NAME</fields>
-        <fields>Contact.NAME</fields>
+        <fields>Contact__c</fields>
         <fields>Role__c</fields>
         <fields>Status__c</fields>
         <fields>StartDate__c</fields>

--- a/src/layouts/Account-HEDA Organization Layout.layout
+++ b/src/layouts/Account-HEDA Organization Layout.layout
@@ -120,8 +120,7 @@
     </relatedLists>
     <relatedLists>
         <fields>NAME</fields>
-        <fields>Contact.CNTC_FIRST_NAME</fields>
-        <fields>Contact.NAME</fields>
+        <fields>Contact__c</fields>
         <fields>Role__c</fields>
         <fields>Status__c</fields>
         <fields>StartDate__c</fields>

--- a/src/layouts/Contact-HEDA Contact Layout.layout
+++ b/src/layouts/Contact-HEDA Contact Layout.layout
@@ -286,7 +286,7 @@
     </relatedContent>
     <relatedLists>
         <fields>NAME</fields>
-        <fields>Account.NAME</fields>
+        <fields>Account__c</fields>
         <fields>Affiliation_Type__c</fields>
         <fields>Role__c</fields>
         <fields>Status__c</fields>
@@ -305,7 +305,7 @@
     </relatedLists>
     <relatedLists>
         <fields>NAME</fields>
-        <fields>Account.NAME</fields>
+        <fields>Program__c</fields>
         <fields>Eligible_to_Enroll__c</fields>
         <fields>Admission_Date__c</fields>
         <fields>Start_Date__c</fields>

--- a/src/objects/Affiliation__c.object
+++ b/src/objects/Affiliation__c.object
@@ -68,17 +68,16 @@
     <enableStreamingApi>true</enableStreamingApi>
     <fields>
         <fullName>Account__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
         <externalId>false</externalId>
         <label>Organization</label>
         <referenceTo>Account</referenceTo>
         <relationshipLabel>Affiliated Contacts</relationshipLabel>
         <relationshipName>Affiliated_Contacts</relationshipName>
-        <relationshipOrder>0</relationshipOrder>
-        <reparentableMasterDetail>false</reparentableMasterDetail>
+        <required>false</required>
         <trackHistory>false</trackHistory>
         <trackTrending>false</trackTrending>
-        <type>MasterDetail</type>
-        <writeRequiresMasterRead>false</writeRequiresMasterRead>
+        <type>Lookup</type>
     </fields>
     <fields>
         <fullName>Affiliation_Type__c</fullName>
@@ -93,17 +92,16 @@
     </fields>
     <fields>
         <fullName>Contact__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
         <externalId>false</externalId>
         <label>Contact</label>
         <referenceTo>Contact</referenceTo>
         <relationshipLabel>Affiliated Accounts</relationshipLabel>
         <relationshipName>Affiliated_Accounts</relationshipName>
-        <relationshipOrder>1</relationshipOrder>
-        <reparentableMasterDetail>true</reparentableMasterDetail>
+        <required>false</required>
         <trackHistory>false</trackHistory>
         <trackTrending>false</trackTrending>
-        <type>MasterDetail</type>
-        <writeRequiresMasterRead>false</writeRequiresMasterRead>
+        <type>Lookup</type>
     </fields>
     <fields>
         <fullName>Description__c</fullName>
@@ -207,5 +205,5 @@
     </nameField>
     <pluralLabel>Affiliations</pluralLabel>
     <searchLayouts/>
-    <sharingModel>ControlledByParent</sharingModel>
+    <sharingModel>ReadWrite</sharingModel>
 </CustomObject>

--- a/src/objects/Course_Enrollment__c.object
+++ b/src/objects/Course_Enrollment__c.object
@@ -67,6 +67,7 @@
     <enableStreamingApi>true</enableStreamingApi>
     <fields>
         <fullName>Account__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
         <description>The Academic Program the student is enrolled in.</description>
         <externalId>false</externalId>
         <inlineHelpText>The Academic Program the student is enrolled in.</inlineHelpText>
@@ -74,11 +75,9 @@
         <referenceTo>Account</referenceTo>
         <relationshipLabel>Course Enrollments</relationshipLabel>
         <relationshipName>Course_Enrollments</relationshipName>
-        <relationshipOrder>1</relationshipOrder>
-        <reparentableMasterDetail>false</reparentableMasterDetail>
+        <required>false</required>
         <trackTrending>false</trackTrending>
-        <type>MasterDetail</type>
-        <writeRequiresMasterRead>false</writeRequiresMasterRead>
+        <type>Lookup</type>
     </fields>
     <fields>
         <fullName>Affiliation__c</fullName>
@@ -94,6 +93,7 @@
     </fields>
     <fields>
         <fullName>Contact__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
         <description>The student taking the course.</description>
         <externalId>false</externalId>
         <inlineHelpText>The student taking the course.</inlineHelpText>
@@ -101,11 +101,9 @@
         <referenceTo>Contact</referenceTo>
         <relationshipLabel>Course Enrollments</relationshipLabel>
         <relationshipName>Courses</relationshipName>
-        <relationshipOrder>0</relationshipOrder>
-        <reparentableMasterDetail>false</reparentableMasterDetail>
+        <required>false</required>
         <trackTrending>false</trackTrending>
-        <type>MasterDetail</type>
-        <writeRequiresMasterRead>false</writeRequiresMasterRead>
+        <type>Lookup</type>
     </fields>
     <fields>
         <fullName>Course_Offering__c</fullName>
@@ -181,5 +179,5 @@
     </nameField>
     <pluralLabel>Course Enrollments</pluralLabel>
     <searchLayouts/>
-    <sharingModel>ControlledByParent</sharingModel>
+    <sharingModel>ReadWrite</sharingModel>
 </CustomObject>

--- a/src/objects/Program_Enrollment__c.object
+++ b/src/objects/Program_Enrollment__c.object
@@ -205,6 +205,7 @@
     </fields>
     <fields>
         <fullName>Program__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
         <description>The program the student is enrolled in.</description>
         <externalId>false</externalId>
         <inlineHelpText>The program the student is enrolled in.</inlineHelpText>
@@ -212,11 +213,9 @@
         <referenceTo>Account</referenceTo>
         <relationshipLabel>Program Enrollments</relationshipLabel>
         <relationshipName>Program_Enrollments</relationshipName>
-        <relationshipOrder>1</relationshipOrder>
-        <reparentableMasterDetail>false</reparentableMasterDetail>
+        <required>false</required>
         <trackTrending>false</trackTrending>
-        <type>MasterDetail</type>
-        <writeRequiresMasterRead>false</writeRequiresMasterRead>
+        <type>Lookup</type>
     </fields>
     <fields>
         <fullName>Start_Date__c</fullName>
@@ -228,6 +227,7 @@
     </fields>
     <fields>
         <fullName>Student__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
         <description>The parent Contact.</description>
         <externalId>false</externalId>
         <inlineHelpText>The parent Contact.</inlineHelpText>
@@ -235,11 +235,9 @@
         <referenceTo>Contact</referenceTo>
         <relationshipLabel>Program Enrollments</relationshipLabel>
         <relationshipName>Program_Enrollments_2</relationshipName>
-        <relationshipOrder>0</relationshipOrder>
-        <reparentableMasterDetail>false</reparentableMasterDetail>
+        <required>false</required>
         <trackTrending>false</trackTrending>
-        <type>MasterDetail</type>
-        <writeRequiresMasterRead>false</writeRequiresMasterRead>
+        <type>Lookup</type>
     </fields>
     <label>Program Enrollment</label>
     <listViews>
@@ -254,5 +252,5 @@
     </nameField>
     <pluralLabel>Program Enrollments</pluralLabel>
     <searchLayouts/>
-    <sharingModel>ControlledByParent</sharingModel>
+    <sharingModel>ReadWrite</sharingModel>
 </CustomObject>


### PR DESCRIPTION
# Warning
- Master-detail fields in Affiliation, Course Enrollment, and Program Enrollment have been changed to lookups, to support certain use cases around information sharing, and to make sure certain limits won't be hit. Changing these fields' type means that there is certain data integrity functionality that now will need to be enforced through other means (for example, now the Contact field on an Affiliation can be left blank).

# Info
- Minor updates to related lists on layouts to make information more easily accessible.
