### PR TITLE
Feature/gender reciprocal settings

### DIFF
--- a/src/classes/REL_Relationships_Con_TDTM.cls
+++ b/src/classes/REL_Relationships_Con_TDTM.cls
@@ -88,7 +88,7 @@ public class REL_Relationships_Con_TDTM extends TDTM_Runnable {
                 }
                 
                 //handle updates to the gender field
-                if (triggerAction == TDTM_Runnable.Action.afterUpdate) {
+                if (triggerAction == TDTM_Runnable.Action.afterUpdate && oldMap.get(c.id) != null) {
                     if (c.Gender__c != oldMap.get(c.id).Gender__c) {
                         changedGender.add(c.id);
                     }

--- a/src/classes/REL_Relationships_Con_TDTM.cls
+++ b/src/classes/REL_Relationships_Con_TDTM.cls
@@ -87,8 +87,8 @@ public class REL_Relationships_Con_TDTM extends TDTM_Runnable {
                     }               
                 }
                 
-                //handle updates to the gender field if we have one
-                if (triggerAction == TDTM_Runnable.Action.afterUpdate && c.Gender__c!=null) {
+                //handle updates to the gender field
+                if (triggerAction == TDTM_Runnable.Action.afterUpdate) {
                     if (c.Gender__c != oldMap.get(c.id).Gender__c) {
                         changedGender.add(c.id);
                     }

--- a/src/classes/REL_Relationships_TDTM.cls
+++ b/src/classes/REL_Relationships_TDTM.cls
@@ -341,8 +341,7 @@ public class REL_Relationships_TDTM extends TDTM_Runnable {
                     
                     //can't match up gender, bad field or otherwise
                     } else {
-                        if (copy.Type__c==null)          
-                            copy.Type__c = rlMap.get(r.Type__c).Neutral__c;                     
+                        copy.Type__c = rlMap.get(r.Type__c).Neutral__c;                     
                     }                                     
                 //no matching custom List setting, use provided type
                 } else {

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -230,6 +230,10 @@ global without sharing class STG_InstallScript implements InstallHandler {
             lookups.add(new Relationship_Lookup__c(Name = 'Grandchild', Male__c = 'Grandfather', Female__c = 'Grandmother', Neutral__c = 'Grandparent', Active__c = true));
             lookups.add(new Relationship_Lookup__c(Name = 'Employer', Male__c = 'Employee', Female__c = 'Employee', Neutral__c = 'Employee', Active__c = true));
             lookups.add(new Relationship_Lookup__c(Name = 'Employee', Male__c = 'Employer', Female__c = 'Employer', Neutral__c = 'Employer', Active__c = true));
+            lookups.add(new Relationship_Lookup__c(Name = 'Sibling\'s Child', Male__c = 'Uncle', Female__c = 'Aunt', Neutral__c = 'Parent\'s Sibling', Active__c = true));
+            lookups.add(new Relationship_Lookup__c(Name = 'Parent\'s Sibling', Male__c = 'Nephew', Female__c = 'Niece', Neutral__c = 'Sibling\'s Child', Active__c = true));
+            lookups.add(new Relationship_Lookup__c(Name = 'Nephew', Male__c = 'Uncle', Female__c = 'Aunt', Neutral__c = 'Parent\'s Sibling', Active__c = true));
+            lookups.add(new Relationship_Lookup__c(Name = 'Niece', Male__c = 'Uncle', Female__c = 'Aunt', Neutral__c = 'Parent\'s Sibling', Active__c = true));
             insert lookups;
         }
     }


### PR DESCRIPTION
# Critical Changes

# Changes
Fixed how gender is indicated in Contacts' relationships. If you update a Contact record to remove the value in HEDA's Gender field, we now change the Contact's relationship type from gender-specific to gender-neutral values. For example, if the Gender field for Jane Smith (female) is blank, we update the relationship with her nephew, John, from Aunt to Parent's Sibling. Previously, the relationship type remained Aunt.

# Issues Closed
Fixes #404 