### PR TITLE
Removing master-detail fields again, and pointing the quick actions t…

### DIFF
--- a/src/objects/Affiliation__c.object
+++ b/src/objects/Affiliation__c.object
@@ -67,20 +67,6 @@
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
     <fields>
-        <fullName>Account__c</fullName>
-        <externalId>false</externalId>
-        <label>Organization</label>
-        <referenceTo>Account</referenceTo>
-        <relationshipLabel>Affiliated Contacts</relationshipLabel>
-        <relationshipName>Affiliated_Contacts</relationshipName>
-        <relationshipOrder>0</relationshipOrder>
-        <reparentableMasterDetail>false</reparentableMasterDetail>
-        <trackHistory>false</trackHistory>
-        <trackTrending>false</trackTrending>
-        <type>MasterDetail</type>
-        <writeRequiresMasterRead>false</writeRequiresMasterRead>
-    </fields>
-    <fields>
         <fullName>AfflAccount__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
         <externalId>false</externalId>
@@ -116,20 +102,6 @@
         <trackHistory>false</trackHistory>
         <trackTrending>false</trackTrending>
         <type>Lookup</type>
-    </fields>
-    <fields>
-        <fullName>Contact__c</fullName>
-        <externalId>false</externalId>
-        <label>Contact</label>
-        <referenceTo>Contact</referenceTo>
-        <relationshipLabel>Affiliated Accounts</relationshipLabel>
-        <relationshipName>Affiliated_Accounts</relationshipName>
-        <relationshipOrder>1</relationshipOrder>
-        <reparentableMasterDetail>true</reparentableMasterDetail>
-        <trackHistory>false</trackHistory>
-        <trackTrending>false</trackTrending>
-        <type>MasterDetail</type>
-        <writeRequiresMasterRead>false</writeRequiresMasterRead>
     </fields>
     <fields>
         <fullName>Description__c</fullName>
@@ -233,5 +205,5 @@
     </nameField>
     <pluralLabel>Affiliations</pluralLabel>
     <searchLayouts/>
-    <sharingModel>ControlledByParent</sharingModel>
+    <sharingModel>ReadWrite</sharingModel>
 </CustomObject>

--- a/src/objects/Course_Enrollment__c.object
+++ b/src/objects/Course_Enrollment__c.object
@@ -66,19 +66,6 @@
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
     <fields>
-        <fullName>Account__c</fullName>
-        <externalId>false</externalId>
-        <label>Deparment</label>
-        <referenceTo>Account</referenceTo>
-        <relationshipLabel>Course Enrollments</relationshipLabel>
-        <relationshipName>Course_Enrollments</relationshipName>
-        <relationshipOrder>1</relationshipOrder>
-        <reparentableMasterDetail>false</reparentableMasterDetail>
-        <trackTrending>false</trackTrending>
-        <type>MasterDetail</type>
-        <writeRequiresMasterRead>false</writeRequiresMasterRead>
-    </fields>
-    <fields>
         <fullName>ProgramAcc__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
         <description>The Academic Program the student is enrolled in.</description>
@@ -117,21 +104,6 @@
         <required>false</required>
         <trackTrending>false</trackTrending>
         <type>Lookup</type>
-    </fields>
-    <fields>
-        <fullName>Contact__c</fullName>
-        <description>The student taking the course.</description>
-        <externalId>false</externalId>
-        <inlineHelpText>The student taking the course.</inlineHelpText>
-        <label>Contact</label>
-        <referenceTo>Contact</referenceTo>
-        <relationshipLabel>Course Enrollments</relationshipLabel>
-        <relationshipName>Courses</relationshipName>
-        <relationshipOrder>0</relationshipOrder>
-        <reparentableMasterDetail>false</reparentableMasterDetail>
-        <trackTrending>false</trackTrending>
-        <type>MasterDetail</type>
-        <writeRequiresMasterRead>false</writeRequiresMasterRead>
     </fields>
     <fields>
         <fullName>Course_Offering__c</fullName>
@@ -207,5 +179,5 @@
     </nameField>
     <pluralLabel>Course Enrollments</pluralLabel>
     <searchLayouts/>
-    <sharingModel>ControlledByParent</sharingModel>
+    <sharingModel>ReadWrite</sharingModel>
 </CustomObject>

--- a/src/objects/Program_Enrollment__c.object
+++ b/src/objects/Program_Enrollment__c.object
@@ -218,42 +218,12 @@
         <type>Lookup</type>
     </fields>
     <fields>
