### PR TITLE
Set preferred email automatically when only a single email is present on Contact

### DIFF
--- a/src/classes/CON_Email.cls
+++ b/src/classes/CON_Email.cls
@@ -81,7 +81,7 @@ public class CON_Email {
                 }
             }
 
-            // Only one emai field, so we can intelligently set preferred email.
+            // Only one email field, so we can intelligently set preferred email.
             if(validatePreferred && emailFields.valuedCount() == 1 && String.isBlank(contact.Preferred_Email__c)){
 
                 contact.Preferred_Email__c = emailFields.valuedFields[0].prefLabel;

--- a/src/classes/CON_Email.cls
+++ b/src/classes/CON_Email.cls
@@ -35,7 +35,6 @@
 *
 */
 public class CON_Email {
-
     /*******************************************************************************************************
     * @description Sets the Email field depending on the value of Preferred Email
     * @param Contact the contact to update
@@ -82,8 +81,14 @@ public class CON_Email {
                 }
             }
 
+            // Only one emai field, so we can intelligently set preferred email.
+            if(validatePreferred && emailFields.valuedCount() == 1 && String.isBlank(contact.Preferred_Email__c)){
+
+                contact.Preferred_Email__c = emailFields.valuedFields[0].prefLabel;
+                contact.Email = emailFields.valuedFields[0].value;
+
             // Enforce preferred email field unless validation is disabled
-            if(validatePreferred && String.isBlank(contact.Preferred_Email__c)){
+            } else if(validatePreferred && String.isBlank(contact.Preferred_Email__c)){
 
                 contact.addError( Label.PreferredEmailRequiredError );
 

--- a/src/classes/CON_Email_TEST.cls
+++ b/src/classes/CON_Email_TEST.cls
@@ -55,7 +55,7 @@ private class CON_Email_TEST {
         insert listCon;
 	}
 
-	@isTest static void tedLeadConversion() {
+	@isTest static void testLeadConversion() {
 		// create a Lead
 		Lead tLead = new Lead(
 			FirstName='Joshua',

--- a/src/classes/CON_Email_TEST.cls
+++ b/src/classes/CON_Email_TEST.cls
@@ -55,6 +55,34 @@ private class CON_Email_TEST {
         insert listCon;
 	}
 
+	@isTest static void tedLeadConversion() {
+		// create a Lead
+		Lead tLead = new Lead(
+			FirstName='Joshua',
+			LastName='McTesterman',
+			Email='mctesterman@mctesersite.com',
+			Company='Test',
+			Status='Inquiry'
+		);
+
+		insert tLead;
+
+		Database.LeadConvert lc = new Database.LeadConvert();
+		lc.setLeadId(tLead.Id);
+
+		LeadStatus convertStatus = [SELECT Id, MasterLabel FROM LeadStatus WHERE IsConverted=true LIMIT 1];
+		lc.setConvertedStatus(convertStatus.MasterLabel);
+
+		Test.startTest();		
+		Database.LeadConvertResult lcr = Database.convertLead(lc);
+		Test.stopTest();
+
+		String contId = lcr.getContactId();
+		Contact c = [SELECT Id, Name, Email FROM Contact WHERE Id =:contId LIMIT 1];
+
+		System.assertEquals(c.Email,tLead.Email );
+	}
+
 	@isTest static void testSingleEmailSmartSet() {
 
 		Contact newCont = new Contact(

--- a/src/classes/CON_Email_TEST.cls
+++ b/src/classes/CON_Email_TEST.cls
@@ -55,6 +55,24 @@ private class CON_Email_TEST {
         insert listCon;
 	}
 
+	@isTest static void testSingleEmailSmartSet() {
+
+		Contact newCont = new Contact(
+			FirstName = 'JohnnyTest',
+			LastName = 'JohnnyTest',
+			WorkEmail__c = 'workit@test.com'
+		);
+
+		Test.startTest();
+        insert newCont;
+		Test.stopTest();
+
+		Contact newContAfter = [SELECT Id, Name, WorkEmail__c, Email, Preferred_Email__c FROM Contact WHERE Name = 'JohnnyTest JohnnyTest' LIMIT 1];
+
+        System.assertEquals(newContAfter.Email, newContAfter.WorkEmail__c);
+        System.assertEquals('Work', newContAfter.Preferred_Email__c);
+	}
+
 	@isTest static void testPrefferedEmailInsertNoStd() {
 		List<Contact> contacts = [SELECT Id, Name, Email FROM Contact WHERE EMAIL != null LIMIT 2];
 		List<String> contIds = new List<String>();


### PR DESCRIPTION
# Critical Changes

# Changes
- When a Contact has only a single email address, we set that value as the Preferred Email and copy the value to the standard Email field. This feature helps prevent errors during lead conversion.

# Issues Closed
Fixes #428