### PR TITLE
Feature/email enhancements

### DIFF
--- a/src/classes/CON_Email.cls
+++ b/src/classes/CON_Email.cls
@@ -1,0 +1,132 @@
+/*
+    Copyright (c) 2014 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+/**
+* @author Salesforce.org
+* @date 2016
+* @group Contacts
+* @group-content ../../ApexDocContent/Contacts.htm
+* @description A Class to handle Contact Email related Items
+*
+*/
+public class CON_Email {
+
+    /*******************************************************************************************************
+    * @description Sets the Email field depending on the value of Preferred Email
+    * @param Contact the contact to update
+    */
+	public static void processPreferredEmail(Contact contact, List<Contact> oldlist) {
+
+		Boolean isUpdate =  (oldlist != null) ? true : false;
+
+	    // Store default email field mappings to preferred email pick list.
+	    Map<String,String> preferredEmailMappings = new Map<String,String>{   
+	        'University' => 'UniversityEmail__c',
+	        'Work' => 'WorkEmail__c',
+	        'Alternate' => 'AlternateEmail__c'
+	    };
+
+	    Map<String,String> valuedEmailMap = emailFieldsWithValue(contact);
+
+        if( valuedEmailMap.size() > 0 ) {
+
+            // Enforce preferred email field
+            if(String.isBlank(contact.Preferred_Email__c)){
+                contact.addError( Label.PreferredEmailRequiredError );
+            }
+
+            // Get the Api name that matches the value in Preferred Email
+            String preferredApiField = ( preferredEmailMappings.containsKey(contact.Preferred_Email__c) ) ? preferredEmailMappings.get(contact.Preferred_Email__c) : valuedEmailMap.get(contact.Preferred_Email__c);
+
+            String prefEmailVal = (String)contact.get(preferredApiField);
+
+            if (  String.isNotBlank( prefEmailVal ) ) { 
+                contact.Email = prefEmailVal;
+            } else {
+                contact.addError(Label.PreferredEmailMatchNotNull);
+            }      
+        
+        } else {
+
+            // Cannot have preferred email set if there are no emails present
+            if( !String.isBlank(contact.Preferred_Email__c)) {
+                contact.addError(Label.PreferredEmailMatchNotNull);                    
+            }
+
+            // oldlist is NULL onInsert so we check to make sure this logic only applies on updates.
+			if( isUpdate && String.isNotBlank(contact.Email) ) {
+	            Map<ID, Contact> oldmap = new Map<ID, Contact>( (List<Contact>)oldlist); 
+
+	            // Get the old email values - if any - to compare.
+	            Map<String,String> oldValuedEmails = emailFieldsWithValue( oldmap.get(contact.Id) );
+
+	            // If this is an update and the contact contained previous emails we want to clear the estandard email field
+	            if (oldValuedEmails.size() > 0) {
+	                contact.Email = null; 
+	            }
+	        } else if(String.isNotBlank(contact.Email)) {
+	        	copyStdEmailToAlternate(contact);
+	        }
+        } 
+	}
+
+    /*******************************************************************************************************
+    * @description Copys the value of the standard Email field to the Alternate Email field if Email has a value and no other emails.
+    * @param Contact the contact to change
+    */
+	public static void copyStdEmailToAlternate(Contact contact) {
+		if(contact.Email != null) {
+			contact.Preferred_Email__c = 'Alternate';
+			contact.AlternateEmail__c = contact.Email;
+		}
+	}
+
+    /*******************************************************************************************************
+    * @description Returns a map of emails fields and their value if they have a value
+    * @param Contact contact object to populate list from
+    * @return Map<String,String> Map of emails fields key is field name and value is the field value
+    */
+	private static Map<String,String> emailFieldsWithValue(Contact contact) {
+        // Retreive all Email fields
+        Map<String, Schema.DescribeFieldResult> emailFields = UTIL_Describe.getFieldsOfType('Contact', 'EMAIL');
+
+        // Organize Email fields with a value
+        Map<String,String> valuedEmailMap = new Map<String,String>(); 
+        for(String fieldName : emailFields.keySet() ) {
+
+            String emailField = (String)contact.get(fieldName);
+
+            // if the field has a value add it to the map, excluding the standard Email field
+            if ( fieldName != 'Email' && String.isNotBlank(emailField) ) {
+                valuedEmailMap.put( emailFields.get(fieldName).getLabel(), fieldName);
+            }
+        }
+
+        return valuedEmailMap;
+	}
+}

