### PR TITLE
Prevent User Managed Trigger handlers from being deleted.

### DIFF
--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -136,7 +136,7 @@ global without sharing class STG_InstallScript implements InstallHandler {
     /*******************************************************************************************************
     * @description Inserts the default TDTM records, if necessary. Updates those that need to be updated, since the last package
     * upgrade.
-    * @param defaultTdtmConfig The default TDTM configuration. Using DI just so it's easier to test it.
+    * @param defaultTdtmConfig The default TDTM configuration. Using DI just so it's easier to test it. Only includes item from TDTM_DefaultConfig
     * @return void
     */
     @TestVisible 
@@ -152,9 +152,10 @@ global without sharing class STG_InstallScript implements InstallHandler {
 
         List<TDTM_Global_API.TdtmToken> newTdtmConfig = new List<TDTM_Global_API.TdtmToken>();
         
-        // First preserve the handlers that are user managed. This helps keep the records manually added by users.
+        // First preserve the trigger handlers that are user managed. We do this because this 
+        // method accepts the default config without the addition of custom trigger handlers 
+        // added by users.
         for(TDTM_Global_API.TdtmToken existingToken : existingTdtmConfig) {
-            // Preserve user managed items
             if(existingToken.userManaged) {
                 UTIL_Debug.debug('****It was user managed,so we should not change it: ' + existingToken.className);
                 newTdtmConfig.add(existingToken);

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -152,6 +152,15 @@ global without sharing class STG_InstallScript implements InstallHandler {
 
         List<TDTM_Global_API.TdtmToken> newTdtmConfig = new List<TDTM_Global_API.TdtmToken>();
         
+        // First preserve the handlers that are user managed. This helps keep the records manually added by users.
+        for(TDTM_Global_API.TdtmToken existingToken : existingTdtmConfig) {
+            // Preserve user managed items
+            if(existingToken.userManaged) {
+                UTIL_Debug.debug('****It was user managed,so we should not change it: ' + existingToken.className);
+                newTdtmConfig.add(existingToken);
+            }
+        }
+
         //Insert those that are in the list of default handlers but aren't in the database
         for(TDTM_Global_API.TdtmToken defaultToken : defaultTdtmConfig) {
             Boolean alreadyExists = false;
@@ -177,9 +186,6 @@ global without sharing class STG_InstallScript implements InstallHandler {
                     } else if(!existingToken.userManaged && defaultToken.loadOrder == existingToken.loadOrder || 
                     defaultToken.actions == existingToken.actions) {
                         UTIL_Debug.debug('****It was not user managed and has not changed: ' + existingToken.className);
-                        newTdtmConfig.add(existingToken);
-                    } else if(existingToken.userManaged) {
-                        UTIL_Debug.debug('****It was user managed,so we should not change it: ' + existingToken.className);
                         newTdtmConfig.add(existingToken);
                     }
                     break;

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -136,7 +136,7 @@ global without sharing class STG_InstallScript implements InstallHandler {
     /*******************************************************************************************************
     * @description Inserts the default TDTM records, if necessary. Updates those that need to be updated, since the last package
     * upgrade.
-    * @param defaultTdtmConfig The default TDTM configuration. Using DI just so it's easier to test it. Only includes item from TDTM_DefaultConfig
+    * @param defaultTdtmConfig The default TDTM configuration. Using DI just so it's easier to test it. Only includes items from TDTM_DefaultConfig
     * @return void
     */
     @TestVisible 

--- a/src/classes/STG_InstallScript_TEST.cls
+++ b/src/classes/STG_InstallScript_TEST.cls
@@ -153,7 +153,7 @@ public with sharing class STG_InstallScript_TEST {
         //Verify handlers marked as "User Managed" were not modified
         List<Trigger_Handler__c> newHandlers = [select Load_Order__c, Class__c, Trigger_Action__c from Trigger_Handler__c order by Load_Order__c];
 
-        // Mae sure the manually added item is not deleted.
+        // Make sure the manually added items are not deleted.
         System.assertEquals(5, newHandlers.size());   
         
         // Individually check each handler scenario

--- a/src/classes/STG_InstallScript_TEST.cls
+++ b/src/classes/STG_InstallScript_TEST.cls
@@ -104,6 +104,7 @@ public with sharing class STG_InstallScript_TEST {
     
     //If the handlers in our default TDTM config are different from what it's in the org (either action or load order),
     //and the user flagged them as user managed, we do not need to update them
+    // also test that new handlers are added 
     @isTest
     public static void handlersChanged_UserManaged() {
         
@@ -121,8 +122,20 @@ public with sharing class STG_InstallScript_TEST {
         TDTM_Global_API.TdtmToken token3 = new TDTM_Global_API.TdtmToken('REL_Relationships_Con_TDTM', 'Contact', 'AfterInsert;AfterDelete', 2);
         token3.userManaged = true;
         oldHandlers.add(token3);
-        
+
         TDTM_Global_API.setTdtmConfig(oldHandlers);
+
+        // Create fourth trigger handler to simulate a new record added by a user.
+        Trigger_Handler__c custTrigHand = new Trigger_Handler__c(
+            Active__c = true, 
+            Asynchronous__c = false, 
+            Class__c = 'ADDR_Addresses_TDTM', 
+            Load_Order__c = 1, 
+            Object__c = 'Address__c', 
+            Trigger_Action__c = 'BeforeInsert;BeforeUpdate;AfterInsert;AfterUpdate;AfterDelete',
+            User_Managed__c = true
+        );
+        insert custTrigHand; // Must be inserted after setTdtmConfig() to prevent deletion
         
         //Updated handlers
         List<TDTM_Global_API.TdtmToken> updatedHandlers = new List<TDTM_Global_API.TdtmToken>();
@@ -130,27 +143,43 @@ public with sharing class STG_InstallScript_TEST {
         updatedHandlers.add(new TDTM_Global_API.TdtmToken('REL_Relationships_Cm_TDTM', 'CampaignMember', 'AfterInsert;AfterUpdate', 0));
         updatedHandlers.add(new TDTM_Global_API.TdtmToken('REL_Relationships_Con_TDTM', 'Contact', 'AfterInsert;AfterUpdate;AfterDelete', 1));
         
+        // Add new items added to default
+        updatedHandlers.add(new TDTM_Global_API.TdtmToken('ADDR_Contact_TDTM', 'Contact', 'BeforeInsert;BeforeUpdate;AfterInsert;AfterUpdate', 2));
+
         Test.startTest();
         STG_InstallScript.updateDefaultTdtmConfig(updatedHandlers);
         Test.stopTest();
         
         //Verify handlers marked as "User Managed" were not modified
         List<Trigger_Handler__c> newHandlers = [select Load_Order__c, Class__c, Trigger_Action__c from Trigger_Handler__c order by Load_Order__c];
+
+        // Mae sure the manually added item is not deleted.
+        System.assertEquals(5, newHandlers.size());   
         
-        //Should have been modified
-        System.assertEquals('REL_Relationships_Cm_TDTM', newHandlers[0].Class__c);   
-        System.assertEquals(0, newHandlers[0].Load_Order__c); 
-        System.assertEquals('AfterInsert;AfterUpdate', newHandlers[0].Trigger_Action__c);
-        
-        //Should not have been modified  
-        System.assertEquals('AFFL_Affiliations_TDTM', newHandlers[1].Class__c);   
-        System.assertEquals(1, newHandlers[1].Load_Order__c);
-        System.assertEquals('AfterInsert', newHandlers[1].Trigger_Action__c);  
-        
-        //Should not have been modified
-        System.assertEquals('REL_Relationships_Con_TDTM', newHandlers[2].Class__c); 
-        System.assertEquals(2, newHandlers[2].Load_Order__c);
-        System.assertEquals('AfterInsert;AfterDelete', newHandlers[2].Trigger_Action__c);     
+        // Individually check each handler scenario
+        for (Trigger_Handler__c handler : newHandlers) {
+            if(handler.Class__c == 'REL_Relationships_Cm_TDTM') {
+                 //Should have been modified
+                System.assertEquals(0, handler.Load_Order__c); 
+                System.assertEquals('AfterInsert;AfterUpdate', handler.Trigger_Action__c);
+            } else if (handler.Class__c == 'AFFL_Affiliations_TDTM') {
+                //Should not have been modified 
+                System.assertEquals(1, handler.Load_Order__c);
+                System.assertEquals('AfterInsert', handler.Trigger_Action__c); 
+            } else if (handler.Class__c == 'REL_Relationships_Con_TDTM') {
+                //Should not have been modified
+                System.assertEquals(2, handler.Load_Order__c);
+                System.assertEquals('AfterInsert;AfterDelete', handler.Trigger_Action__c);
+            } else if (handler.Class__c == 'ADDR_Addresses_TDTM') {
+                //Should not have been modified
+                System.assertEquals(1, handler.Load_Order__c);
+                System.assertEquals('BeforeInsert;BeforeUpdate;AfterInsert;AfterUpdate;AfterDelete', handler.Trigger_Action__c);  
+            } else if (handler.Class__c == 'ADDR_Contact_TDTM') {
+                //Should have been added
+                System.assertEquals(2, handler.Load_Order__c);
+                System.assertEquals('BeforeInsert;BeforeUpdate;AfterInsert;AfterUpdate', handler.Trigger_Action__c);  
+            }
+        }
     }
     
     @isTest

--- a/src/classes/TDTM_Config.cls
+++ b/src/classes/TDTM_Config.cls
@@ -63,8 +63,8 @@ public class TDTM_Config {
         List<Trigger_Handler__c> tdtmConfig = [select Class__c, Object__c, Trigger_Action__c, Load_Order__c, Active__c, 
                             Asynchronous__c, Filter_Field__c, Filter_Value__c, User_Managed__c from Trigger_Handler__c];
                          
-        //Getting the default configuration only if there is no data in the Trigger Handler object. Otherwise
-        //we would delete customizations and Trigger Handlers entries that aren't in the default configuration. 
+        // Getting the default configuration only if there is no data in the Trigger Handler object. Otherwise
+        // we would delete customizations and Trigger Handlers entries that aren't in the default configuration. 
         if(tdtmConfig.size() == 0) {
 	        tdtmConfig = TDTM_DefaultConfig.getDefaultRecords();
         }


### PR DESCRIPTION
# Critical Changes

# Changes
- Trigger Handler records marked as User Managed are no longer deleted when upgrading from HEDA release 1.32 to later versions

# Issues Closed
Fixes #424