### PR TITLE
Prevent null ID values in the ReciprocalRelationship__c field when deleting Contacts.

### DIFF
--- a/src/classes/REL_Relationships_Con_TDTM.cls
+++ b/src/classes/REL_Relationships_Con_TDTM.cls
@@ -147,7 +147,9 @@ public class REL_Relationships_Con_TDTM extends TDTM_Runnable {
         // Using ALL ROWS returns them in the query used to gather the mirror Relationships to be deleted 
         for (Relationship__c r : [Select Id, ReciprocalRelationship__c from Relationship__c 
             where Contact__c in :contacts.keySet() ALL ROWS]){
-            relationshipsToDelete.add(new Relationship__c(Id = r.ReciprocalRelationship__c));
+            if (r.ReciprocalRelationship__c != null) {
+                relationshipsToDelete.add(new Relationship__c(Id = r.ReciprocalRelationship__c));
+            }
         }
         if ( relationshipsToDelete.size() > 0 ) {
             dmlWrapper.objectsToDelete.addAll(relationshipsToDelete);


### PR DESCRIPTION

# Critical Changes

# Changes
- Fixed an error that prevented Contacts from being deleted, even after deleting Relationship records associated with the Contact.
# Issues Closed
Fixes #458