### PR TITLE
Feature/205 acc contact del

### DIFF
--- a/ApexDocContent/Accounts.htm
+++ b/ApexDocContent/Accounts.htm
@@ -11,6 +11,7 @@
         when a Contact is created. Administrative and Household Accounts are recommended as the preferred Account Model.</p>
             
 	<ul>
+        <li>ACCT_CannotDelete_TDTM - Stops an Account from being deleted if it has any Affiliation, Program Enrollment or Course Enrollment children.</li>
 		<li>ACCT_IndividualAccounts_TDTM - Trigger Handler on Contacts, that manages creating the appropriate Account for Contacts, when they are created or updated.</li>
         <li>CAO_Constants - Constants and helper methods used with the Account Model.</li>
 	</ul>

--- a/ApexDocContent/Contacts.htm
+++ b/ApexDocContent/Contacts.htm
@@ -10,6 +10,7 @@
 	
 		<p>The classes involved with Contact include:</p>
 		<ul>
+            <li>CON_CannotDelete_TDTM - Stops a Contact from being deleted if it has any Affiliation, Program Enrollment or Course Enrollment children.</li>		
 			<li>CON_DoNotContact_TDTM - Handles changes to the deceased and do not contact fields on Contact.</li>
 			<li>CON_Preferred_TDTM - Populates default email and phone fields according to user preferences.</li>
 			<li>CON_PrimaryAffls_TDTM - Creates Affiliations when the user manually populates any of the primary affiliation lookup fields.</li>

--- a/src/classes/ACCT_CannotDelete_TDTM.cls
+++ b/src/classes/ACCT_CannotDelete_TDTM.cls
@@ -35,6 +35,38 @@
 * @description Stops an Account from being deleted if it has any Affiliation, 
 * Program Enrollment or Course Enrollment children. 
 */
-public with sharing class ACCT_CannotDelete_TDTM {
+public with sharing class ACCT_CannotDelete_TDTM extends TDTM_Runnable {
 
+    /*******************************************************************************************************
+    * @description Stops an Account from being deleted if it has any Affiliation, 
+    * Program Enrollment or Course Enrollment children.
+    * @param listNew the list of Accounts from trigger new. 
+    * @param listOld the list of Accounts from trigger old. 
+    * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.). 
+    * @param objResult the describe for Accounts 
+    * @return dmlWrapper.  
+    ********************************************************************************************************/
+    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
+    TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
+
+        Map<ID, SObject> oldmap = new Map<ID, SObject>(oldlist);
+        
+        if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
+                        
+            for (Account a : [select ID, (select ID from Account.Affl_Contacts__r), 
+                                         (select ID from Account.Program_Enrollments__r), 
+                                         (select ID from Account.Course_Enrollments__r) 
+                                         from Account where ID in :oldlist]) {
+                
+                if(a.Affl_Contacts__r.size() > 0 || a.Program_Enrollments__r.size() > 0 
+                || a.Course_Enrollments__r.size() > 0) {
+
+                    Account accountInContext = (Account)oldmap.get(a.ID);
+                    accountInContext.addError(Label.CannotDelete);
+                }
+            }     
+        }
+        
+        return new DmlWrapper();
+    }
 }

--- a/src/classes/ACCT_CannotDelete_TDTM.cls
+++ b/src/classes/ACCT_CannotDelete_TDTM.cls
@@ -1,0 +1,40 @@
+/*
+    Copyright (c) 2016, Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2016
+* @group Accounts
+* @group-content ../../ApexDocContent/Accounts.htm
+* @description Stops an Account from being deleted if it has any Affiliation, 
+* Program Enrollment or Course Enrollment children. 
+*/
+public with sharing class ACCT_DoNotDelete_TDTM {
+
+}

--- a/src/classes/ACCT_CannotDelete_TDTM.cls
+++ b/src/classes/ACCT_CannotDelete_TDTM.cls
@@ -35,6 +35,6 @@
 * @description Stops an Account from being deleted if it has any Affiliation, 
 * Program Enrollment or Course Enrollment children. 
 */
