### PR TITLE
Modify Ethnicity field and add Race field.

### DIFF
--- a/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
+++ b/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
@@ -118,7 +118,7 @@
             <h2>Ethnicity and Race Backfill</h2>
             <div class="slds-text-body--small">
 
-                <p>Use the Ethnicity and Race Backfill only if your org used the Ethnicity field before HEDA added the Race field and removed values from the Ethnicity field in HEDA version 1.28. The Backfill copies all values that were not “Hispanic or Latino” in the Ethnicity field to the Race field. The copy includes both standard picklist values and any custom values you may have added.</p>
+                <p>Use the Ethnicity and Race Backfill only if your org used the Ethnicity field before HEDA added the Race field and removed values from the Ethnicity field as of HEDA version 1.28. The Backfill copies all values that were not “Hispanic or Latino” in the Ethnicity field to the Race field. The copy includes both standard picklist values and any custom values you may have added.</p>
 
                 <h3>Before you run the Backfill:</h3>
                 <p>Add the "Not Hispanic or Latino" picklist value to the Ethnicity field.</p>

--- a/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
+++ b/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
@@ -119,11 +119,11 @@
             <div class="slds-text-body--small">
 
                 <p>Use the Ethnicity and Race Backfill only if your org used the Ethnicity field before HEDA added the Race field and removed values from the Ethnicity field as of HEDA version 1.28. The Backfill copies all values that were not “Hispanic or Latino” in the Ethnicity field to the Race field. The copy includes both standard picklist values and any custom values you may have added.</p>
-
-                <h3>Before you run the Backfill:</h3>
+                <br />
+                <h3><strong>Before you run the Backfill:</strong></h3>
                 <p>Add the "Not Hispanic or Latino" picklist value to the Ethnicity field.</p>
-
-                <h3>After you run the Backfill:</h3>
+                <br />
+                <h3><strong>After you run the Backfill:</strong></h3>
                 <ul class="slds-list--dotted">
                     <li>Remove these picklist values from the Ethnicity field: "American Indian or Alaskan Native," "Asian," "Black or African American," "Native Hawaiian or Other Pacific Islander," and "White." We recommend that you replace these values with "Not Hispanic or Latino" rather than deleting them outright from existing records.</li>
                     <li>If you had dependencies that relied on the previous values in the Ethnicity field, such as in reports, update them.</li>

--- a/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
+++ b/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
@@ -116,22 +116,20 @@
 
         <div class="slds-col slds-size--1-of-2 slds-m-top--large slds-border--top slds-p-right--xx-large">
             <h2>Ethnicity and Race Backfill</h2>
-            <p class="slds-text-body--small">
-                These steps will help you modify the existing data in your organization to utilize the new “Race” field and modify the “Ethnicity” field to match the current version of HEDA.
-                <ol class="slds-list--ordered">
-                    <li>Add “Not Hispanic or Latino” pick-list option to the “Ethnicity” field</li>
-                    <li>Optional: If your Org has any additional values configured in the “Ethnicity” Field these may need to be re-created in the “Race” field.</li>
-                    <li>Run the batch job by clicking the button in the settings</li>
-                        <ul>
-                            <li>This will copy the values that are not “Hispanic or Latino” to the “Race” field</li>
-                        </ul>
-                    <li>Delete "American Indian or Alaskan Native", "Asian", "Black or African American", "Native Hawaiian or Other Pacific Islander", and "White" options from the “Ethnicity” field.</li>
-                        <ul>
-                            <li>Note: It is recommended that you use the option to replace the values you are deleting with “Not Hispanic or Latino”.</li>
-                        </ul>
-                    <li>Optional: Update any dependencies that have been been added to your Org that relied on previous values in the “Ethnicity” field.</li>
-                </ol>
-            </p>
+            <div class="slds-text-body--small">
+
+                <p>Use the Ethnicity and Race Backfill only if your org used the Ethnicity field before HEDA added the Race field and removed values from the Ethnicity field in HEDA version 1.28. The Backfill copies all values that were not “Hispanic or Latino” in the Ethnicity field to the Race field. The copy includes both standard picklist values and any custom values you may have added.</p>
+
+                <h3>Before you run the Backfill:</h3>
+                <p>Add the "Not Hispanic or Latino" picklist value to the Ethnicity field.</p>
+
+                <h3>After you run the Backfill:</h3>
+                <ul class="slds-list--dotted">
+                    <li>Remove these picklist values from the Ethnicity field: "American Indian or Alaskan Native," "Asian," "Black or African American," "Native Hawaiian or Other Pacific Islander," and "White." We recommend that you replace these values with "Not Hispanic or Latino" rather than deleting them outright from existing records.</li>
+                    <li>If you had dependencies that relied on the previous values in the Ethnicity field, such as in reports, update them.</li>
+                    <li>If your org had previously added custom values to the Ethnicity field that you want to be available in the Race field, copy those values to Race.</li>
+                </ul>
+            </div>
         </div>
         <div class="slds-col slds-size--1-of-2 slds-m-top--large slds-border--top">
             <lightning:button variant="brand" label="Run Backfill" iconName="utility:copy" iconPosition="left" onclick="{! c.runBackfill }" aura:id="ethnicRaceBtn" />

--- a/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
+++ b/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
@@ -111,5 +111,33 @@
                           recTypesSelected="{!v.accTypesToDeleteSelected}" isView="{!v.isView}"
                           class="accounts-to-delete" />
         </div>