--- a/src/classes/CON_Email.cls
+++ b/src/classes/CON_Email.cls
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2014 Salesforce.org
+    Copyright (c) 2017 Salesforce.org
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
@@ -28,10 +28,10 @@
     POSSIBILITY OF SUCH DAMAGE.
 /**
 * @author Salesforce.org
-* @date 2016
+* @date 2017
 * @group Contacts
 * @group-content ../../ApexDocContent/Contacts.htm
-* @description A Class to handle Contact Email related Items
+* @description Handles processing of COntact preferred emails. Copies custom email fields to the standard field.
 *
 */
 public class CON_Email {
@@ -39,10 +39,16 @@ public class CON_Email {
     /*******************************************************************************************************
     * @description Sets the Email field depending on the value of Preferred Email
     * @param Contact the contact to update
+    * @param oldlist list of old contacts from update or delete context of a trigger
     */
 	public static void processPreferredEmail(Contact contact, List<Contact> oldlist) {
 
-		Boolean isUpdate =  (oldlist != null) ? true : false;
+        // No need to run if we are in a delete context
+        if(contact == null) {
+            return;
+        }
+
+		Boolean isUpdateOrDelete = (oldlist != null) ? true : false;
 
 	    // Store default email field mappings to preferred email pick list.
 	    Map<String,String> preferredEmailMappings = new Map<String,String>{   
@@ -51,7 +57,7 @@ public class CON_Email {
 	        'Alternate' => 'AlternateEmail__c'
 	    };
 
-	    Map<String,String> valuedEmailMap = emailFieldsWithValue(contact);
+	    Map<String,String> valuedEmailMap = getEmailFieldsWithValue(contact);
 
         if( valuedEmailMap.size() > 0 ) {
 
@@ -78,17 +84,19 @@ public class CON_Email {
                 contact.addError(Label.PreferredEmailMatchNotNull);                    
             }
 
-            // oldlist is NULL onInsert so we check to make sure this logic only applies on updates.
-			if( isUpdate && String.isNotBlank(contact.Email) ) {
+            // oldlist is NULL on insert so we check to make sure this logic only applies on updates.
+			if( isUpdateOrDelete && String.isNotBlank(contact.Email) ) {
 	            Map<ID, Contact> oldmap = new Map<ID, Contact>( (List<Contact>)oldlist); 
 
 	            // Get the old email values - if any - to compare.
-	            Map<String,String> oldValuedEmails = emailFieldsWithValue( oldmap.get(contact.Id) );
+	            Map<String,String> oldValuedEmails = getEmailFieldsWithValue( oldmap.get(contact.Id) );
 
-	            // If this is an update and the contact contained previous emails we want to clear the estandard email field
+	            // If this is an update and the contact contained previous emails we want to clear the standard email field
+                // we do this because when a user deletes all email values in the HEDA contact without clearing
+                // the value if email, there would be an emil address that the user tried to delete.
 	            if (oldValuedEmails.size() > 0) {
 	                contact.Email = null; 
-	            }
+	            } 
 	        } else if(String.isNotBlank(contact.Email)) {
 	        	copyStdEmailToAlternate(contact);
 	        }
@@ -96,7 +104,7 @@ public class CON_Email {
 	}
 
     /*******************************************************************************************************
-    * @description Copys the value of the standard Email field to the Alternate Email field if Email has a value and no other emails.
+    * @description Copies the value of the standard Email field to the Alternate Email field if Email has a value and no other emails.
     * @param Contact the contact to change
     */
 	public static void copyStdEmailToAlternate(Contact contact) {
@@ -111,20 +119,25 @@ public class CON_Email {
     * @param Contact contact object to populate list from
     * @return Map<String,String> Map of emails fields key is field name and value is the field value
     */
-	private static Map<String,String> emailFieldsWithValue(Contact contact) {
-        // Retreive all Email fields
-        Map<String, Schema.DescribeFieldResult> emailFields = UTIL_Describe.getFieldsOfType('Contact', 'EMAIL');
-
+	private static Map<String,String> getEmailFieldsWithValue(Contact contact) {
         // Organize Email fields with a value
         Map<String,String> valuedEmailMap = new Map<String,String>(); 
-        for(String fieldName : emailFields.keySet() ) {
 
-            String emailField = (String)contact.get(fieldName);
+        if(contact != null) {
 
-            // if the field has a value add it to the map, excluding the standard Email field
-            if ( fieldName != 'Email' && String.isNotBlank(emailField) ) {
-                valuedEmailMap.put( emailFields.get(fieldName).getLabel(), fieldName);
+            // Retreive all Email fields
+            Map<String, Schema.DescribeFieldResult> emailFields = UTIL_Describe.getFieldsOfType('Contact', 'EMAIL');
+
+            for(String fieldName : emailFields.keySet() ) {
+
+                String emailField = (String)contact.get(fieldName);
+
+                // if the field has a value add it to the map, excluding the standard Email field
+                if ( fieldName != 'Email' && String.isNotBlank(emailField) ) {
+                    valuedEmailMap.put( emailFields.get(fieldName).getLabel(), fieldName);
+                }
             }
+
         }
 
         return valuedEmailMap;

--- a/src/classes/CON_Email.cls
+++ b/src/classes/CON_Email.cls
@@ -115,7 +115,7 @@ public class CON_Email {
 	}
 
     /*******************************************************************************************************
-    * @description Returns a map of emails fields and their value if they have a value
+    * @description Returns a map of emails field labels and their api name if they have a value
     * @param Contact contact object to populate list from
     * @return Map<String,String> Map of emails fields key is field name and value is the field value
     */

--- a/src/classes/CON_Email.cls-meta.xml
+++ b/src/classes/CON_Email.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>35.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/CON_Email.cls-meta.xml
+++ b/src/classes/CON_Email.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>35.0</apiVersion>
+    <apiVersion>39.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_Email_BATCH.cls
+++ b/src/classes/CON_Email_BATCH.cls
@@ -34,19 +34,19 @@
 * @group-content ../../ApexDocContent/Contacts.htm
 * @description Batch Class to process contacts on HEDA installation
 */
-global class CON_Email_BATCH implements Database.Batchable<sObject> {
+public class CON_Email_BATCH implements Database.Batchable<sObject> {
 
-	String query = 'SELECT Id, Name, Email FROM Contact WHERE Email != null';
+	String query = 'SELECT Id, Name, Email FROM Contact WHERE Email != null AND Preferred_Email__c = null';
 	
-	global Database.QueryLocator start(Database.BatchableContext BC) {
+	public Database.QueryLocator start(Database.BatchableContext BC) {
 
 		return Database.getQueryLocator(query);
 	}
 
-   	global void execute(Database.BatchableContext BC, List<sObject> scope) {
+   	public void execute(Database.BatchableContext BC, List<sObject> scope) {
 		List<Contact> contacts = (List<Contact> ) scope; //Cast list of contacts
         
-        // According to the spec (https://nces.ed.gov/ipeds/Section/collecting_re on 1/13/2017) Ethnicity should only ask if Hispanic or Latino, so the other options will be copied to the Race field. 
+        // process contact emails
         if(contacts.size()>0) {
 	        for(Contact c : contacts) {
 	        	CON_Email.copyStdEmailToAlternate(c);
@@ -56,7 +56,7 @@ global class CON_Email_BATCH implements Database.Batchable<sObject> {
         update contacts;
 	}
 	
-	global void finish(Database.BatchableContext BC) {
+	public void finish(Database.BatchableContext BC) {
 		UTIL_Debug.debug('****Contact Email batch completed. ID:'+BC.getJobId() );
 	}
 	

--- a/src/classes/CON_Email_BATCH.cls
+++ b/src/classes/CON_Email_BATCH.cls
@@ -1,0 +1,63 @@
+/*
+    Copyright (c) 2017, Salesforce.com Foundation
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Salesforce.com Foundation nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.com Foundation
+* @date 2017
+* @group Contacts
+* @group-content ../../ApexDocContent/Contacts.htm
+* @description Batch Class to process contacts on HEDA installation
+*/
+global class CON_Email_BATCH implements Database.Batchable<sObject> {
+
+	String query = 'SELECT Id, Name, Email FROM Contact WHERE Email != null';
+	
+	global Database.QueryLocator start(Database.BatchableContext BC) {
+
+		return Database.getQueryLocator(query);
+	}
+
+   	global void execute(Database.BatchableContext BC, List<sObject> scope) {
+		List<Contact> contacts = (List<Contact> ) scope; //Cast list of contacts
+        
+        // According to the spec (https://nces.ed.gov/ipeds/Section/collecting_re on 1/13/2017) Ethnicity should only ask if Hispanic or Latino, so the other options will be copied to the Race field. 
+        if(contacts.size()>0) {
+	        for(Contact c : contacts) {
+	        	CON_Email.copyStdEmailToAlternate(c);
+            }
+        }
+
+        update contacts;
+	}
+	
+	global void finish(Database.BatchableContext BC) {
+		UTIL_Debug.debug('****Contact Email batch completed. ID:'+BC.getJobId() );
+	}
+	
+}

--- a/src/classes/CON_Email_BATCH.cls-meta.xml
+++ b/src/classes/CON_Email_BATCH.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>35.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/CON_Email_BATCH.cls-meta.xml
+++ b/src/classes/CON_Email_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>35.0</apiVersion>
+    <apiVersion>39.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_Email_TEST.cls
+++ b/src/classes/CON_Email_TEST.cls
@@ -43,7 +43,10 @@ private class CON_Email_TEST {
 		// Get contacts set up
         List<Contact> listCon = UTIL_UnitTestData_TEST.getMultipleTestContacts(10);
         for (Integer i = 0; i < 10; i++) {
+
             listCon[i].LastName = 'ToAvoidDupeRule' + i;//Avoid duplicate matching
+            listCon[i].WorkEmail__c = ''; // clear email field set in getMultipleTestContacts
+            listCon[i].Preferred_Email__c = ''; // clear preferred field set in getMultipleTestContacts
         }
 
         insert listCon;
@@ -75,16 +78,22 @@ private class CON_Email_TEST {
 
 	@isTest static void testPrefferedEmailDeleting() {
 
-		List<Contact> contacts = [SELECT Id, Name, Preferred_Email__c, Email, AlternateEmail__c,UniversityEmail__c, WorkEmail__c FROM Contact WHERE EMAIL != null LIMIT 1];
+		List<Contact> contacts = [SELECT Id, Name, Preferred_Email__c, Email, AlternateEmail__c,UniversityEmail__c, WorkEmail__c FROM Contact LIMIT 1];
 
+		// Process the contact for testing
         if(contacts.size()>0) {
-	        for(Contact c : contacts) {
-	        	c.Preferred_Email__c = null;
-	        	c.AlternateEmail__c = null;
-	        	c.UniversityEmail__c = null;
-	        	c.WorkEmail__c = null;
-            }
+        	contacts[0].WorkEmail__c = 'testworkemail@domain.com';
+        	contacts[0].Preferred_Email__c = 'Work';
+		    CON_Preferred_TDTM.alreadyRunBefore = true; // turn off preferred emial processing
+	        update contacts;
+
+        	contacts[0].Preferred_Email__c = null;
+        	contacts[0].AlternateEmail__c = null;
+        	contacts[0].UniversityEmail__c = null;
+        	contacts[0].WorkEmail__c = null;
         }
+
+	    CON_Preferred_TDTM.alreadyRunBefore = false; // need to re-activate the trigger
 
 		Test.startTest();
         update contacts;
@@ -97,6 +106,29 @@ private class CON_Email_TEST {
 
 	// Test the batch Class
 	@isTest static void testContactEmailBatch() {
+		List<String> contIds = new List<String>();
+
+		List<Contact> contacts = [SELECT Id, Name, Preferred_Email__c, Email, AlternateEmail__c,UniversityEmail__c, WorkEmail__c FROM Contact];
+
+		// Process the contact for testing
+        if(contacts.size()>0) {
+
+	        for (Integer i = 0; i < contacts.size(); i++) {
+				contacts[i].Email = 'emailtest' + i + '@domainemail.com';
+				contIds.add(contacts[i].Id);
+	        }
+
+	        CON_Preferred_TDTM.alreadyRunBefore = true; // need to turn off the trigger for this test
+	        update contacts;
+
+        	contacts[0].Preferred_Email__c = null;
+        	contacts[0].AlternateEmail__c = null;
+        	contacts[0].UniversityEmail__c = null;
+        	contacts[0].WorkEmail__c = null;
+        }
+
+	    CON_Preferred_TDTM.alreadyRunBefore = false; // need to activate these for the batch
+
 		// Run Batch
 		Test.startTest();
 	    CON_Email_BATCH contbatch = new CON_Email_BATCH();
@@ -104,7 +136,7 @@ private class CON_Email_TEST {
 		Test.stopTest();
 
 		// After batch run assert
-		List<Contact> contacts = [SELECT Id, Name, Email, AlternateEmail__c FROM Contact WHERE Email != null];
+		contacts = [SELECT Id, Name, Email, AlternateEmail__c FROM Contact WHERE Id in: contIds ];
 
 		for(Contact c : contacts) {
 			System.assertEquals( c.AlternateEmail__c , c.Email ); 

--- a/src/classes/CON_Email_TEST.cls
+++ b/src/classes/CON_Email_TEST.cls
@@ -1,0 +1,113 @@
+/*
+    Copyright (c) 2017, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2017
+* @group Contacts
+* @group-content ../../ApexDocContent/Contacts.htm
+* @description Tests Email Management Classes
+*/
+@isTest
+private class CON_Email_TEST {
+	
+	@testSetup
+	static void dataSetup() {
+
+		// Get contacts set up
+        List<Contact> listCon = UTIL_UnitTestData_TEST.getMultipleTestContacts(10);
+        for (Integer i = 0; i < 10; i++) {
+            listCon[i].LastName = 'ToAvoidDupeRule' + i;//Avoid duplicate matching
+        }
+
+        insert listCon;
+	}
+
+	@isTest static void testPrefferedEmailInsert() {
+		List<Contact> contacts = [SELECT Id, Name, Email FROM Contact WHERE EMAIL != null LIMIT 2];
+		List<String> contIds = new List<String>();
+
+        for (Integer i = 0; i < contacts.size(); i++) {
+			contacts[i].Preferred_Email__c = 'Alternate';
+			contacts[i].AlternateEmail__c = 'alternetemailtest' + i + '@domainemail.com';
+			contIds.add(contacts[i].Id);
+        }
+
+		Test.startTest();
+        update contacts;
+		Test.stopTest();
+
+		contacts = [SELECT Id, Name, AlternateEmail__c, Email FROM Contact WHERE Id in:contIds LIMIT 2];
+
+        if(contacts.size()>0) {
+	        for(Contact c : contacts) {
+	        	// Make sure the new values were copies to the standard email field
+	            System.assertEquals(c.Email, c.AlternateEmail__c);
+            }
+        }
+	}
+
+	@isTest static void testPrefferedEmailDeleting() {
+
+		List<Contact> contacts = [SELECT Id, Name, Preferred_Email__c, Email, Personal_Email__c,UniversityEmail__c, WorkEmail__c FROM Contact WHERE EMAIL != null LIMIT 1];
+
+        if(contacts.size()>0) {
+	        for(Contact c : contacts) {
+	        	c.Preferred_Email__c = null;
+	        	c.Personal_Email__c = null;
+	        	c.UniversityEmail__c = null;
+	        	c.WorkEmail__c = null;
+            }
+        }
+
+		Test.startTest();
+        update contacts;
+		Test.stopTest();
+
+		contacts = [SELECT Id, Name, Preferred_Email__c, Email, Personal_Email__c,UniversityEmail__c, WorkEmail__c FROM Contact WHERE id =: contacts[0].Id LIMIT 1];
+
+		System.assertEquals(null, contacts[0].Email); // Contact email should be null because all other emails fields were deleted.
+	}
+
+	// Test the batch Class
+	@isTest static void testContactEmailBatch() {
+		// Run Batch
+		Test.startTest();
+	    CON_Email_BATCH contbatch = new CON_Email_BATCH();
+	    Database.executeBatch( contbatch );
+		Test.stopTest();
+
+		// After batch run assert
+		List<Contact> contacts = [SELECT Id, Name, Email, AlternateEmail__c FROM Contact WHERE Email != null];
+
+		for(Contact c : contacts) {
+			System.assertEquals( c.AlternateEmail__c , c.Email ); 
+		}
+	}	
+}

--- a/src/classes/CON_Email_TEST.cls
+++ b/src/classes/CON_Email_TEST.cls
@@ -75,12 +75,12 @@ private class CON_Email_TEST {
 
 	@isTest static void testPrefferedEmailDeleting() {
 
-		List<Contact> contacts = [SELECT Id, Name, Preferred_Email__c, Email, Personal_Email__c,UniversityEmail__c, WorkEmail__c FROM Contact WHERE EMAIL != null LIMIT 1];
+		List<Contact> contacts = [SELECT Id, Name, Preferred_Email__c, Email, AlternateEmail__c,UniversityEmail__c, WorkEmail__c FROM Contact WHERE EMAIL != null LIMIT 1];
 
         if(contacts.size()>0) {
 	        for(Contact c : contacts) {
 	        	c.Preferred_Email__c = null;
-	        	c.Personal_Email__c = null;
+	        	c.AlternateEmail__c = null;
 	        	c.UniversityEmail__c = null;
 	        	c.WorkEmail__c = null;
             }
@@ -90,7 +90,7 @@ private class CON_Email_TEST {
         update contacts;
 		Test.stopTest();
 
-		contacts = [SELECT Id, Name, Preferred_Email__c, Email, Personal_Email__c,UniversityEmail__c, WorkEmail__c FROM Contact WHERE id =: contacts[0].Id LIMIT 1];
+		contacts = [SELECT Id, Name, Preferred_Email__c, Email, AlternateEmail__c,UniversityEmail__c, WorkEmail__c FROM Contact WHERE id =: contacts[0].Id LIMIT 1];
 
 		System.assertEquals(null, contacts[0].Email); // Contact email should be null because all other emails fields were deleted.
 	}

--- a/src/classes/CON_Email_TEST.cls-meta.xml
+++ b/src/classes/CON_Email_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>35.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/CON_Email_TEST.cls-meta.xml
+++ b/src/classes/CON_Email_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>35.0</apiVersion>
+    <apiVersion>39.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_Preferred_TDTM.cls
+++ b/src/classes/CON_Preferred_TDTM.cls
@@ -36,13 +36,6 @@
 */
 public class CON_Preferred_TDTM extends TDTM_Runnable {
 
-    // Store default email field mappings to preferred email pick list.
-    private Map<String,String> preferredEmailMappings = new Map<String,String>{   
-        'University' => 'UniversityEmail__c',
-        'Work' => 'WorkEmail__c',
-        'Alternate' => 'AlternateEmail__c'
-    };
-
     /*******************************************************************************************************
     * @description Updates default email and phone fields based to the preferred email and preferred phone values.
     * @return dmlWrapper
@@ -50,55 +43,15 @@ public class CON_Preferred_TDTM extends TDTM_Runnable {
     public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
         TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
              
-         if((triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) && newlist != null) {
-            
+        if((triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) && newlist != null) {
+
             for(SObject so : newlist) {
                 Contact contact = (Contact)so;
 
-                // Retreive all Email fields
-                Map<String, Schema.DescribeFieldResult> emailFields = UTIL_Describe.getFieldsOfType('Contact', 'EMAIL');
-
-                // Organize Email fields with a value
-                Map<String,String> valuedEmailMap = new Map<String,String>(); 
-                for(String fieldName : emailFields.keySet() ) {
-
-                    String emailField = (String)contact.get(fieldName);
-
-                    if ( fieldName != 'Email' && String.isNotBlank(emailField) ) {
-                        valuedEmailMap.put( emailFields.get(fieldName).getLabel(), fieldName);
-                    }
-                }
-
-                if( valuedEmailMap.size() > 0 ) {
-
-                    // Enforce preferred email field
-                    if(String.isBlank(contact.Preferred_Email__c)){
-                        contact.addError( Label.PreferredEmailRequiredError );
-                    }
-
-                    // Get the Api name that matches the value in Preferred Email
-                    String preferredApiField = ( preferredEmailMappings.containsKey(contact.Preferred_Email__c) ) ? preferredEmailMappings.get(contact.Preferred_Email__c) : valuedEmailMap.get(contact.Preferred_Email__c);
-
-                    String prefEmailVal = (String)contact.get(preferredApiField);
-
-                    if (  String.isNotBlank( prefEmailVal ) ) { 
-                        contact.Email = prefEmailVal;
-                    } else {
-                        contact.addError(Label.PreferredEmailMatchNotNull);
-                    }      
+                // Process the prefered Email
+                CON_Email.processPreferredEmail(contact, oldlist);
                 
-                } else {
-
-                    // Cannot have preferred email set if there are no emails present
-                    if( !String.isBlank(contact.Preferred_Email__c)) {
-                        contact.addError(Label.PreferredEmailMatchNotNull);                    
-                    }
-
-                    if (!String.isBlank(contact.Email)) {
-                        contact.Email = null; // Need to clear the standard email field if no emails are present.
-                    }
-                } 
-                
+                // Process the Preferred Phone
                 if(!String.isBlank(contact.PreferredPhone__c)) {
                     if(contact.PreferredPhone__c == 'Home') {
                         contact.Phone = contact.HomePhone;
@@ -111,8 +64,8 @@ public class CON_Preferred_TDTM extends TDTM_Runnable {
                     }
                 }
             }
-         }
+        }
          
-         return null;
+        return null;
     }
 }

--- a/src/classes/CON_Preferred_TDTM.cls
+++ b/src/classes/CON_Preferred_TDTM.cls
@@ -36,6 +36,9 @@
 */
 public class CON_Preferred_TDTM extends TDTM_Runnable {
 
+    /* @description Flag to prevent recursive call on beforeInsert and BeforeUpdate */
+    public static Boolean alreadyRunBefore = false;
+
     /*******************************************************************************************************
     * @description Updates default email and phone fields based to the preferred email and preferred phone values.
     * @return dmlWrapper
@@ -43,7 +46,9 @@ public class CON_Preferred_TDTM extends TDTM_Runnable {
     public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
         TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
              
-        if((triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) && newlist != null) {
+        if( !alreadyRunBefore && (triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) && newlist != null) {
+
+            alreadyRunBefore = true;
 
             for(SObject so : newlist) {
                 Contact contact = (Contact)so;

--- a/src/classes/CON_Preferred_TDTM.cls
+++ b/src/classes/CON_Preferred_TDTM.cls
@@ -36,6 +36,13 @@
 */
 public class CON_Preferred_TDTM extends TDTM_Runnable {
 
+    // Store default email field mappings to preferred email pick list.
+    private Map<String,String> preferredEmailMappings = new Map<String,String>{   
+        'University' => 'UniversityEmail__c',
+        'Work' => 'WorkEmail__c',
+        'Alternate' => 'AlternateEmail__c'
+    };
+
     /*******************************************************************************************************
     * @description Updates default email and phone fields based to the preferred email and preferred phone values.
     * @return dmlWrapper
@@ -47,46 +54,40 @@ public class CON_Preferred_TDTM extends TDTM_Runnable {
             
             for(SObject so : newlist) {
                 Contact contact = (Contact)so;
-            
-                if(!String.isBlank(contact.Preferred_Email__c)) {
 
-                    if(contact.Preferred_Email__c == 'University') {
-                        contact.Email = contact.UniversityEmail__c;
-                    } else if(contact.Preferred_Email__c == 'Work') {
-                        contact.Email = contact.WorkEmail__c;
-                    } else if(contact.Preferred_Email__c == 'Alternate') {
-                        contact.Email = contact.AlternateEmail__c;
-                    } else {
-                        // We have a custom value in Preferred Email so we will try to match this value with an Email
-                        // field. We'll try with two options, with and without an underscore.
 
-                        // Make lowercase
-                        String preferredLowCase = contact.Preferred_Email__c.toLowerCase();
 
-                        // Get options
-                        String labelWithUndr = preferredLowCase.replace(' ', '_') + '__c';
-                        String labelNoSpaces = preferredLowCase.deleteWhitespace()+ '__c';
+                // Copy custom email fields to standard if only one is present
+                Map<String, Schema.DescribeFieldResult> emailFields = UTIL_Describe.getFieldsOfType('Contact', 'EMAIL');
 
-                        // Get field map from Contact
-                        Map<String, Schema.SObjectField> allFieldsMap = Schema.SObjectType.Contact.fields.getMap();
+                // Organize Email fields with a value
+                Map<String,String> valuedEmailMap = new Map<String,String>(); 
+                for(String fieldName : emailFields.keySet() ) {
 
-                        // Figure out which label to use
-                        String fieldLabel = null;
-                        if(allFieldsMap.containsKey(labelWithUndr)){
-                            fieldLabel = labelWithUndr;
-                        } else if (allFieldsMap.containsKey(labelNoSpaces)) {
-                            fieldLabel = labelNoSpaces;
-                        }
+                    String emailField = (String)contact.get(fieldName);
 
-                        if(String.isNotBlank(fieldLabel)) {
-                            Schema.DisplayType fieldType = allFieldsMap.get(fieldLabel).getDescribe().getType();
-
-                            // Make sure this is an email field
-                            if( String.valueOf(fieldType) == 'EMAIL' ) {
-                                contact.Email = (String)contact.get(fieldLabel);
-                            }
-                        }
+                    if ( fieldName != 'Email' && String.isNotBlank(emailField) ) {
+                        valuedEmailMap.put( emailFields.get(fieldName).getLabel(), fieldName);
                     }
+                }
+
+                // Enforce preferred email field
+                if(valuedEmailMap.size() > 0 && String.isBlank(contact.Preferred_Email__c) ) {
+                    contact.addError( Label.PreferredEmailRequiredError );
+                }
+            
+                if(!String.isBlank(contact.Preferred_Email__c) && valuedEmailMap.size() > 1 ) {
+
+                    // Get the Api name that matches the value in Preferred Email
+                    String preferredApiField = ( preferredEmailMappings.containsKey(contact.Preferred_Email__c) ) ? preferredEmailMappings.get(contact.Preferred_Email__c) : valuedEmailMap.get(contact.Preferred_Email__c);
+
+                    String prefEmailVal = (String)contact.get(preferredApiField);
+
+                    if (  String.isNotBlank( prefEmailVal ) ) { 
+                        contact.put('Email',  prefEmailVal );
+                    } else {
+                        contact.addError(Label.PreferredEmailMatchNotNull);
+                    }                    
                 }
                 
                 if(!String.isBlank(contact.PreferredPhone__c)) {

--- a/src/classes/CON_Preferred_TDTM.cls
+++ b/src/classes/CON_Preferred_TDTM.cls
@@ -36,42 +36,73 @@
 */
 public class CON_Preferred_TDTM extends TDTM_Runnable {
 
-	/*******************************************************************************************************
+    /*******************************************************************************************************
     * @description Updates default email and phone fields based to the preferred email and preferred phone values.
     * @return dmlWrapper
     ********************************************************************************************************/
-	public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
+    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
         TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
-        	 
-    	 if((triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) && newlist != null) {
-    	 	
-    	 	for(SObject so : newlist) {
-    	 		Contact contact = (Contact)so;
-    	 	
-	    	 	if(!String.isBlank(contact.Preferred_Email__c)) {
-	    	 		if(contact.Preferred_Email__c == 'University') {
-	    	 			contact.Email = contact.UniversityEmail__c;
-	    	 		} else if(contact.Preferred_Email__c == 'Work') {
-	    	 			contact.Email = contact.WorkEmail__c;
-	    	 		} else if(contact.Preferred_Email__c == 'Alternate') {
-	    	 			contact.Email = contact.AlternateEmail__c;
-	    	 		}
-	    	 	}
-	    	 	
-	    	 	if(!String.isBlank(contact.PreferredPhone__c)) {
-	    	 		if(contact.PreferredPhone__c == 'Home') {
-	    	 			contact.Phone = contact.HomePhone;
-	    	 		} else if(contact.PreferredPhone__c == 'Work') {
-	    	 			contact.Phone = contact.WorkPhone__c;
-	    	 		} else if(contact.PreferredPhone__c == 'Mobile') {
-	    	 			contact.Phone = contact.MobilePhone;
-	    	 		} else if(contact.PreferredPhone__c == 'Other') {
-	    	 			contact.Phone = contact.OtherPhone;
-	    	 		}
-	    	 	}
-    	 	}
-    	 }
-    	 
-    	 return null;
-   	}
+             
+         if((triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) && newlist != null) {
+            
+            for(SObject so : newlist) {
+                Contact contact = (Contact)so;
+            
+                if(!String.isBlank(contact.Preferred_Email__c)) {
+
+                    if(contact.Preferred_Email__c == 'University') {
+                        contact.Email = contact.UniversityEmail__c;
+                    } else if(contact.Preferred_Email__c == 'Work') {
+                        contact.Email = contact.WorkEmail__c;
+                    } else if(contact.Preferred_Email__c == 'Alternate') {
+                        contact.Email = contact.AlternateEmail__c;
+                    } else {
+                        // We have a custom value in Preferred Email so we will try to match this value with an Email
+                        // field. We'll try with two options, with and without an underscore.
+
+                        // Make lowercase
+                        String preferredLowCase = contact.Preferred_Email__c.toLowerCase();
+
+                        // Get options
+                        String labelWithUndr = preferredLowCase.replace(' ', '_') + '__c';
+                        String labelNoSpaces = preferredLowCase.deleteWhitespace()+ '__c';
+
+                        // Get field map from Contact
+                        Map<String, Schema.SObjectField> allFieldsMap = Schema.SObjectType.Contact.fields.getMap();
+
+                        // Figure out which label to use
+                        String fieldLabel = null;
+                        if(allFieldsMap.containsKey(labelWithUndr)){
+                            fieldLabel = labelWithUndr;
+                        } else if (allFieldsMap.containsKey(labelNoSpaces)) {
+                            fieldLabel = labelNoSpaces;
+                        }
+
+                        if(String.isNotBlank(fieldLabel)) {
+                            Schema.DisplayType fieldType = allFieldsMap.get(fieldLabel).getDescribe().getType();
+
+                            // Make sure this is an email field
+                            if( String.valueOf(fieldType) == 'EMAIL' ) {
+                                contact.Email = (String)contact.get(fieldLabel);
+                            }
+                        }
+                    }
+                }
+                
+                if(!String.isBlank(contact.PreferredPhone__c)) {
+                    if(contact.PreferredPhone__c == 'Home') {
+                        contact.Phone = contact.HomePhone;
+                    } else if(contact.PreferredPhone__c == 'Work') {
+                        contact.Phone = contact.WorkPhone__c;
+                    } else if(contact.PreferredPhone__c == 'Mobile') {
+                        contact.Phone = contact.MobilePhone;
+                    } else if(contact.PreferredPhone__c == 'Other') {
+                        contact.Phone = contact.OtherPhone;
+                    }
+                }
+            }
+         }
+         
+         return null;
+    }
 }

--- a/src/classes/CON_Preferred_TDTM.cls
+++ b/src/classes/CON_Preferred_TDTM.cls
@@ -55,9 +55,7 @@ public class CON_Preferred_TDTM extends TDTM_Runnable {
             for(SObject so : newlist) {
                 Contact contact = (Contact)so;
 
-
-
-                // Copy custom email fields to standard if only one is present
+                // Retreive all Email fields
                 Map<String, Schema.DescribeFieldResult> emailFields = UTIL_Describe.getFieldsOfType('Contact', 'EMAIL');
 
                 // Organize Email fields with a value
@@ -71,12 +69,12 @@ public class CON_Preferred_TDTM extends TDTM_Runnable {
                     }
                 }
 
-                // Enforce preferred email field
-                if(valuedEmailMap.size() > 0 && String.isBlank(contact.Preferred_Email__c) ) {
-                    contact.addError( Label.PreferredEmailRequiredError );
-                }
-            
-                if(!String.isBlank(contact.Preferred_Email__c) && valuedEmailMap.size() > 1 ) {
+                if( valuedEmailMap.size() > 0 ) {
+
+                    // Enforce preferred email field
+                    if(String.isBlank(contact.Preferred_Email__c)){
+                        contact.addError( Label.PreferredEmailRequiredError );
+                    }
 
                     // Get the Api name that matches the value in Preferred Email
                     String preferredApiField = ( preferredEmailMappings.containsKey(contact.Preferred_Email__c) ) ? preferredEmailMappings.get(contact.Preferred_Email__c) : valuedEmailMap.get(contact.Preferred_Email__c);
@@ -84,11 +82,22 @@ public class CON_Preferred_TDTM extends TDTM_Runnable {
                     String prefEmailVal = (String)contact.get(preferredApiField);
 
                     if (  String.isNotBlank( prefEmailVal ) ) { 
-                        contact.put('Email',  prefEmailVal );
+                        contact.Email = prefEmailVal;
                     } else {
                         contact.addError(Label.PreferredEmailMatchNotNull);
-                    }                    
-                }
+                    }      
+                
+                } else {
+
+                    // Cannot have preferred email set if there are no emails present
+                    if( !String.isBlank(contact.Preferred_Email__c)) {
+                        contact.addError(Label.PreferredEmailMatchNotNull);                    
+                    }
+
+                    if (!String.isBlank(contact.Email)) {
+                        contact.Email = null; // Need to clear the standard email field if no emails are present.
+                    }
+                } 
                 
                 if(!String.isBlank(contact.PreferredPhone__c)) {
                     if(contact.PreferredPhone__c == 'Home') {

--- a/src/classes/CON_Preferred_TEST.cls
+++ b/src/classes/CON_Preferred_TEST.cls
@@ -46,7 +46,7 @@ public with sharing class CON_Preferred_TEST {
 			WorkPhone__c = '555-432-4433', PreferredPhone__c = 'Work');
 		Contact contact3 = new Contact(LastName = 'TestersonC', AlternateEmail__c = 'fake@test3.com', Preferred_Email__c = 'Alternate', 
 			OtherPhone = '555-432-4433', PreferredPhone__c = 'Other');
-		Contact contact4 = new Contact(LastName = 'TestersonD', AlternateEmail__c = 'fake@test4.com',
+		Contact contact4 = new Contact(LastName = 'TestersonD', AlternateEmail__c = 'fake@test4.com',Preferred_Email__c = 'Alternate',
 			MobilePhone = '555-432-4433', PreferredPhone__c = 'Mobile');
 			
 		List<Contact> contacts = new Contact[]{contact1, contact2, contact3, contact4};
@@ -74,9 +74,10 @@ public with sharing class CON_Preferred_TEST {
 	@isTest
 	public static void preferredEmailPhoneUpdate() {
 		
-		Contact contact1 = new Contact(LastName = 'TestersonE', UniversityEmail__c = 'fake@test5.com', HomePhone = '555-432-4433');
-		Contact contact2 = new Contact(LastName = 'TestersonF', WorkEmail__c = 'fake@test6.com', WorkPhone__c = '555-432-4433');
-		Contact contact3 = new Contact(LastName = 'TestersonG', AlternateEmail__c = 'fake@test7.com', OtherPhone = '555-432-4433');
+		// Preferred email is required to pass checks in preferred trigger
+		Contact contact1 = new Contact(LastName = 'TestersonE', UniversityEmail__c = 'fake@test5.com', HomePhone = '555-432-4433',Preferred_Email__c = 'University');
+		Contact contact2 = new Contact(LastName = 'TestersonF', WorkEmail__c = 'fake@test6.com', WorkPhone__c = '555-432-4433',Preferred_Email__c = 'Work');
+		Contact contact3 = new Contact(LastName = 'TestersonG', AlternateEmail__c = 'fake@test7.com', OtherPhone = '555-432-4433',Preferred_Email__c = 'Alternate');
 		Contact contact4 = new Contact(LastName = 'TestersonH', MobilePhone = '555-432-4433');
 			
 		List<Contact> contacts = new Contact[]{contact1, contact2, contact3, contact4};

--- a/src/classes/CON_Preferred_TEST.cls
+++ b/src/classes/CON_Preferred_TEST.cls
@@ -90,7 +90,8 @@ public with sharing class CON_Preferred_TEST {
 		contact3.Preferred_Email__c = 'Alternate';
 		contact3.PreferredPhone__c = 'Other';
 		contact4.PreferredPhone__c = 'Mobile';
-		
+
+	    CON_Preferred_TDTM.alreadyRunBefore = false; // need to re-activate the trigger since this is all the same transaction
 		Test.startTest();
 		update contacts;
 		Test.stopTest();

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -53,6 +53,10 @@ global without sharing class STG_InstallScript implements InstallHandler {
     	    //Insert default TDTM config (not necessary, but better to be explicit).
     	    List<TDTM_Global_API.TdtmToken> tokens = TDTM_Global_API.getTdtmConfig();
             TDTM_Global_API.setTdtmConfig(tokens); 
+
+            // Format existing contact email addresses
+            CON_Email_BATCH contbatch = new CON_Email_BATCH();
+            Database.executeBatch( contbatch );
     	 
     	 //Updates, manual of pushed by publisher.
     	 } else if(context.isUpgrade() || context.isPush()) {

--- a/src/classes/TDTM_Filter_TEST.cls
+++ b/src/classes/TDTM_Filter_TEST.cls
@@ -77,9 +77,9 @@ public with sharing class TDTM_Filter_TEST {
         TDTM_Global_API.setTdtmConfig(tokens);
 		
 		//Creating four contacts. two of them are not students, because they don't have a university email.
-		Contact c1 = new Contact(FirstName = 'Test', LastName = 'Testerson1', UniversityEmail__c = 'tt1@fake.edu');
+		Contact c1 = new Contact(FirstName = 'Test', LastName = 'Testerson1', UniversityEmail__c = 'tt1@fake.edu',Preferred_Email__c = 'University');
 		Contact c2 = new Contact(FirstName = 'Test', LastName = 'Testerson2', UniversityEmail__c = null);
-		Contact c3 = new Contact(FirstName = 'Test', LastName = 'Testerson3', UniversityEmail__c = 'tt3@fake.edu');
+		Contact c3 = new Contact(FirstName = 'Test', LastName = 'Testerson3', UniversityEmail__c = 'tt3@fake.edu',Preferred_Email__c = 'University');
 		Contact c4 = new Contact(FirstName = 'Test', LastName = 'Testerson4', UniversityEmail__c = '');
 		Contact[] contacts = new Contact[] {c1, c2, c3, c4};
 		insert contacts;

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -226,6 +226,29 @@ public class UTIL_Describe {
     }
 
     /*******************************************************************************************************
+    * @description Gives fields of given type
+    * @param objectName the name of the object to look up
+    * @param type the type of field to return - ID, STRING, TEXTAREA, DATE, DATETIME, BOOLEAN, REFERENCE,
+    * PICKLIST, MULTIPICKLIST, CURRENCY, DOUBLE, INTEGER, PERCENT, PHONE, EMAIL
+    * @return DescribeFieldResult Map of DescribeFieldResult
+    */
+    public static Map<String, Schema.DescribeFieldResult> getFieldsOfType(String objectName, String type) {
+
+        Map<String, Schema.DescribeFieldResult> allFields = UTIL_Describe.getAllFieldsDescribe( objectName );
+        Map<String, Schema.DescribeFieldResult> fields = new Map<String, Schema.DescribeFieldResult>();
+
+        for(String fieldLabel: allFields.keySet()) {
+            Schema.DescribeFieldResult field = allFields.get(fieldLabel);
+     
+            if (String.valueOf( field.getType() ) == 'EMAIL') {
+                fields.put(field.getName(), field );
+            }
+        }
+
+        return fields;
+    }
+
+    /*******************************************************************************************************
     * @description Returns field describe data
     * @param objectName the name of the object to look up
     * @param fieldName the name of the field to look up

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -226,7 +226,7 @@ public class UTIL_Describe {
     }
 
     /*******************************************************************************************************
-    * @description Gives fields of given type
+    * @description returns fields of given type by object
     * @param objectName the name of the object to look up
     * @param type the type of field to return - ID, STRING, TEXTAREA, DATE, DATETIME, BOOLEAN, REFERENCE,
     * PICKLIST, MULTIPICKLIST, CURRENCY, DOUBLE, INTEGER, PERCENT, PHONE, EMAIL
@@ -240,7 +240,7 @@ public class UTIL_Describe {
         for(String fieldLabel: allFields.keySet()) {
             Schema.DescribeFieldResult field = allFields.get(fieldLabel);
      
-            if (String.valueOf( field.getType() ) == 'EMAIL') {
+            if (String.valueOf( field.getType() ) == type) {
                 fields.put(field.getName(), field );
             }
         }

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -94,7 +94,7 @@
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>PreferredEmailMatchNotNull</shortDescription>
-        <value>Please check the Preferred Email field, the corresponding field does not have a value.</value>
+        <value>The email selected for Preferred Email can&apos;t be blank.</value>
     </labels>
     <labels>
         <fullName>PreferredEmailRequiredError</fullName>
@@ -102,7 +102,7 @@
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>Preferred Email Required Error</shortDescription>
-        <value>Preferred Email field is required when email fields are populated.</value>
+        <value>Tell us which email is preferred.</value>
     </labels>
     <labels>
         <fullName>Relationship_Explanation_Connector</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -89,6 +89,22 @@
         <value>Male</value>
     </labels>
     <labels>
+        <fullName>PreferredEmailMatchNotNull</fullName>
+        <categories>Contacts</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>PreferredEmailMatchNotNull</shortDescription>
+        <value>Please check the Preferred Email field, the corresponding field does not have a value.</value>
+    </labels>
+    <labels>
+        <fullName>PreferredEmailRequiredError</fullName>
+        <categories>Contacts</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Preferred Email Required Error</shortDescription>
+        <value>Preferred Email field is required when email fields are populated.</value>
+    </labels>
+    <labels>
         <fullName>Relationship_Explanation_Connector</fullName>
         <categories>Relationships</categories>
         <language>en_US</language>

--- a/src/package.xml
+++ b/src/package.xml
@@ -40,6 +40,9 @@
         <members>CON_CannotDelete_TEST</members>
         <members>CON_DoNotContact_TDTM</members>
         <members>CON_DoNotContact_TEST</members>
+        <members>CON_Email</members>
+        <members>CON_Email_BATCH</members>
+        <members>CON_Email_TEST</members>
         <members>CON_EthnicityRace_BATCH</members>
         <members>CON_EthnicityRace_TEST</members>
         <members>CON_Preferred_TDTM</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -326,6 +326,8 @@
         <members>Female</members>
         <members>InvalidFilter</members>
         <members>Male</members>
+        <members>PreferredEmailMatchNotNull</members>
+        <members>PreferredEmailRequiredError</members>
         <members>Relationship_Explanation_Connector</members>
         <members>Relationship_Split</members>
         <members>RelationshipsAutoDescription</members>


### PR DESCRIPTION
# Critical Changes

# Changes
- Enhancements to how the Preferred Email field is parsed for Contacts. System Administrators can now add a custom email field and add that field as an option to the Preferred Email field pick-list. 
- Preferred Email is now required when any email fields are populated on a Contact.
- Preferred Email field cannot be set to an email field with a blank value.
- On new installations of HEDA if there is a value in the standard Email field it will be copied to the Alternate email field and Alternate will be set as the preferred email.

# Issues Closed
Fixes #371 
Fixes #372 
Fixes #373 
Fixes #374 
Fixes #344