-public with sharing class ACCT_DoNotDelete_TDTM {
+public with sharing class ACCT_CannotDelete_TDTM {
 
 }

--- a/src/classes/ACCT_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/ACCT_CannotDelete_TDTM.cls-meta.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>35.0</apiVersion>
+</ApexClass>

--- a/src/classes/ACCT_CannotDelete_TEST.cls
+++ b/src/classes/ACCT_CannotDelete_TEST.cls
@@ -1,0 +1,83 @@
+/*
+    Copyright (c) 2016, Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2016
+* @group Contacts
+* @group-content ../../ApexDocContent/Accounts.htm
+* @description Tests for ACCT_CannotDelete_TDTM.
+*/
+@isTest
+public with sharing class ACCT_CannotDelete_TEST {
+
+    @isTest
+    public static void cannotDelete() {
+        Contact c = new Contact(LastName = 'l1');
+        insert c;
+        
+        //Create contact with child affl
+        Account acc1 = new Account(Name='test1');       
+        
+        //Create contact with child program enrollment
+        Account acc2 = new Account(Name='test2');
+        
+        //Create contact with child course enrollment
+        Account acc3 = new Account(Name='test3');
+        
+        //Create contact without affl, program enrollment, or course enrollment children
+        Account acc4 = new Account(Name='test4');
+        
+        Account[] accs = new Account[] {acc1, acc2, acc3, acc4};
+        insert accs;
+
+        Affiliation__c affl = new Affiliation__c(Contact__c = c.ID, Account__c = acc1.ID);
+        Program_Enrollment__c programEnroll = new Program_Enrollment__c(Contact__c = c.ID, Account__c = acc2.ID);
+        Course_Enrollment__c courseEnroll = new Course_Enrollment__c(Contact__c = c.ID, Account__c = acc3.ID);
+        insert new SObject[] {affl, programEnroll, courseEnroll};
+        
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(accs, false);
+        Test.stopTest();
+        
+        UTIL_Debug.debug('****Delete results: ' + JSON.serializePretty(results));
+        
+        //Verify only acc4 was successfully deleted
+        accs = [select ID from Account where ID in :accs];
+        System.assertEquals(3, accs.size());
+        
+        System.assertEquals(false, results[0].success);
+        System.assertEquals(Label.CannotDelete, results[0].errors[0].message);
+        System.assertEquals(false, results[1].success);
+        System.assertEquals(Label.CannotDelete, results[1].errors[0].message);
+        System.assertEquals(false, results[2].success);
+        System.assertEquals(Label.CannotDelete, results[2].errors[0].message);
+        System.assertEquals(true, results[3].success);
+    }
+}

--- a/src/classes/ACCT_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/ACCT_CannotDelete_TEST.cls-meta.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>35.0</apiVersion>
+</ApexClass>

--- a/src/classes/CON_CannotDelete_TDTM.cls
+++ b/src/classes/CON_CannotDelete_TDTM.cls
@@ -1,0 +1,68 @@
+/*
+    Copyright (c) 2016, Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2016
+* @group Accounts
+* @group-content ../../ApexDocContent/Contacts.htm
+* @description Stops a Contact from being deleted if it has any Affiliation, 
+* Program Enrollment or Course Enrollment children.
+*/
+public with sharing class CON_DoNotDelete_TDTM extends TDTM_Runnable {
+
+    /*******************************************************************************************************
+    * @description Stops a Contact from being deleted if it has any Affiliation, 
+    * Program Enrollment or Course Enrollment children.
+    * @param listNew the list of Accounts from trigger new. 
+    * @param listOld the list of Accounts from trigger old. 
+    * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.). 
+    * @param objResult the describe for Accounts 
+    * @return dmlWrapper.  
+    ********************************************************************************************************/
+    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
+    TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
+
+        if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
+            
+            for (Contact c : [select ID, (select ID from Contact.Affl_Accounts__r), 
+                                         (select ID from Contact.Program_Enrollments__r), 
+                                         (select ID from Contact.Student_Course_Enrollments__r) 
+                                         from Contact where ID in :newlist]) {
+                
+                if(c.Affl_Accounts__r.size() > 0 || c.Program_Enrollments__r.size() > 0 
+                || c.Student_Course_Enrollments__r.size() > 0) {
+                    c.addError(Label.CannotDelete);
+                }
+            }     
+        }
+        
+        return new DmlWrapper();
+    }
+}