+
+        <hr />
+
+        <div class="slds-col slds-size--1-of-2 slds-m-top--large slds-border--top slds-p-right--xx-large">
+            <h2>Ethnicity and Race Backfill</h2>
+            <p class="slds-text-body--small">
+                These steps will help you modify the existing data in your organization to utilize the new “Race” field and modify the “Ethnicity” field to match the current version of HEDA.
+                <ol class="slds-list--ordered">
+                    <li>Add “Not Hispanic or Latino” pick-list option to the “Ethnicity” field</li>
+                    <li>Optional: If your Org has any additional values configured in the “Ethnicity” Field these may need to be re-created in the “Race” field.</li>
+                    <li>Run the batch job by clicking the button in the settings</li>
+                        <ul>
+                            <li>This will copy the values that are not “Hispanic or Latino” to the “Race” field</li>
+                        </ul>
+                    <li>Delete "American Indian or Alaskan Native", "Asian", "Black or African American", "Native Hawaiian or Other Pacific Islander", and "White" options from the “Ethnicity” field.</li>
+                        <ul>
+                            <li>Note: It is recommended that you use the option to replace the values you are deleting with “Not Hispanic or Latino”.</li>
+                        </ul>
+                    <li>Optional: Update any dependencies that have been been added to your Org that relied on previous values in the “Ethnicity” field.</li>
+                </ol>
+            </p>
+        </div>
+        <div class="slds-col slds-size--1-of-2 slds-m-top--large slds-border--top">
+            <lightning:button variant="brand" label="Run Backfill" iconName="utility:copy" iconPosition="left" onclick="{! c.runBackfill }" aura:id="ethnicRaceBtn" />
+            <br />
+            <ui:outputText aura:id="ethnicRaceMsg" value="The backfill was queued successfully. An email will be sent at the completion of the batch." class="slds-text-color--weak slds-hide" />
+        </div>
+        
     </div>
 </aura:component>

--- a/src/aura/STG_CMP_Addr/STG_CMP_AddrController.js
+++ b/src/aura/STG_CMP_Addr/STG_CMP_AddrController.js
@@ -1,5 +1,8 @@
 ({
     toggleIsView : function(component, event) {
 		component.set("v.isView", event.getParam("isView"));
+	},
+	runBackfill : function (component, event, helper) {
+		helper.runBackfill(component);
 	}
 })

--- a/src/aura/STG_CMP_Addr/STG_CMP_AddrHelper.js
+++ b/src/aura/STG_CMP_Addr/STG_CMP_AddrHelper.js
@@ -1,0 +1,17 @@
+({
+	runBackfill : function (component, event, helper) {
+		// console.log();
+		var runBatchAction = component.get("c.executeEthnicityRaceBatch");
+		runBatchAction.setCallback(this, function(response) {
+	        if(response.getState() === "SUCCESS") {
+
+			    var backfillBtn = component.find("ethnicRaceMsg");
+			    $A.util.toggleClass(backfillBtn, "slds-hide");
+
+	        } else if(response.getState() === "ERROR") {
+	        	this.displayError(response);
+		    }
+		});
+		$A.enqueueAction(runBatchAction);
+	}
+})