-        <fullName>Program__c</fullName>
-        <description>The program the student is enrolled in.</description>
-        <externalId>false</externalId>
-        <inlineHelpText>The program the student is enrolled in.</inlineHelpText>
-        <label>Program</label>
-        <referenceTo>Account</referenceTo>
-        <relationshipLabel>Program Enrollments</relationshipLabel>
-        <relationshipName>Program_Enrollments</relationshipName>
-        <relationshipOrder>1</relationshipOrder>
-        <reparentableMasterDetail>false</reparentableMasterDetail>
-        <trackTrending>false</trackTrending>
-        <type>MasterDetail</type>
-        <writeRequiresMasterRead>false</writeRequiresMasterRead>
-    </fields>
-    <fields>
         <fullName>Start_Date__c</fullName>
         <externalId>false</externalId>
         <label>Start Date</label>
         <required>false</required>
         <trackTrending>false</trackTrending>
         <type>Date</type>
-    </fields>
-    <fields>
-        <fullName>Student__c</fullName>
-        <description>The parent Contact.</description>
-        <externalId>false</externalId>
-        <inlineHelpText>The parent Contact.</inlineHelpText>
-        <label>Contact</label>
-        <referenceTo>Contact</referenceTo>
-        <relationshipLabel>Program Enrollments</relationshipLabel>
-        <relationshipName>Program_Enrollments_2</relationshipName>
-        <relationshipOrder>0</relationshipOrder>
-        <reparentableMasterDetail>false</reparentableMasterDetail>
-        <trackTrending>false</trackTrending>
-        <type>MasterDetail</type>
-        <writeRequiresMasterRead>false</writeRequiresMasterRead>
     </fields>
     <fields>
         <fullName>StudentContact__c</fullName>
@@ -282,5 +252,5 @@
     </nameField>
     <pluralLabel>Program Enrollments</pluralLabel>
     <searchLayouts/>
-    <sharingModel>ControlledByParent</sharingModel>
+    <sharingModel>ReadWrite</sharingModel>
 </CustomObject>

--- a/src/package.xml
+++ b/src/package.xml
@@ -134,11 +134,9 @@
         <members>Address__c.Seasonal_Start_Day__c</members>
         <members>Address__c.Seasonal_Start_Month__c</members>
         <members>Address__c.Seasonal_Start_Year__c</members>
-        <members>Affiliation__c.Account__c</members>
         <members>Affiliation__c.AfflAccount__c</members>
         <members>Affiliation__c.Affiliation_Type__c</members>
         <members>Affiliation__c.AfflContact__c</members>
-        <members>Affiliation__c.Contact__c</members>
         <members>Affiliation__c.Description__c</members>
         <members>Affiliation__c.EndDate__c</members>
         <members>Affiliation__c.Primary__c</members>
@@ -181,11 +179,9 @@
         <members>Contact.WorkPhone__c</members>
         <members>Contact.Work_Address__c</members>
         <members>Contact.is_Address_Override__c</members>
-        <members>Course_Enrollment__c.Account__c</members>
         <members>Course_Enrollment__c.ProgramAcc__c</members>
         <members>Course_Enrollment__c.Affiliation__c</members>
         <members>Course_Enrollment__c.StudentContact__c</members>
-        <members>Course_Enrollment__c.Contact__c</members>
         <members>Course_Enrollment__c.Course_Offering__c</members>
         <members>Course_Enrollment__c.Credits_Attempted__c</members>
         <members>Course_Enrollment__c.Credits_Earned__c</members>
@@ -238,9 +234,7 @@
         <members>Program_Enrollment__c.GPA__c</members>
         <members>Program_Enrollment__c.Graduation_Year__c</members>
         <members>Program_Enrollment__c.ProgramAcc__c</members>
-        <members>Program_Enrollment__c.Program__c</members>
         <members>Program_Enrollment__c.Start_Date__c</members>
-        <members>Program_Enrollment__c.Student__c</members>
         <members>Program_Enrollment__c.StudentContact__c</members>
         <members>Relationship_Auto_Create__c.Campaign_Types__c</members>
         <members>Relationship_Auto_Create__c.Field__c</members>

--- a/src/quickActions/Account.New_Affiliation.quickAction
+++ b/src/quickActions/Account.New_Affiliation.quickAction
@@ -48,6 +48,6 @@
         </quickActionLayoutColumns>
     </quickActionLayout>
     <targetObject>Affiliation__c</targetObject>
-    <targetParentField>Account__c</targetParentField>
+    <targetParentField>AfflAccount__c</targetParentField>
     <type>Create</type>
 </QuickAction>

--- a/src/quickActions/Contact.New_Affiliation.quickAction
+++ b/src/quickActions/Contact.New_Affiliation.quickAction
@@ -42,6 +42,6 @@
         <quickActionLayoutColumns/>
     </quickActionLayout>
     <targetObject>Affiliation__c</targetObject>
-    <targetParentField>Contact__c</targetParentField>
+    <targetParentField>AfflContact__c</targetParentField>
     <type>Create</type>
 </QuickAction>


### PR DESCRIPTION
…o the lookups. This shouldn't fail now, because they lookups have already been deployed to the packaging org.