--- a/src/classes/CON_CannotDelete_TDTM.cls
+++ b/src/classes/CON_CannotDelete_TDTM.cls
@@ -40,8 +40,8 @@ public with sharing class CON_CannotDelete_TDTM extends TDTM_Runnable {
     /*******************************************************************************************************
     * @description Stops a Contact from being deleted if it has any Affiliation, 
     * Program Enrollment or Course Enrollment children.
-    * @param listNew the list of Accounts from trigger new. 
-    * @param listOld the list of Accounts from trigger old. 
+    * @param listNew the list of Contacts from trigger new. 
+    * @param listOld the list of Contacts from trigger old. 
     * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.). 
     * @param objResult the describe for Accounts 
     * @return dmlWrapper.  

--- a/src/classes/CON_CannotDelete_TDTM.cls
+++ b/src/classes/CON_CannotDelete_TDTM.cls
@@ -35,7 +35,7 @@
 * @description Stops a Contact from being deleted if it has any Affiliation, 
 * Program Enrollment or Course Enrollment children.
 */
-public with sharing class CON_DoNotDelete_TDTM extends TDTM_Runnable {
+public with sharing class CON_CannotDelete_TDTM extends TDTM_Runnable {
 
     /*******************************************************************************************************
     * @description Stops a Contact from being deleted if it has any Affiliation, 
@@ -49,16 +49,20 @@ public with sharing class CON_DoNotDelete_TDTM extends TDTM_Runnable {
     public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
     TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
 
+        Map<ID, SObject> oldmap = new Map<ID, SObject>(oldlist);
+        
         if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
-            
+                        
             for (Contact c : [select ID, (select ID from Contact.Affl_Accounts__r), 
                                          (select ID from Contact.Program_Enrollments__r), 
                                          (select ID from Contact.Student_Course_Enrollments__r) 
-                                         from Contact where ID in :newlist]) {
+                                         from Contact where ID in :oldlist]) {
                 
                 if(c.Affl_Accounts__r.size() > 0 || c.Program_Enrollments__r.size() > 0 
                 || c.Student_Course_Enrollments__r.size() > 0) {
-                    c.addError(Label.CannotDelete);
+
+                    Contact contactInContext = (Contact)oldmap.get(c.ID);
+                    contactInContext.addError(Label.CannotDelete);
                 }
             }     
         }

--- a/src/classes/CON_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/CON_CannotDelete_TDTM.cls-meta.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>35.0</apiVersion>
+</ApexClass>

--- a/src/classes/CON_CannotDelete_TEST.cls
+++ b/src/classes/CON_CannotDelete_TEST.cls
@@ -71,5 +71,13 @@ public with sharing class CON_CannotDelete_TEST {
         //Verify only c4 was successfully deleted
         contacts = [select ID from Contact where ID in :contacts];
         System.assertEquals(3, contacts.size());
+        
+        System.assertEquals(false, results[0].success);
+        System.assertEquals(Label.CannotDelete, results[0].errors[0].message);
+        System.assertEquals(false, results[1].success);
+        System.assertEquals(Label.CannotDelete, results[1].errors[0].message);
+        System.assertEquals(false, results[2].success);
+        System.assertEquals(Label.CannotDelete, results[2].errors[0].message);
+        System.assertEquals(true, results[3].success);
     }
 }

--- a/src/classes/CON_CannotDelete_TEST.cls
+++ b/src/classes/CON_CannotDelete_TEST.cls
@@ -1,0 +1,75 @@
+/*
+    Copyright (c) 2016, Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2016
+* @group Contacts
+* @group-content ../../ApexDocContent/Contacts.htm
+* @description Tests for CON_CannotDelete_TDTM.
+*/
+@isTest
+public with sharing class CON_CannotDelete_TEST {
+
+    @isTest
+    public static void cannotDelete() {
+        Account acc = new Account(Name='test');
+        insert acc;
+        
+        //Create contact with child affl
+        Contact c1 = new Contact(LastName = 'l1');
+        
+        //Create contact with child program enrollment
+        Contact c2 = new Contact(LastName = 'l2');
+        
+        //Create contact with child course enrollment
+        Contact c3 = new Contact(LastName = 'l3');
+        
+        //Create contact without affl, program enrollment, or course enrollment children
+        Contact c4 = new Contact(LastName = 'l4');
+        
+        Contact[] contacts = new Contact[] {c1, c2, c3, c4};
+        insert contacts;
+
+        Affiliation__c affl = new Affiliation__c(Contact__c = c1.ID, Account__c = acc.ID);
+        Program_Enrollment__c programEnroll = new Program_Enrollment__c(Contact__c = c2.ID, Account__c = acc.ID);
+        Course_Enrollment__c courseEnroll = new Course_Enrollment__c(Contact__c = c3.ID, Account__c = acc.ID);
+        insert new SObject[] {affl, programEnroll, courseEnroll};
+        
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(contacts, false);
+        Test.stopTest();
+        
+        UTIL_Debug.debug('****Delete results: ' + JSON.serializePretty(results));
+        
+        //Verify only c4 was successfully deleted
+        contacts = [select ID from Contact where ID in :contacts];
+        System.assertEquals(3, contacts.size());
+    }
+}

--- a/src/classes/CON_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/CON_CannotDelete_TEST.cls-meta.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>35.0</apiVersion>
+</ApexClass>

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -136,7 +136,17 @@ public without sharing class TDTM_DefaultConfig {
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
               Class__c = 'TERM_CourseOff_TDTM', Load_Order__c = 1, Object__c = 'Term__c', 
               Trigger_Action__c = 'AfterUpdate'));
-                    
+        
+        // Stops a Contact from being deleted if it has any Affiliation, Program Enrollment or Course Enrollment children
+        handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
+              Class__c = 'CON_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Contact', 
+              Trigger_Action__c = 'BeforeDelete'));
+                     
+        // Stops a Account from being deleted if it has any Affiliation, Program Enrollment or Course Enrollment children
+        handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
+              Class__c = 'ACCT_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Account', 
+              Trigger_Action__c = 'BeforeDelete'));
+              
         return handlers;
     }
 }

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -33,6 +33,14 @@
         <value>Household</value>
     </labels>
     <labels>
