### PR TITLE
Removing unnecessary system field from Account. Looking instead at the account's record type.

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -41,6 +41,10 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
     */ 
     private static Hierarchy_Settings__c ContactsSettings;
     
+    private static ID orgRecTypeID = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get('Business Organization').getRecordTypeId();
+    private static ID householdRecTypeID = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get('Household Account').getRecordTypeId();
+    private static ID adminRecTypeID = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get('Administrative').getRecordTypeId();
+    
     /*******************************************************************************************************
     * @description a set of languages that require different naming conventions
     */ 
@@ -91,7 +95,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
            
            // requery to get correct Account values (and all the other fields we will look at)
            string strSoql = 'select id,AccountId,' +
-                'Account.SYSTEM_AccountType__c,' +
+                'Account.RecordType.Name,' +
                 'Account.Primary_Contact__c,Account.Name,' +
                 'firstname, lastname, OwnerId, Salutation,' +
                 'MailingStreet, MailingCity, MailingState, MailingPostalCode, MailingCountry, MailingLatitude, MailingLongitude, ' + 
@@ -132,8 +136,8 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                     }
 
 	                // HHAccount renaming needs to be called to set various HH naming fields like greeting.
-	                if (c.AccountId != null && (c.Account.SYSTEM_AccountType__c == CAO_Constants.HH_ACCOUNT_PROCESSOR
-	                || c.Account.SYSTEM_AccountType__c == CAO_Constants.ADM_ACCOUNT_PROCESSOR))
+	                if (c.AccountId != null && (c.Account.RecordType.Name == CAO_Constants.HH_ACCOUNT_PROCESSOR
+	                || c.Account.RecordType.Name == CAO_Constants.ADM_ACCOUNT_PROCESSOR))
 	                   listAccountIdHHToRename.add(c.AccountId);    
 	            }
         
@@ -311,7 +315,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             }
         }
         // get all the Accounts that are connected to the existing Contacts
