### PR TITLE
It seems like we need to reference labels in Apex in order for them t…

### DIFF
--- a/src/classes/UTIL_Namespace.cls
+++ b/src/classes/UTIL_Namespace.cls
@@ -142,5 +142,6 @@ public class UTIL_Namespace {
         String l1 = Label.noAfflMappings;
         String l2 = Label.noAutoCreateSettings;
         String l3 = Label.noRecSettings;
+        String l4 = Label.stgHelpRelReciprocalMethod;
     }
 }


### PR DESCRIPTION
…o be included in the package, even if they are not build dynamically in JS.