+        <fullName>CannotDelete</fullName>
+        <categories>Contacts, Accounts</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>CannotDelete</shortDescription>
+        <value>Record cannot be deleted because children records exist. Delete children first.</value>
+    </labels>
+    <labels>
         <fullName>Female</fullName>
         <categories>Relationships</categories>
         <language>en_US</language>

--- a/src/objects/Course__c.object
+++ b/src/objects/Course__c.object
@@ -93,7 +93,7 @@
         <label>Credit Hours</label>
         <precision>6</precision>
         <required>false</required>
-        <scale>2</scale>
+        <scale>3</scale>
         <trackTrending>false</trackTrending>
         <type>Number</type>
         <unique>false</unique>

--- a/src/package.xml
+++ b/src/package.xml
@@ -23,6 +23,7 @@
         <members>COFF_Affiliation_TDTM</members>
         <members>COFF_Affiliation_TEST</members>
         <members>CON_CannotDelete_TDTM</members>
+        <members>CON_CannotDelete_TEST</members>
         <members>CON_DoNotContact_TDTM</members>
         <members>CON_DoNotContact_TEST</members>
         <members>CON_Preferred_TDTM</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -3,6 +3,7 @@
     <fullName>HEDA</fullName>
     <types>
         <members>ACCT_CannotDelete_TDTM</members>
+        <members>ACCT_CannotDelete_TEST</members>
         <members>ACCT_IndividualAccounts_TDTM</members>
         <members>ACCT_IndividualAccounts_TEST</members>
         <members>ADDR_Account_TDTM</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -2,6 +2,7 @@
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>HEDA</fullName>
     <types>
+        <members>ACCT_CannotDelete_TDTM</members>
         <members>ACCT_IndividualAccounts_TDTM</members>
         <members>ACCT_IndividualAccounts_TEST</members>
         <members>ADDR_Account_TDTM</members>
@@ -21,6 +22,7 @@
         <members>CAO_Constants</members>
         <members>COFF_Affiliation_TDTM</members>
         <members>COFF_Affiliation_TEST</members>
+        <members>CON_CannotDelete_TDTM</members>
         <members>CON_DoNotContact_TDTM</members>
         <members>CON_DoNotContact_TEST</members>
         <members>CON_Preferred_TDTM</members>
@@ -276,6 +278,7 @@
         <members>BothFieldAndValue</members>
         <members>DefaultAdminName</members>
         <members>DefaultHouseholdName</members>
+        <members>CannotDelete</members>
         <members>Female</members>
         <members>InvalidFilter</members>
         <members>Male</members>


### PR DESCRIPTION
# Warning

# Info
- Adding classes that will stop a user from deleting an Account or Contact if it has child Affiliation, Program Enrollment, or Course Enrollment records. This logic can be turned off by setting the Active field to false for the ACCT_CannotDelete_TDTM and CON_CannotDelete_TDTM entries in the Trigger Handler object.

# Issues
Fixes #205.
Fixes #206. 