--- a/src/aura/STG_CMP_Addr/STG_CMP_AddrHelper.js
+++ b/src/aura/STG_CMP_Addr/STG_CMP_AddrHelper.js
@@ -1,12 +1,11 @@
 ({
 	runBackfill : function (component, event, helper) {
-		// console.log();
 		var runBatchAction = component.get("c.executeEthnicityRaceBatch");
 		runBatchAction.setCallback(this, function(response) {
 	        if(response.getState() === "SUCCESS") {
 
-			    var backfillBtn = component.find("ethnicRaceMsg");
-			    $A.util.toggleClass(backfillBtn, "slds-hide");
+			    var backfillStatusMsg = component.find("ethnicRaceMsg");
+			    $A.util.toggleClass(backfillStatusMsg, "slds-hide");
 
 	        } else if(response.getState() === "ERROR") {
 	        	this.displayError(response);

--- a/src/aura/STG_CMP_Base/STG_CMP_BaseHelper.js
+++ b/src/aura/STG_CMP_Base/STG_CMP_BaseHelper.js
@@ -76,10 +76,14 @@
 
 	displayError : function(response) {
 		var errors = response.getError();
-		if (errors && errors[0].pageErrors[0] && errors[0].pageErrors[0].message) {
+		if (errors && errors[0].message && typeof errors[0].pageErrors == 'undefined' && typeof errors[0].fieldErrors == 'undefined') {
+			throw new Error("Error message: " + errors[0].message);
+		} else if (errors && errors[0].pageErrors[0] && errors[0].pageErrors[0].message) {
 			throw new Error("Error message: " + errors[0].pageErrors[0].message);
-		} else if(errors && errors[0].fieldErrors && errors[0].fieldErrors.Name[0] && errors[0].fieldErrors.Name[0].message) {
-			throw new Error("Error message: " + errors[0].fieldErrors[0].Name[0].message);
+		} else if(errors && errors[0].fieldErrors && errors[0].fieldErrors.Name && errors[0].fieldErrors.Name[0] && errors[0].fieldErrors.Name[0].message) {
+			throw new Error("Error message: " + errors[0].fieldErrors.Name[0].message);
+		} else if(errors && errors[0].fieldErrors && errors[0].fieldErrors.Id && errors[0].fieldErrors.Id[0] && errors[0].fieldErrors.Id[0].message) {
+			throw new Error("Error message: " + errors[0].fieldErrors.Id[0].message);
 		} else {
 			throw new Error("Unknown error");
 		}

--- a/src/classes/CON_EthnicityRace_BATCH.cls
+++ b/src/classes/CON_EthnicityRace_BATCH.cls
@@ -43,7 +43,7 @@ global class CON_EthnicityRace_BATCH implements Database.Batchable<sObject> {
     ********************************************************************************************************/
 	global Database.QueryLocator start(Database.BatchableContext BC) {
 
-		// Get all Contacts that have Ethnicity/Race information that is not "Hispanic or Latino"
+		// Get all Contacts that have Ethnicity/Race information that is not "Hispanic or Latino" and not "Not Hispanic or Latino"
 		String query = 'SELECT Id, Name, Ethnicity__c, Race__c FROM Contact WHERE Ethnicity__c != \'Hispanic or Latino\' AND Ethnicity__c != \'Not Hispanic or Latino\' AND Ethnicity__c != null';
 
 		return Database.getQueryLocator(query);
@@ -52,7 +52,7 @@ global class CON_EthnicityRace_BATCH implements Database.Batchable<sObject> {
    	global void execute(Database.BatchableContext BC, List<sObject> scope) {
    		System.debug(scope);
 
-		List<Contact> contacts = (List<Contact> ) scope; //Cast list of Addresses
+		List<Contact> contacts = (List<Contact> ) scope; //Cast list of contacts
         
         // According to the spec (https://nces.ed.gov/ipeds/Section/collecting_re on 1/13/2017) Ethnicity should only ask if Hispanic or Latino, so the other options will be copied to the Race field. 
         if(contacts.size()>0) {

--- a/src/classes/CON_EthnicityRace_BATCH.cls
+++ b/src/classes/CON_EthnicityRace_BATCH.cls
@@ -1,0 +1,90 @@
+/*
+    Copyright (c) 2017, Salesforce.com Foundation
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Salesforce.com Foundation nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.com Foundation
+* @date 2017
+* @group Contacts
+* @group-content ../../ApexDocContent/Contacts.htm
+* @description Copies data from the Ethnicty Field to the Race Field.
+*/
+global class CON_EthnicityRace_BATCH implements Database.Batchable<sObject> {
+
+    /*******************************************************************************************************
+    * @description start Method for the Database.Batchable interface
+    * @param bc the BatchableContext
+    * @return database.Querylocator
+    ********************************************************************************************************/
+	global Database.QueryLocator start(Database.BatchableContext BC) {
+
+		// Get all Contacts that have Ethnicity/Race information that is not "Hispanic or Latino"
+		String query = 'SELECT Id, Name, Ethnicity__c, Race__c FROM Contact WHERE Ethnicity__c != \'Hispanic or Latino\' AND Ethnicity__c != \'Not Hispanic or Latino\' AND Ethnicity__c != null';
+
+		return Database.getQueryLocator(query);
+	}
+
+   	global void execute(Database.BatchableContext BC, List<sObject> scope) {
+   		System.debug(scope);
+
+		List<Contact> contacts = (List<Contact> ) scope; //Cast list of Addresses
+        
+        // According to the spec (https://nces.ed.gov/ipeds/Section/collecting_re on 1/13/2017) Ethnicity should only ask if Hispanic or Latino, so the other options will be copied to the Race field. 
+        if(contacts.size()>0) {
+	        for(Contact c : contacts) {
+
+	        	// If the race field is populated we dont want to override it
+	        	if(c.Ethnicity__c != null && c.Race__c == null) {
+	        		c.Race__c = c.Ethnicity__c;
+	        	}
+            }
+        }
+
+        update contacts;
+	}
+
+	global void finish(Database.BatchableContext BC) {
+
+		// Email Notification
+		AsyncApexJob a = [SELECT Id, Status, NumberOfErrors, JobItemsProcessed, TotalJobItems, CreatedBy.Email
+							FROM AsyncApexJob WHERE Id =:BC.getJobId()];
+
+		String emailBody = 'The batch Apex job processed ' + a.TotalJobItems +
+		' batches with '+ a.NumberOfErrors + ' failures.';
+
+		// Send an email to the Apex job's submitter notifying of job completion.
+		Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
+		String[] toAddresses = new String[] {a.CreatedBy.Email};
+		mail.setToAddresses(toAddresses);
+		mail.setSubject('Ethnicity and Race field backfill: ' + a.Status);
+		mail.setPlainTextBody(emailBody);
+		Messaging.sendEmail(new Messaging.SingleEmailMessage[] { mail });
+		
+	}
+
+}

--- a/src/classes/CON_EthnicityRace_BATCH.cls-meta.xml
+++ b/src/classes/CON_EthnicityRace_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>35.0</apiVersion>
+    <apiVersion>36.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_EthnicityRace_BATCH.cls-meta.xml
+++ b/src/classes/CON_EthnicityRace_BATCH.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>35.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/CON_EthnicityRace_TEST.cls
+++ b/src/classes/CON_EthnicityRace_TEST.cls
@@ -38,6 +38,7 @@
 private class CON_EthnicityRace_TEST {
 
 	Private static List<String> races = new List<String>{
+			'Non-Standard to see what happens',
 			'White',
 			'Asian',
 			'Hispanic or Latino',
@@ -52,7 +53,7 @@ private class CON_EthnicityRace_TEST {
 		// How many races to test
 		Integer raceCount = races.size();
 
-		// Get contacts that match the number ot
+		// Get contacts
         List<Contact> listCon = UTIL_UnitTestData_TEST.getMultipleTestContacts(raceCount);
         for (Integer i = 0; i < raceCount; i++) {
             listCon[i].LastName = 'ToAvoidDupeRule' + i;//Avoid duplicate matching
@@ -72,8 +73,7 @@ private class CON_EthnicityRace_TEST {
 	    Database.executeBatch( contbatch );
 		Test.stopTest();
 
-		// AFter test run assert
-		//System.assertEquals( 7, contacts.size() );
+		// After test run assert
 		List<Contact> contacts = [SELECT Id, Name, Ethnicity__c, Race__c FROM Contact WHERE Race__c in: races];
 		System.assertEquals( (races.size()-2) , contacts.size() ); // We reduce the count by two because we are explicitly trying to exclude two of the results
 	}

--- a/src/classes/CON_EthnicityRace_TEST.cls
+++ b/src/classes/CON_EthnicityRace_TEST.cls
@@ -1,0 +1,80 @@
+/*
+    Copyright (c) 2017, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2017
+* @group Contacts
+* @group-content ../../ApexDocContent/Contacts.htm
+* @description Tests Race Ethnicity Batch Class
+*/
+@isTest
+private class CON_EthnicityRace_TEST {
+
+	Private static List<String> races = new List<String>{
+			'White',
+			'Asian',
+			'Hispanic or Latino',
+			'Not Hispanic or Latino',
+			'Black or African American',
+			'American Indian or Alaskan Native',
+			'Native Hawaiian or Other Pacific Islander'};
+
+	@testSetup
+	static void dataSetup() {
+
+		// How many races to test
+		Integer raceCount = races.size();
+
+		// Get contacts that match the number ot
+        List<Contact> listCon = UTIL_UnitTestData_TEST.getMultipleTestContacts(raceCount);
+        for (Integer i = 0; i < raceCount; i++) {
+            listCon[i].LastName = 'ToAvoidDupeRule' + i;//Avoid duplicate matching
+
+            // Setup the Ethnicity info
+            listCon[i].Ethnicity__c = races.get(i);
+        }
+
+        insert listCon;
+	}
+
+	@isTest
+	static void testEthnicityRaceBatch() {
+		// Run Batch
+		Test.startTest();
+	    CON_EthnicityRace_BATCH contbatch = new CON_EthnicityRace_BATCH();
+	    Database.executeBatch( contbatch );
+		Test.stopTest();
+
+		// AFter test run assert
+		//System.assertEquals( 7, contacts.size() );
+		List<Contact> contacts = [SELECT Id, Name, Ethnicity__c, Race__c FROM Contact WHERE Race__c in: races];
+		System.assertEquals( (races.size()-2) , contacts.size() ); // We reduce the count by two because we are explicitly trying to exclude two of the results
+	}
+}

--- a/src/classes/CON_EthnicityRace_TEST.cls-meta.xml
+++ b/src/classes/CON_EthnicityRace_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>35.0</apiVersion>
+    <apiVersion>36.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_EthnicityRace_TEST.cls-meta.xml
+++ b/src/classes/CON_EthnicityRace_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>35.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/CON_PrimaryAffls_TDTM.cls
+++ b/src/classes/CON_PrimaryAffls_TDTM.cls
@@ -69,80 +69,70 @@ public class CON_PrimaryAffls_TDTM extends TDTM_Runnable {
         //Map of Contact ID to list of Account IDs that represent key Affl fields that have been cleared or modified. 
         //The old Affls need to be made non-primary.
         Map<ID, List<ID>> changedConToAccsMap = new Map<ID, List<ID>>();
-
-        // AFTER INSERT
-        if( newlist != null && triggerAction == TDTM_Runnable.Action.AfterInsert  && !alreadyRunAfterInsert) {
-
-            // Loop over contact list
-            for (integer i=0; i<newlist.size(); i++) {
-
-                Contact newContact = (Contact)newlist[i];
-
-                //If the Contact has been created with any of the Key Affiliation fields populated
-                //  --> Create a matching primary Affiliation for the Contact
-                for(Integer j = 0; j < afflMapper.primaryAfflFieldNames.size(); j++) {
-                    try {
-                        if(newContact.get(afflMapper.primaryAfflFieldNames[j]) != null) {
-                            UTIL_Debug.debug('****Contact has been created with one of the Key Affiliation fields populated');
-                            createAfflFromLookup(newContact, j, afflsToInsert);                           
-                        }
-                    } catch(Exception e) {
-                        UTIL_Debug.debug('****Exception message: ' + e.getMessage());
-                        UTIL_Debug.debug('****Stack trace: \n' + e.getStackTraceString());
-                        newContact.addError(e.getMessage());
-                    }
-                }
-            }
-
-            // Set reentrant Flag
-            alreadyRunAfterInsert = true;
-        }
-
-        // BEFORE UPDATE
-        if ( newlist != null && triggerAction == TDTM_Runnable.Action.BeforeUpdate && !alreadyRunBeforeUpdate) {
+        
+        if(newlist != null) {
             for (integer i=0; i<newlist.size(); i++) {
                 Contact newContact = (Contact)newlist[i];
-                Contact oldContact = (Contact)oldlist[i];
-
-                for(Integer j = 0; j < afflMapper.primaryAfflFieldNames.size(); j++) {
-                    try {
-                        //If any Key Affiliation field has been set
-                        //  --> Create a matching primary Affiliation for the Contact
-                        //  --> If another Affl to the same Account exists, it should be made not primary. But this is AFFL_MultiRecordType_TDTM's responsibility. 
-                        if(newContact.get(afflMapper.primaryAfflFieldNames[j]) != null && oldContact.get(afflMapper.primaryAfflFieldNames[j]) == null) {
-                           UTIL_Debug.debug('****Key Affiliation field has been set');
-                           createAfflFromLookup(newContact, j, afflsToInsert);
+                
+                if(triggerAction == TDTM_Runnable.Action.AfterInsert && !alreadyRunAfterInsert) {
+                    
+                    //If the Contact has been created with any of the Key Affiliation fields populated
+                    //  --> Create a matching primary Affiliation for the Contact
+                    for(Integer j = 0; j < afflMapper.primaryAfflFieldNames.size(); j++) {
+                        try {
+		                    if(newContact.get(afflMapper.primaryAfflFieldNames[j]) != null) {
+		                        UTIL_Debug.debug('****Contact has been created with one of the Key Affiliation fields populated');
+		                        createAfflFromLookup(newContact, j, afflsToInsert);                           
+		                    }
+                        } catch(Exception e) {
+                            UTIL_Debug.debug('****Exception message: ' + e.getMessage());
+                            UTIL_Debug.debug('****Stack trace: \n' + e.getStackTraceString());
+                            newContact.addError(e.getMessage());
                         }
-                        
-                        //If any Key Affiliation field has been changed to point to another Account
-                        //  --> Create new Affiliation (even if another one exists to the same Account - used should have made existing one primary if that 
-                        //         was his intention)
-                        //  --> Make the old Affiliation non-primary. Although this could be AFFL_MultiRecordType_TDTM's responsibility, since the Affl type
-                        //        is not yet defined (and the formula will run later), we'll do it here.    
-                        else if(newContact.get(afflMapper.primaryAfflFieldNames[j]) != null && newContact.get(afflMapper.primaryAfflFieldNames[j]) 
-                        != oldContact.get(afflMapper.primaryAfflFieldNames[j])) {
-                            UTIL_Debug.debug('****Key Affiliation field has been changed');
-                            createAfflFromLookup(newContact, j, afflsToInsert);
-                            populateConToAccsMap(newContact, oldContact, changedConToAccsMap, j);
-                        }
-                        
-                        //If any Key Affiliation field has been cleared
-                        //  --> Make the matching Affiliation non-primary
-                        else if(newContact.get(afflMapper.primaryAfflFieldNames[j]) == null && oldContact.get(afflMapper.primaryAfflFieldNames[j]) != null) {
-                            UTIL_Debug.debug('****Key Affiliation field has been cleared');
-                            populateConToAccsMap(newContact, oldContact, changedConToAccsMap, j);
-                        }
-                        
-                    } catch(Exception e) {
-                        UTIL_Debug.debug('****Exception message: ' + e.getMessage());
-                        UTIL_Debug.debug('****Stack trace: \n' + e.getStackTraceString());
-                        newContact.addError(e.getMessage());
                     }
+                    alreadyRunAfterInsert = true;
+                    
+                } else if(triggerAction == TDTM_Runnable.Action.BeforeUpdate && !alreadyRunBeforeUpdate) {
+                    Contact oldContact = (Contact)oldlist[i];
+                    
+                    for(Integer j = 0; j < afflMapper.primaryAfflFieldNames.size(); j++) {
+	                    try {
+		                    //If any Key Affiliation field has been set
+		                    //  --> Create a matching primary Affiliation for the Contact
+		                    //  --> If another Affl to the same Account exists, it should be made not primary. But this is AFFL_MultiRecordType_TDTM's responsibility. 
+		                    if(newContact.get(afflMapper.primaryAfflFieldNames[j]) != null && oldContact.get(afflMapper.primaryAfflFieldNames[j]) == null) {
+	                           UTIL_Debug.debug('****Key Affiliation field has been set');
+	                           createAfflFromLookup(newContact, j, afflsToInsert);
+		                    }
+		                    
+		                    //If any Key Affiliation field has been changed to point to another Account
+		                    //  --> Create new Affiliation (even if another one exists to the same Account - used should have made existing one primary if that 
+		                    //         was his intention)
+		                    //  --> Make the old Affiliation non-primary. Although this could be AFFL_MultiRecordType_TDTM's responsibility, since the Affl type
+		                    //        is not yet defined (and the formula will run later), we'll do it here.    
+		                    else if(newContact.get(afflMapper.primaryAfflFieldNames[j]) != null && newContact.get(afflMapper.primaryAfflFieldNames[j]) 
+		                    != oldContact.get(afflMapper.primaryAfflFieldNames[j])) {
+		                        UTIL_Debug.debug('****Key Affiliation field has been changed');
+                                createAfflFromLookup(newContact, j, afflsToInsert);
+                                populateConToAccsMap(newContact, oldContact, changedConToAccsMap, j);
+                            }
+		                    
+		                    //If any Key Affiliation field has been cleared
+		                    //  --> Make the matching Affiliation non-primary
+	                        else if(newContact.get(afflMapper.primaryAfflFieldNames[j]) == null && oldContact.get(afflMapper.primaryAfflFieldNames[j]) != null) {
+                                UTIL_Debug.debug('****Key Affiliation field has been cleared');
+                                populateConToAccsMap(newContact, oldContact, changedConToAccsMap, j);
+                            }
+                            
+	                    } catch(Exception e) {
+                            UTIL_Debug.debug('****Exception message: ' + e.getMessage());
+                            UTIL_Debug.debug('****Stack trace: \n' + e.getStackTraceString());
+                            newContact.addError(e.getMessage());
+                        }
+                    }
+                    alreadyRunBeforeUpdate = true;
                 }
             }
-
-            // Set reentrant Flag
-            alreadyRunBeforeUpdate = true;
         }
         
         if(afflsToInsert.size() > 0) {

--- a/src/classes/CON_PrimaryAffls_TDTM.cls
+++ b/src/classes/CON_PrimaryAffls_TDTM.cls
@@ -69,70 +69,80 @@ public class CON_PrimaryAffls_TDTM extends TDTM_Runnable {
         //Map of Contact ID to list of Account IDs that represent key Affl fields that have been cleared or modified. 
         //The old Affls need to be made non-primary.
         Map<ID, List<ID>> changedConToAccsMap = new Map<ID, List<ID>>();
-        
-        if(newlist != null) {
+
+        // AFTER INSERT
+        if( newlist != null && triggerAction == TDTM_Runnable.Action.AfterInsert  && !alreadyRunAfterInsert) {
+
+            // Loop over contact list
             for (integer i=0; i<newlist.size(); i++) {
+
                 Contact newContact = (Contact)newlist[i];
-                
-                if(triggerAction == TDTM_Runnable.Action.AfterInsert && !alreadyRunAfterInsert) {
-                    
-                    //If the Contact has been created with any of the Key Affiliation fields populated
-                    //  --> Create a matching primary Affiliation for the Contact
-                    for(Integer j = 0; j < afflMapper.primaryAfflFieldNames.size(); j++) {
-                        try {
-		                    if(newContact.get(afflMapper.primaryAfflFieldNames[j]) != null) {
-		                        UTIL_Debug.debug('****Contact has been created with one of the Key Affiliation fields populated');
-		                        createAfflFromLookup(newContact, j, afflsToInsert);                           
-		                    }
-                        } catch(Exception e) {
-                            UTIL_Debug.debug('****Exception message: ' + e.getMessage());
-                            UTIL_Debug.debug('****Stack trace: \n' + e.getStackTraceString());
-                            newContact.addError(e.getMessage());
+
+                //If the Contact has been created with any of the Key Affiliation fields populated
+                //  --> Create a matching primary Affiliation for the Contact
+                for(Integer j = 0; j < afflMapper.primaryAfflFieldNames.size(); j++) {
+                    try {
+                        if(newContact.get(afflMapper.primaryAfflFieldNames[j]) != null) {
+                            UTIL_Debug.debug('****Contact has been created with one of the Key Affiliation fields populated');
+                            createAfflFromLookup(newContact, j, afflsToInsert);                           
                         }
+                    } catch(Exception e) {
+                        UTIL_Debug.debug('****Exception message: ' + e.getMessage());
+                        UTIL_Debug.debug('****Stack trace: \n' + e.getStackTraceString());
+                        newContact.addError(e.getMessage());
                     }
-                    alreadyRunAfterInsert = true;
-                    
-                } else if(triggerAction == TDTM_Runnable.Action.BeforeUpdate && !alreadyRunBeforeUpdate) {
-                    Contact oldContact = (Contact)oldlist[i];
-                    
-                    for(Integer j = 0; j < afflMapper.primaryAfflFieldNames.size(); j++) {
-	                    try {
-		                    //If any Key Affiliation field has been set
-		                    //  --> Create a matching primary Affiliation for the Contact
-		                    //  --> If another Affl to the same Account exists, it should be made not primary. But this is AFFL_MultiRecordType_TDTM's responsibility. 
-		                    if(newContact.get(afflMapper.primaryAfflFieldNames[j]) != null && oldContact.get(afflMapper.primaryAfflFieldNames[j]) == null) {
-	                           UTIL_Debug.debug('****Key Affiliation field has been set');
-	                           createAfflFromLookup(newContact, j, afflsToInsert);
-		                    }
-		                    
-		                    //If any Key Affiliation field has been changed to point to another Account
-		                    //  --> Create new Affiliation (even if another one exists to the same Account - used should have made existing one primary if that 
-		                    //         was his intention)
-		                    //  --> Make the old Affiliation non-primary. Although this could be AFFL_MultiRecordType_TDTM's responsibility, since the Affl type
-		                    //        is not yet defined (and the formula will run later), we'll do it here.    
-		                    else if(newContact.get(afflMapper.primaryAfflFieldNames[j]) != null && newContact.get(afflMapper.primaryAfflFieldNames[j]) 
-		                    != oldContact.get(afflMapper.primaryAfflFieldNames[j])) {
-		                        UTIL_Debug.debug('****Key Affiliation field has been changed');
-                                createAfflFromLookup(newContact, j, afflsToInsert);
-                                populateConToAccsMap(newContact, oldContact, changedConToAccsMap, j);
-                            }
-		                    
-		                    //If any Key Affiliation field has been cleared
-		                    //  --> Make the matching Affiliation non-primary
-	                        else if(newContact.get(afflMapper.primaryAfflFieldNames[j]) == null && oldContact.get(afflMapper.primaryAfflFieldNames[j]) != null) {
-                                UTIL_Debug.debug('****Key Affiliation field has been cleared');
-                                populateConToAccsMap(newContact, oldContact, changedConToAccsMap, j);
-                            }
-                            
-	                    } catch(Exception e) {
-                            UTIL_Debug.debug('****Exception message: ' + e.getMessage());
-                            UTIL_Debug.debug('****Stack trace: \n' + e.getStackTraceString());
-                            newContact.addError(e.getMessage());
-                        }
-                    }
-                    alreadyRunBeforeUpdate = true;
                 }
             }
+
+            // Set reentrant Flag
+            alreadyRunAfterInsert = true;
+        }
+
+        // BEFORE UPDATE
+        if ( newlist != null && triggerAction == TDTM_Runnable.Action.BeforeUpdate && !alreadyRunBeforeUpdate) {
+            for (integer i=0; i<newlist.size(); i++) {
+                Contact newContact = (Contact)newlist[i];
+                Contact oldContact = (Contact)oldlist[i];
+
+                for(Integer j = 0; j < afflMapper.primaryAfflFieldNames.size(); j++) {
+                    try {
+                        //If any Key Affiliation field has been set
+                        //  --> Create a matching primary Affiliation for the Contact
+                        //  --> If another Affl to the same Account exists, it should be made not primary. But this is AFFL_MultiRecordType_TDTM's responsibility. 
+                        if(newContact.get(afflMapper.primaryAfflFieldNames[j]) != null && oldContact.get(afflMapper.primaryAfflFieldNames[j]) == null) {
+                           UTIL_Debug.debug('****Key Affiliation field has been set');
+                           createAfflFromLookup(newContact, j, afflsToInsert);
+                        }
+                        
+                        //If any Key Affiliation field has been changed to point to another Account
+                        //  --> Create new Affiliation (even if another one exists to the same Account - used should have made existing one primary if that 
+                        //         was his intention)
+                        //  --> Make the old Affiliation non-primary. Although this could be AFFL_MultiRecordType_TDTM's responsibility, since the Affl type
+                        //        is not yet defined (and the formula will run later), we'll do it here.    
+                        else if(newContact.get(afflMapper.primaryAfflFieldNames[j]) != null && newContact.get(afflMapper.primaryAfflFieldNames[j]) 
+                        != oldContact.get(afflMapper.primaryAfflFieldNames[j])) {
+                            UTIL_Debug.debug('****Key Affiliation field has been changed');
+                            createAfflFromLookup(newContact, j, afflsToInsert);
+                            populateConToAccsMap(newContact, oldContact, changedConToAccsMap, j);
+                        }
+                        
+                        //If any Key Affiliation field has been cleared
+                        //  --> Make the matching Affiliation non-primary
+                        else if(newContact.get(afflMapper.primaryAfflFieldNames[j]) == null && oldContact.get(afflMapper.primaryAfflFieldNames[j]) != null) {
+                            UTIL_Debug.debug('****Key Affiliation field has been cleared');
+                            populateConToAccsMap(newContact, oldContact, changedConToAccsMap, j);
+                        }
+                        
+                    } catch(Exception e) {
+                        UTIL_Debug.debug('****Exception message: ' + e.getMessage());
+                        UTIL_Debug.debug('****Stack trace: \n' + e.getStackTraceString());
+                        newContact.addError(e.getMessage());
+                    }
+                }
+            }
+
+            // Set reentrant Flag
+            alreadyRunBeforeUpdate = true;
         }
         
         if(afflsToInsert.size() > 0) {

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -49,16 +49,6 @@ public without sharing class UTIL_CustomSettingsFacade {
     static List<Relationship_Auto_Create__c> relationshipAutocreate;
     static List<Relationship_Lookup__c> relationshipLookup;
 
-    // Constructor
-    public UTIL_CustomSettingsFacade() {
-        User usr = [SELECT ProfileId FROM User where Id = :UserInfo.getUserId()]; 
-        Profile prof = [SELECT PermissionsCustomizeApplication FROM Profile Where Id =: usr.ProfileId];
-        System.debug('PermissionsApiEnabled: '+prof.PermissionsApiEnabled);
-
-        throw new StgException('You do not have permission to Customize this Application.');
-    }
-
-
     /*******************************************************************************************************
     * @description Returns the default settings.
     * @return Hierarchy_Settings__c custom settings record.
@@ -402,10 +392,4 @@ public without sharing class UTIL_CustomSettingsFacade {
             return jobId;
         }
     }
-
-    /*******************************************************************************************************
-    * @description A custom Exception for Settings
-    */
-    public class StgException extends Exception {}
-
 }

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -49,6 +49,16 @@ public without sharing class UTIL_CustomSettingsFacade {
     static List<Relationship_Auto_Create__c> relationshipAutocreate;
     static List<Relationship_Lookup__c> relationshipLookup;
 
+    // Constructor
+    public UTIL_CustomSettingsFacade() {
+        User usr = [SELECT ProfileId FROM User where Id = :UserInfo.getUserId()]; 
+        Profile prof = [SELECT PermissionsCustomizeApplication FROM Profile Where Id =: usr.ProfileId];
+        System.debug('PermissionsApiEnabled: '+prof.PermissionsApiEnabled);
+
+        throw new StgException('You do not have permission to Customize this Application.');
+    }
+
+
     /*******************************************************************************************************
     * @description Returns the default settings.
     * @return Hierarchy_Settings__c custom settings record.
@@ -377,4 +387,21 @@ public without sharing class UTIL_CustomSettingsFacade {
         }
         return false;
     }
+
+    /*******************************************************************************************************
+    * @description Executes Ethnicity Race Batch
+    * @return void
+    */
+    @AuraEnabled
+    public static Id executeEthnicityRaceBatch() {
+        CON_EthnicityRace_BATCH contbatch = new CON_EthnicityRace_BATCH();
+        Id jobId = Database.executeBatch( contbatch , 200 );
+        return jobId;
+    }
+
+    /*******************************************************************************************************
+    * @description A custom Exception for Settings
+    */
+    public class StgException extends Exception {}
+
 }

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -396,7 +396,11 @@ public without sharing class UTIL_CustomSettingsFacade {
     public static Id executeEthnicityRaceBatch() {
         CON_EthnicityRace_BATCH contbatch = new CON_EthnicityRace_BATCH();
         Id jobId = Database.executeBatch( contbatch , 200 );
-        return jobId;
+        if(jobId == null) {
+            throw new AuraHandledException('There was a problem starting the Batch.');
+        } else {
+            return jobId;
+        }
     }
 
     /*******************************************************************************************************

--- a/src/layouts/Contact-HEDA Contact Layout.layout
+++ b/src/layouts/Contact-HEDA Contact Layout.layout
@@ -88,6 +88,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>Race__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>Religion__c</field>
             </layoutItems>
             <layoutItems>
@@ -352,7 +356,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00ho000000CW5Ua</masterLabel>
+        <masterLabel>00h41000002tpBe</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -2311,31 +2311,16 @@
         <label>Ethnicity</label>
         <picklist>
             <picklistValues>
-                <fullName>American Indian or Alaska Native</fullName>
-                <default>false</default>
-            </picklistValues>
-            <picklistValues>
-                <fullName>Asian</fullName>
-                <default>false</default>
-            </picklistValues>
-            <picklistValues>
-                <fullName>Black or African American</fullName>
-                <default>false</default>
-            </picklistValues>
-            <picklistValues>
                 <fullName>Hispanic or Latino</fullName>
                 <default>false</default>
             </picklistValues>
             <picklistValues>
-                <fullName>Native Hawaiian or Other Pacific Islander</fullName>
-                <default>false</default>
-            </picklistValues>
-            <picklistValues>
-                <fullName>White</fullName>
+                <fullName>Not Hispanic or Latino</fullName>
                 <default>false</default>
             </picklistValues>
             <sorted>false</sorted>
         </picklist>
+        <required>false</required>
         <trackFeedHistory>false</trackFeedHistory>
         <type>Picklist</type>
     </fields>
@@ -2560,6 +2545,42 @@
         <required>false</required>
         <trackFeedHistory>false</trackFeedHistory>
         <type>Lookup</type>
+    </fields>
+    <fields>
+        <fullName>Race__c</fullName>
+        <externalId>false</externalId>
+        <label>Race</label>
+        <picklist>
+            <picklistValues>
+                <fullName>American Indian or Alaska Native</fullName>
+                <default>false</default>
+            </picklistValues>
+            <picklistValues>
+                <fullName>Asian</fullName>
+                <default>false</default>
+            </picklistValues>
+            <picklistValues>
+                <fullName>Black or African American</fullName>
+                <default>false</default>
+            </picklistValues>
+            <picklistValues>
+                <fullName>Hispanic or Latino</fullName>
+                <default>false</default>
+            </picklistValues>
+            <picklistValues>
+                <fullName>Native Hawaiian or Other Pacific Islander</fullName>
+                <default>false</default>
+            </picklistValues>
+            <picklistValues>
+                <fullName>White</fullName>
+                <default>false</default>
+            </picklistValues>
+            <restrictedPicklist>true</restrictedPicklist>
+            <sorted>false</sorted>
+        </picklist>
+        <required>false</required>
+        <trackFeedHistory>false</trackFeedHistory>
+        <type>Picklist</type>
     </fields>
     <fields>
         <fullName>Religion__c</fullName>

--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -2580,7 +2580,8 @@
         </picklist>
         <required>false</required>
         <trackFeedHistory>false</trackFeedHistory>
-        <type>Picklist</type>
+        <type>MultiselectPicklist</type>
+        <visibleLines>6</visibleLines>
     </fields>
     <fields>
         <fullName>Religion__c</fullName>

--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -3707,7 +3707,6 @@
                 <fullName>White</fullName>
                 <default>false</default>
             </picklistValues>
-            <restrictedPicklist>true</restrictedPicklist>
             <sorted>false</sorted>
         </picklist>
         <required>false</required>

--- a/src/package.xml
+++ b/src/package.xml
@@ -40,6 +40,8 @@
         <members>CON_CannotDelete_TEST</members>
         <members>CON_DoNotContact_TDTM</members>
         <members>CON_DoNotContact_TEST</members>
+        <members>CON_EthnicityRace_BATCH</members>
+        <members>CON_EthnicityRace_TEST</members>
         <members>CON_Preferred_TDTM</members>
         <members>CON_Preferred_TEST</members>
         <members>CON_PrimaryAffls_TDTM</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -205,6 +205,7 @@
         <members>Contact.Primary_Address_Type__c</members>
         <members>Contact.Primary_Household__c</members>
         <members>Contact.Primary_Organization__c</members>
+        <members>Contact.Race__c</members>
         <members>Contact.Religion__c</members>
         <members>Contact.Secondary_Address_Type__c</members>
         <members>Contact.Social_Security_Number__c</members>


### PR DESCRIPTION
# Critical Changes

# Changes
- Changed Ethnicity field picklist values and added Race field to match NCES and IPEDS categories for reporting ethnicity and race data. The Ethnicity field now supports only two values: "Hispanic or Latino" and "Not Hispanic or Latino." If your org uses the Ethnicity field to comply with NCES or IPEDS standards, we recommend replacing any other values that were previously available with the new values.
- Added a button to activate a batch process to copy appropriate values from the existing Ethnicity field to the new Race field.
# Issues Closed
Implements #363 