### PR TITLE
Schedule job only if not scheduled.

### DIFF
--- a/src/classes/ADDR_Addresses_TEST.cls
+++ b/src/classes/ADDR_Addresses_TEST.cls
@@ -2079,17 +2079,17 @@ private with sharing class ADDR_Addresses_TEST {
     public static void scheduleSeasonalAddrUpdateHH() {        
         // this creates a default Address for each Account
         createHHTestData(parentAccs, cCon);
-        scheduleSeasonalAddrUpdate('HH');
+        scheduleSeasonalAddrUpdate();
     }
     
     @isTest
     public static void scheduleSeasonalAddrUpdateAdm() {        
         // this creates a default Address for each Account
         createAdmTestData(parentAccs, cCon);
-        scheduleSeasonalAddrUpdate('Adm');
+        scheduleSeasonalAddrUpdate();
     }
     
-    public static void scheduleSeasonalAddrUpdate(String suffix) { 
+    public static void scheduleSeasonalAddrUpdate() { 
         // create additional addresses
         initTestAddr(parentAccs);
         for (Integer i = 0; i < parentAccs; i++) {
@@ -2113,7 +2113,7 @@ private with sharing class ADDR_Addresses_TEST {
         //Schedule the job just for test coverage purposes. But we still have to manually run the
         //batch, as batch jobs run from a scheduled job don't actually run after stopTest, as described
         //at https://salesforce.stackexchange.com/questions/36806/does-test-stoptest-ensure-a-system-schedule-database-batchable-completes-in-a
-        String jobId= System.schedule('Seasonal Addresses Update' + suffix, '0 15 0 * * ?', new ADDR_Seasonal_SCHED());
+        String jobId = STG_InstallScript.scheduleJobIfNotScheduled('Seasonal Addresses Update', '0 15 0 * * ?', 'ADDR_Seasonal_SCHED');
         // Get the information from the CronTrigger API object
         CronTrigger ct = [SELECT Id, CronExpression, TimesTriggered, NextFireTime FROM CronTrigger WHERE id = :jobId];
         // Verify the expressions are the same

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -47,7 +47,7 @@ global without sharing class STG_InstallScript implements InstallHandler {
     		insertMappings(); //putting the logic in a different method to be able to call it from the anonymous window
     		insertRelationshipLookups();
     		//Schedule Seasonal Addresses recurring job daily
-    		System.schedule('Seasonal Addresses Update', '0 15 0 * * ?', new ADDR_Seasonal_SCHED());
+    		scheduleJobIfNotScheduled('Seasonal Addresses Update', '0 15 0 * * ?', 'ADDR_Seasonal_SCHED');
     	 } else if(context.isUpgrade() || context.isPush()) {
     	 	List<Trigger_Handler__c> defaultHandlers = TDTM_DefaultConfig.getDefaultRecords(); 
             insertTdtmDefaults(defaultHandlers);
@@ -68,6 +68,10 @@ global without sharing class STG_InstallScript implements InstallHandler {
     	 }
     }
     
+    /*******************************************************************************************************
+    * @description Inserts the default Affiliation Mappings.
+    * @return void
+    */
     global static void insertMappings() {
     	List<Affl_Mappings__c> mappings = [select ID from Affl_Mappings__c where Account_Record_Type__c != null AND Primary_Affl_Field__c != null];
     	if(mappings.size() == 0) {
@@ -119,6 +123,10 @@ global without sharing class STG_InstallScript implements InstallHandler {
         if(handlersToUpdate.size() > 0) update handlersToUpdate;
     }
     
+    /*******************************************************************************************************
+    * @description Inserts the default Relationship Lookup settings.
+    * @return void
+    */
     global static void insertRelationshipLookups() {
         Integer lookupCount = [select count() from Relationship_Lookup__c];
         if(lookupCount == 0) {
@@ -143,5 +151,31 @@ global without sharing class STG_InstallScript implements InstallHandler {
             lookups.add(new Relationship_Lookup__c(Name = 'Employee', Male__c = 'Employer', Female__c = 'Employer', Neutral__c = 'Employer', Active__c = true));
             insert lookups;
         }
+    }
+    
+    /*******************************************************************************************************
+    * @description Schedules a class that implements the Schedulable interface, if it's not already scheduled.
+    * @param JobName The name to give the scheduled job.
+    * @param frequency The frequency to schedule the job at.
+    * @param className The class to schedule. Should implement the Schedulable interface.
+    * @return The ID of the scheduled job.
+    */
+    public static String scheduleJobIfNotScheduled(String JobName, String frequency, String className) {
+        
+        //Check if the job is already scheduled - CronJobDetail is the parent and CronTrigger is the child
+        //Type '7' is for scheduled Apex
+        List<CronTrigger> scheduledJobs = [select Id, CronJobDetail.Id from CronTrigger 
+                    where CronJobDetail.Name = :JobName and CronJobDetail.JobType = '7'];
+        
+        if(scheduledJobs.size() == 0) {
+            Type classType = Type.forName(className);
+            
+            if(classType != null) {     
+               Object instance = classType.newInstance();
+               if(instance instanceof Schedulable)
+                   return System.schedule(JobName, frequency, (Schedulable)instance);
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Scheduling job only if not scheduled. To avoid tests failing after the first install of the package in an org. Addresses failures we were seeing in the new Bamboo CI system. 

Changes in ADDR_Addresses_TEST.cls are just undoing some minor changes that had been done directly in master branch.