-        for (Account acc : [Select Id, Primary_Contact__c, SYSTEM_AccountType__c from Account where Primary_Contact__c in :contactIds]) {
+        for (Account acc : [Select Id, Primary_Contact__c, RecordTypeId, RecordType.Name from Account where Primary_Contact__c in :contactIds]) {
             mapContactIdAccount.put(acc.Primary_Contact__c, acc);
         }
         
@@ -321,8 +325,8 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             // if we found an Account already connected to this Contact, connect the Contact to that Account if it
             // is the correct type for the current account processor
             Account acc = mapContactIdAccount.get(c.Id);
-            if (acc != null && CAO_Constants.isHhOrAdmAccountModel() && (acc.SYSTEM_AccountType__c == 
-            CAO_Constants.HH_ACCOUNT_PROCESSOR || acc.SYSTEM_AccountType__c == CAO_Constants.ADM_ACCOUNT_PROCESSOR)) {
+            if (acc != null && CAO_Constants.isHhOrAdmAccountModel() && (acc.RecordType.Name == 
+            CAO_Constants.HH_ACCOUNT_PROCESSOR || acc.RecordType.Name == CAO_Constants.ADM_ACCOUNT_PROCESSOR)) {
                 UTIL_Debug.debug('****Account already existed');
                 // if a user has blanked out the Account for a Contact, this will put it right back
                 c.AccountId = acc.Id;                
@@ -346,10 +350,10 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                 ADDR_Addresses_TDTM.copyAddressStdSObj(c, 'Mailing', a, 'Billing');
                 ADDR_Addresses_TDTM.copyAddressStdSObj(c, 'Other', a, 'Shipping');
 
-                if(CAO_Constants.isHHAccountModel()) {
-                    a.SYSTEM_AccountType__c = CAO_Constants.HH_ACCOUNT_PROCESSOR;   
-                } else if(CAO_Constants.isAdmAccountModel()) {
-                    a.SYSTEM_AccountType__c = CAO_Constants.ADM_ACCOUNT_PROCESSOR;
+                if(CAO_Constants.isHHAccountModel() && householdRecTypeID != null) {
+                    a.RecordTypeID = householdRecTypeID;   
+                } else if(CAO_Constants.isAdmAccountModel() && adminRecTypeID != null) {
+                    a.RecordTypeID = adminRecTypeID;
                 }
                 
                 //Creating account of the record type defined in the Account_Processor__c field of the Contacts and Orgs custom settings
@@ -411,18 +415,19 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                 accountIds.add(thisContact.accountId);
             }
 
-            accountsOnContacts = [Select Id, Type, SYSTEM_AccountType__c, (Select Id from Opportunities limit 1), (select Id from Contacts limit 1) from Account where Id IN :accountIds];
+            accountsOnContacts = [Select Id, Type, RecordTypeId, RecordType.Name, (Select Id from Opportunities limit 1), (select Id from Contacts limit 1) 
+                                  from Account where Id IN :accountIds];
             
             for (Account thisAccount : accountsOnContacts) {
                 //if the legacy or current type field show it's not a HH Account record, don't delete the account
-                if (thisAccount.SYSTEM_AccountType__c == CAO_Constants.HH_ACCOUNT_PROCESSOR || 
-                thisAccount.SYSTEM_AccountType__c == CAO_Constants.ADM_ACCOUNT_PROCESSOR) {
+                if (thisAccount.RecordType.Name == CAO_Constants.HH_ACCOUNT_PROCESSOR || 
+                thisAccount.RecordType.Name == CAO_Constants.ADM_ACCOUNT_PROCESSOR) {
                     
                     // if there are no Opportunities for this Account, add it for deletion
                     if (thisAccount.Opportunities.size() == 0 && thisAccount.Contacts.size() == 0) {
                         accountsForDeletion.add(thisAccount);
-                    } else if (thisAccount.SYSTEM_AccountType__c == CAO_Constants.HH_ACCOUNT_PROCESSOR || 
-                    thisAccount.SYSTEM_AccountType__c == CAO_Constants.ADM_ACCOUNT_PROCESSOR) {
+                    } else if (thisAccount.RecordType.Name == CAO_Constants.HH_ACCOUNT_PROCESSOR || 
+                    thisAccount.RecordType.Name == CAO_Constants.ADM_ACCOUNT_PROCESSOR) {
                         listAccountIdUpdate.add(thisAccount.Id);
                     }
                 }   
@@ -450,13 +455,13 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             	setAccId.add(con.AccountId);
             }
                        
-            list<Account> listAcc = [Select Id, SYSTEM_AccountType__c, Primary_Contact__c, OwnerId, (select Id from Contacts limit 2) from Account 
+            list<Account> listAcc = [Select Id, RecordType.Name, Primary_Contact__c, OwnerId, (select Id from Contacts limit 2) from Account 
                 where Id IN :setAccId];
             
             for (Account acc : listAcc) {
                 // only consider HH Accounts
-                if (acc.SYSTEM_AccountType__c == CAO_Constants.HH_ACCOUNT_PROCESSOR || 
-                acc.SYSTEM_AccountType__c == CAO_Constants.ADM_ACCOUNT_PROCESSOR) {                    
+                if (acc.RecordType.Name == CAO_Constants.HH_ACCOUNT_PROCESSOR || 
+                acc.RecordType.Name == CAO_Constants.ADM_ACCOUNT_PROCESSOR) {                    
                     // if there is only 1 contact associated with this account
                     if (acc.Contacts.size() == 1 && acc.Primary_Contact__c != null) {
                     	Contact c = mapContactIdContactOwnerChange.get(acc.Primary_Contact__c);

--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -41,7 +41,6 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
     */ 
     private static Hierarchy_Settings__c ContactsSettings;
     
-    private static ID orgRecTypeID = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get('Business Organization').getRecordTypeId();
     private static ID householdRecTypeID = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get('Household Account').getRecordTypeId();
     private static ID adminRecTypeID = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get('Administrative').getRecordTypeId();
     

--- a/src/classes/ADDR_Account_TDTM.cls
+++ b/src/classes/ADDR_Account_TDTM.cls
@@ -66,7 +66,7 @@ public class ADDR_Account_TDTM extends TDTM_Runnable {
             // AFTER INSERT
             if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
                 // for new accounts that are using address management, create the address object.
-                if (acc.SYSTEM_AccountType__c != CAO_Constants.HH_ACCOUNT_PROCESSOR && acc.SYSTEM_AccountType__c != CAO_Constants.ADM_ACCOUNT_PROCESSOR && 
+                if (acc.RecordType.Name != CAO_Constants.HH_ACCOUNT_PROCESSOR && acc.RecordType.Name != CAO_Constants.ADM_ACCOUNT_PROCESSOR && 
                 UTIL_CustomSettingsFacade.getSettings().Organizational_Account_Addresses_Enabled__c) {
                     if (isAccountAddressSpecified(acc))
                         listAccCreateAddr.add(acc);
@@ -82,9 +82,9 @@ public class ADDR_Account_TDTM extends TDTM_Runnable {
                     continue;
                 }
                 // we only support address management with HH Accounts and Organizational Accounts (if enabled)
-                if (((acc.SYSTEM_AccountType__c == CAO_Constants.HH_ACCOUNT_PROCESSOR || acc.SYSTEM_AccountType__c == CAO_Constants.ADM_ACCOUNT_PROCESSOR) && 
+                if (((acc.RecordType.Name == CAO_Constants.HH_ACCOUNT_PROCESSOR || acc.RecordType.Name == CAO_Constants.ADM_ACCOUNT_PROCESSOR) && 
                 UTIL_CustomSettingsFacade.getSettings().Household_Adm_Acct_Addresses_Enabled__c) || 
-                (acc.SYSTEM_AccountType__c != CAO_Constants.HH_ACCOUNT_PROCESSOR && acc.SYSTEM_AccountType__c != CAO_Constants.ADM_ACCOUNT_PROCESSOR && 
+                (acc.RecordType.Name != CAO_Constants.HH_ACCOUNT_PROCESSOR && acc.RecordType.Name != CAO_Constants.ADM_ACCOUNT_PROCESSOR && 
                 UTIL_CustomSettingsFacade.getSettings().Organizational_Account_Addresses_Enabled__c)) {
                     // if the address changed, remember the account we want to add a new address for    
                     if (isAccountAddressChanged(acc, accOld)) 

--- a/src/classes/ADDR_Addresses_TDTM.cls
+++ b/src/classes/ADDR_Addresses_TDTM.cls
@@ -290,7 +290,7 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
         set<Id> setHHId =  mapAccIdAddr.keySet();
         list<Contact> listCon = [select Id, is_Address_Override__c, Current_Address__c, AccountId 
             from Contact where 
-                (Account.SYSTEM_AccountType__c = :CAO_Constants.HH_ACCOUNT_PROCESSOR or Account.SYSTEM_AccountType__c = :CAO_Constants.ADM_ACCOUNT_PROCESSOR)
+                (Account.RecordType.Name = :CAO_Constants.HH_ACCOUNT_PROCESSOR or Account.RecordType.Name = :CAO_Constants.ADM_ACCOUNT_PROCESSOR)
                  and AccountId != null and AccountId in :setHHId];
         for (Contact con : listCon) {
             list<Contact> listConHH = mapAccIdListCon.get(con.AccountId);
@@ -671,14 +671,14 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
                 setAccId.add(addr.Parent_Account__c);
             }
         }       
-        map<Id, Account> mapAccIdAcc = new map<Id, Account>([select Id, SYSTEM_AccountType__c from Account where Id in :setAccId]);
+        map<Id, Account> mapAccIdAcc = new map<Id, Account>([select Id, RecordType.Name from Account where Id in :setAccId]);
         for (Address__c addr : listAddr) {
             if (addr.Parent_Account__c == null) {
                 // with TDTM, have to use addError, not throw an exception, or the error will just get logged but not passed to Salesforce to stop its DML.
                 addr.addError(Label.addrHhAdmAccountOnly);
             } else {
                 Account acc = mapAccIdAcc.get(addr.Parent_Account__c);
-                if ((acc.SYSTEM_AccountType__c != CAO_Constants.HH_ACCOUNT_PROCESSOR && acc.SYSTEM_AccountType__c != CAO_Constants.ADM_ACCOUNT_PROCESSOR) &&
+                if ((acc.RecordType.Name != CAO_Constants.HH_ACCOUNT_PROCESSOR && acc.RecordType.Name != CAO_Constants.ADM_ACCOUNT_PROCESSOR) &&
                     (!UTIL_CustomSettingsFacade.getSettings().Organizational_Account_Addresses_Enabled__c)) {
                     // with TDTM, have to use addError, not throw an exception, or the error will just get logged but not passed to Salesforce to stop its DML.
                     addr.addError(Label.addrHhAdmAccountOnly);

--- a/src/classes/ADDR_Addresses_TEST.cls
+++ b/src/classes/ADDR_Addresses_TEST.cls
@@ -61,7 +61,17 @@ private with sharing class ADDR_Addresses_TEST {
     /*********************************************************************************************************
     * @description The list of created test Addresses.
     */
-    private static list<Address__c> listAddrT;           
+    private static list<Address__c> listAddrT;
+    
+    private static ID orgRecTypeID;
+    private static ID householdRecTypeID;
+    private static ID adminRecTypeID;
+    
+    public static void recTypesSetup() {
+        orgRecTypeID = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get('Business Organization').getRecordTypeId();
+        householdRecTypeID = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get('Household Account').getRecordTypeId();
+        adminRecTypeID = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get('Administrative').getRecordTypeId();
+    }        
 
     /*********************************************************************************************************
     * @description
@@ -73,7 +83,9 @@ private with sharing class ADDR_Addresses_TEST {
     * @param cConT the number of Contacts to create per Household
     * @return  void
     **********************************************************************************************************/
-    private static void createHHTestData(Integer parentAccsT, Integer cConT) {  
+    private static void createHHTestData(Integer parentAccsT, Integer cConT) {
+        recTypesSetup();
+        
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c();
         hs.Account_Processor__c = CAO_Constants.HH_ACCOUNT_PROCESSOR;
         hs.Organizational_Account_Addresses_Enabled__c = true;
@@ -83,13 +95,15 @@ private with sharing class ADDR_Addresses_TEST {
         UTIL_CustomSettingsFacade.getSettingsForTests(hs);
             
         listConT = UTIL_UnitTestData_TEST.CreateMultipleTestContacts(parentAccsT * cConT);
-        listAccT = UTIL_UnitTestData_TEST.CreateMultipleTestAccounts(parentAccsT, CAO_Constants.HH_ACCOUNT_PROCESSOR);
+        listAccT = UTIL_UnitTestData_TEST.CreateMultipleTestAccounts(parentAccsT, householdRecTypeID);
         insert listAccT;
         
         createTestData(parentAccsT, cConT);
     }
     
     private static void createAdmTestData(Integer parentAccsT, Integer cConT) {
+        recTypesSetup();
+        
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c();
         hs.Account_Processor__c = CAO_Constants.ADM_ACCOUNT_PROCESSOR;
         hs.Organizational_Account_Addresses_Enabled__c = true;
@@ -100,7 +114,7 @@ private with sharing class ADDR_Addresses_TEST {
         UTIL_CustomSettingsFacade.getSettingsForTests(hs);
         
         listConT = UTIL_UnitTestData_TEST.CreateMultipleTestContacts(parentAccsT * cConT);
-        listAccT = UTIL_UnitTestData_TEST.CreateMultipleTestAccounts(parentAccsT, CAO_Constants.ADM_ACCOUNT_PROCESSOR);
+        listAccT = UTIL_UnitTestData_TEST.CreateMultipleTestAccounts(parentAccsT, adminRecTypeID);
         insert listAccT;
         
         createTestData(parentAccsT, cConT);
@@ -2786,7 +2800,9 @@ private with sharing class ADDR_Addresses_TEST {
         account address matches address object address
     **********************************************************************************************************/            
     @isTest
-    public static void newOrgAccounts() {        
+    public static void newOrgAccounts() {
+        recTypesSetup();
+            
         Hierarchy_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getSettingsForTests(
             new Hierarchy_Settings__c (
                 Account_Processor__c = CAO_Constants.HH_ACCOUNT_PROCESSOR,
@@ -2794,7 +2810,7 @@ private with sharing class ADDR_Addresses_TEST {
         ));
  
         Integer cAcc = 3;
-        list<Account> listAcc = UTIL_UnitTestData_TEST.CreateMultipleTestAccounts(cAcc, null);
+        list<Account> listAcc = UTIL_UnitTestData_TEST.CreateMultipleTestAccounts(cAcc, orgRecTypeID);
         for (Account acc : listAcc) {
             acc.BillingStreet = '123 45th';
             acc.BillingCity = 'Seattle';
@@ -2826,7 +2842,9 @@ private with sharing class ADDR_Addresses_TEST {
         contact addresses not updated
     **********************************************************************************************************/            
     @isTest
-    public static void updateOrgAccounts() {        
+    public static void updateOrgAccounts() {
+        recTypesSetup();
+         
         Hierarchy_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getSettingsForTests(
             new Hierarchy_Settings__c (
                 Account_Processor__c = CAO_Constants.HH_ACCOUNT_PROCESSOR,
@@ -2835,7 +2853,7 @@ private with sharing class ADDR_Addresses_TEST {
  
         // create accounts without addresses
         Integer cAcc = 3;
-        list<Account> listAcc = UTIL_UnitTestData_TEST.CreateMultipleTestAccounts(cAcc, null);
+        list<Account> listAcc = UTIL_UnitTestData_TEST.CreateMultipleTestAccounts(cAcc, orgRecTypeID);
         insert listAcc;
         
         // add a contact to each account.
@@ -2888,7 +2906,9 @@ private with sharing class ADDR_Addresses_TEST {
         contact addresses not updated
     **********************************************************************************************************/            
     @isTest
-    public static void newAddrForOrgAccounts() {        
+    public static void newAddrForOrgAccounts() {
+        recTypesSetup();
+           
         Hierarchy_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getSettingsForTests(
             new Hierarchy_Settings__c (
                 Account_Processor__c = CAO_Constants.HH_ACCOUNT_PROCESSOR,
@@ -2897,7 +2917,7 @@ private with sharing class ADDR_Addresses_TEST {
  
         // create accounts without addresses
         Integer cAcc = 3;
-        list<Account> listAcc = UTIL_UnitTestData_TEST.CreateMultipleTestAccounts(cAcc, null);
+        list<Account> listAcc = UTIL_UnitTestData_TEST.CreateMultipleTestAccounts(cAcc, orgRecTypeID);
         insert listAcc;
         
         // add a contact to each account.

--- a/src/classes/ADDR_Contact_TDTM.cls
+++ b/src/classes/ADDR_Contact_TDTM.cls
@@ -76,7 +76,7 @@ public class ADDR_Contact_TDTM extends TDTM_Runnable {
                 if (con.AccountId != null)
                     setAccountId.add(con.AccountId);
             }
-            mapAccountIdAccount = new Map<Id,Account>([select Id, SYSTEM_AccountType__c from Account where Id IN :setAccountId]);
+            mapAccountIdAccount = new Map<Id,Account>([select Id, RecordType.Name from Account where Id IN :setAccountId]);
         }        
        
         integer i = -1;        

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -72,10 +72,10 @@ public class UTIL_UnitTestData_TEST {
         return ContactsToAdd;
     }
 
-    public static List<Account> CreateMultipleTestAccounts (integer n, string strType) {
+    public static List<Account> CreateMultipleTestAccounts (integer n, ID recTypeId) {
         List<Account> AcctsToAdd = New List<Account> ();    
         for (integer i=0;i<n;i++) {
-            AcctsToAdd.add(new Account(Name = 'Yet Another Org ' + i, SYSTEM_AccountType__c = strType));
+            AcctsToAdd.add(new Account(Name = 'Yet Another Org ' + i, RecordTypeId = recTypeId));
         }
         return AcctsToAdd;
     }

--- a/src/objects/Account.object
+++ b/src/objects/Account.object
@@ -20,16 +20,4 @@
         <trackFeedHistory>false</trackFeedHistory>
         <type>Lookup</type>
     </fields>
-    <fields>
-        <fullName>SYSTEM_AccountType__c</fullName>
-        <description>Hidden system field: do not change.  Updated by automatic processes.</description>
-        <externalId>false</externalId>
-        <inlineHelpText>Indicates which model drives Contact relationship behavior: Administrative (One-to-One) or Household</inlineHelpText>
-        <label>_SYSTEM: AccountType</label>
-        <length>100</length>
-        <required>false</required>
-        <trackFeedHistory>false</trackFeedHistory>
-        <type>Text</type>
-        <unique>false</unique>
-    </fields>
 </CustomObject>

--- a/src/package.xml
+++ b/src/package.xml
@@ -121,7 +121,6 @@
     </types>
     <types>
         <members>Account.Primary_Contact__c</members>
-        <members>Account.SYSTEM_AccountType__c</members>
         <members>Address__c.Address_Type__c</members>
         <members>Address__c.Default_Address__c</members>
         <members>Address__c.Formula_MailingAddress__c</members>


### PR DESCRIPTION
# Warning

# Info
- Field SYSTEM_AccountType__c in Account can now be safely deleted from the user's org.

# Issues
Fixes #212.