### PR TITLE
Feature/static flag

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -178,7 +178,6 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         	UTIL_Debug.debug('****Number of contacts that need accounts created: ' + listContactNeedAccount.size());
             //add the newly created or updated Contacts that need a new individual account
             insertContactAccount(listContactNeedAccount, dmlWrapper);
-            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Insert, false);
         }
         if (mapAccountIdContactId.size() > 0) {
             //update Accounts that have newly created Contacts connected to them
@@ -444,9 +443,6 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         // update any HH accounts that just lost a contact
         if (listAccountIdUpdate.size() > 0)
             updateParentAcc(listAccountIdUpdate, dmlWrapper);
-
-        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Delete, false);
-
     }
 
     /*******************************************************************************************************

--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -42,31 +42,6 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
     private static ID defaultRecTypeID = UTIL_CustomSettingsFacade.getSettings().Account_Processor__c;
 
     /*******************************************************************************************************
-    * @description Re-entrant Flag for After Insert
-    */
-    public static boolean alreadyRunAfterInsert = false;
-
-    /*******************************************************************************************************
-    * @description Re-entrant Flag for After Update
-    */
-    public static boolean alreadyRunAfterUpdate = false;
-
-    /*******************************************************************************************************
-    * @description Re-entrant Flag for After Delete
-    */
-    public static boolean alreadyRunAfterDelete = false;
-
-    /*******************************************************************************************************
-    * @description A method to disable all trigger actions for this trigger class
-    * @return void
-    */
-    public static void turnOff() {
-        alreadyRunAfterInsert = true;
-        alreadyRunAfterUpdate = true;
-        alreadyRunAfterDelete = true;
-    }
-
-    /*******************************************************************************************************
     * @description a set of languages that require different naming conventions
     */
     private static Set<String> EasternOrderLanguages = new Set<String>{
@@ -128,7 +103,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         }
 
         // AFTER DELETE
-        if (triggerAction == TDTM_Runnable.Action.AfterDelete && !alreadyRunAfterDelete) {
+        if (triggerAction == TDTM_Runnable.Action.AfterDelete && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Delete)) {
             for (Contact c : oldContacts)
                 listContactAccountDelete.add(c);
         } else {
@@ -136,7 +111,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             for (Contact c : contacts) {
 
                 // AFTER INSERT
-                if (triggerAction == TDTM_Runnable.Action.AfterInsert && !alreadyRunAfterInsert) {
+                if (triggerAction == TDTM_Runnable.Action.AfterInsert && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Insert)) {
 
                 	// Account should be created if:
                     //    1. The account isn't set by the user
@@ -154,7 +129,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
 	            }
 
                 // AFTER UPDATE
-                if (triggerAction == TDTM_Runnable.Action.AfterUpdate && !alreadyRunAfterUpdate) {
+                if (triggerAction == TDTM_Runnable.Action.AfterUpdate && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Update)) {
                     // HH account should be created if:
 	                //   1. The account has been blanked out by the user
 	                //   2. The Account Model is not blank
@@ -185,15 +160,15 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             // Must set flags after contact for loop to make sure all contacts are processed.
             if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
                 // Set reentrant flag
-                alreadyRunAfterInsert = true;
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Insert, true);
             }
             if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
                 // Set reentrant flag
-                alreadyRunAfterUpdate = true;
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Update, true);
             }
             if (triggerAction == TDTM_Runnable.Action.AfterDelete) {
                 // Set reentrant flag
-                alreadyRunAfterDelete = true;
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Delete, true);
             }
         }
 
@@ -203,6 +178,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         	UTIL_Debug.debug('****Number of contacts that need accounts created: ' + listContactNeedAccount.size());
             //add the newly created or updated Contacts that need a new individual account
             insertContactAccount(listContactNeedAccount, dmlWrapper);
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Insert, false);
         }
         if (mapAccountIdContactId.size() > 0) {
             //update Accounts that have newly created Contacts connected to them
@@ -216,7 +192,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             updateParentAcc(listAccountIdHHToUpdate, dmlWrapper);
         }
         if (mapContactIdContactOwnerChange.size() > 0) {
-        	updateOwners(mapContactIdContactOwnerChange, dmlWrapper);
+            updateOwners(mapContactIdContactOwnerChange, dmlWrapper);
         }
         if (listContactAccountDelete.size() > 0) {
         	UTIL_Debug.debug('****Number of accs to delete: ' + listContactAccountDelete.size());
@@ -224,6 +200,15 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             deleteContactAccountsIfEmpty(listContactAccountDelete, dmlWrapper);
         }
 
+        TDTM_TriggerHandler.processDML(dmlWrapper, true);
+        dmlWrapper = null;
+        if (triggerAction == TDTM_Runnable.Action.AfterInsert){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Insert, false);
+        }else if (triggerAction == TDTM_Runnable.Action.AfterUpdate){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Update, false);
+        }else if (triggerAction == TDTM_Runnable.Action.AfterDelete){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Delete, false);            
+        }
     	return dmlWrapper;
     }
 
@@ -459,6 +444,9 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         // update any HH accounts that just lost a contact
         if (listAccountIdUpdate.size() > 0)
             updateParentAcc(listAccountIdUpdate, dmlWrapper);
+
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Delete, false);
+
     }
 
     /*******************************************************************************************************

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -46,7 +46,10 @@ private class ACCT_IndividualAccounts_TEST {
             new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe.getAdminAccRecTypeID()));
 
         // turn off all TDTM triggers for this component
-        ACCT_IndividualAccounts_TDTM.turnOff();
+        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Insert);
+        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Update);
+        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Delete);
+    
 
         Contact con = new Contact(
             FirstName='Test',
@@ -157,7 +160,7 @@ private class ACCT_IndividualAccounts_TEST {
         Contact con2 = new Contact(FirstName='John', LastName='Smith', AccountId = accountId);
 
         Test.startTest();
-        AFFL_MultiRecordType_TDTM.afflMultiHasRunBefore = false;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before, false);
         insert con2;
         Test.stopTest();
 

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -48,8 +48,7 @@ private class ACCT_IndividualAccounts_TEST {
         // turn off all TDTM triggers for this component
         TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Insert);
         TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Update);
-        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Delete);
-    
+        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Delete);               
 
         Contact con = new Contact(
             FirstName='Test',
@@ -160,7 +159,7 @@ private class ACCT_IndividualAccounts_TEST {
         Contact con2 = new Contact(FirstName='John', LastName='Smith', AccountId = accountId);
 
         Test.startTest();
-        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before, false);
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert, false);
         insert con2;
         Test.stopTest();
 

--- a/src/classes/ADDR_Account_TDTM.cls
+++ b/src/classes/ADDR_Account_TDTM.cls
@@ -36,18 +36,15 @@
 */
 public class ADDR_Account_TDTM extends TDTM_Runnable {
     
-    /* @description Flag to prevent recursive call after insert */
-    public static boolean alreadyRunAfterInsert = false;
-    /* @description Flag to prevent recursive call after update */
-    public static boolean alreadyRunAfterUpdate = false;
-    
+    public static Set<Id> accountIdsInserted = new Set<Id>();
+    public static Set<Id> accountIdsUpdated = new Set<Id>();
     /*******************************************************************************************************
     * @description Turns class off.
     * @return void
     ********************************************************************************************************/
     public static void turnOff() {
-        alreadyRunAfterInsert = true;
-        alreadyRunAfterUpdate = true;
+        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Account_TDTM_After_Insert);
+        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Account_TDTM_After_Update);
     }
     
     /*******************************************************************************************************
@@ -55,8 +52,8 @@ public class ADDR_Account_TDTM extends TDTM_Runnable {
     * @return void
     ********************************************************************************************************/
     public static void turnOn() {
-        alreadyRunAfterInsert = false;
-        alreadyRunAfterUpdate = false;
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Account_TDTM_After_Insert);
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Account_TDTM_After_Update);
     }
     
     /*******************************************************************************************************
@@ -72,7 +69,7 @@ public class ADDR_Account_TDTM extends TDTM_Runnable {
             
         DmlWrapper dmlWrapper = new DmlWrapper();
             
-        if(!alreadyRunAfterInsert || !alreadyRunAfterUpdate) {
+        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Account_TDTM_After_Insert) || !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Account_TDTM_After_Update)) {
 	        
 	        //Turn off other address triggers
             ADDR_Contact_TDTM.turnOff();
@@ -82,24 +79,27 @@ public class ADDR_Account_TDTM extends TDTM_Runnable {
 	        List<Account> accsAddrInfoCleared = new List<Account>();
 	                
 	        // AFTER INSERT
-	        if (!alreadyRunAfterInsert && triggerAction == TDTM_Runnable.Action.AfterInsert) {
+	        if (!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Account_TDTM_After_Insert) && triggerAction == TDTM_Runnable.Action.AfterInsert) {
 	            Integer i = 0;        
 		        for (SObject so : listNew) {
 		            Account acc = (Account)so;
-	                // for new accounts that are using address management, create the address object.
-	                if (UTIL_CustomSettingsFacade.getSettings().Accounts_Addresses_Enabled__c != null && acc.RecordTypeId != null
-	                && UTIL_CustomSettingsFacade.getSettings().Accounts_Addresses_Enabled__c.contains(acc.RecordTypeId)) {
-	                    if (!ADDR_Addresses_UTIL.isAccAddressEmpty(acc)) {
-	                        newAddrInfoAccs.add(acc);
-	                    }
-	                }
+                    if (!accountIdsInserted.contains(acc.Id)){
+    	                // for new accounts that are using address management, create the address object.
+    	                if (UTIL_CustomSettingsFacade.getSettings().Accounts_Addresses_Enabled__c != null && acc.RecordTypeId != null
+    	                && UTIL_CustomSettingsFacade.getSettings().Accounts_Addresses_Enabled__c.contains(acc.RecordTypeId)) {
+    	                    if (!ADDR_Addresses_UTIL.isAccAddressEmpty(acc)) {
+    	                        newAddrInfoAccs.add(acc);
+    	                    }
+    	                }
+                        accountIdsInserted.add(acc.Id);
+                    }
 	                i++;
 		        }
-	            alreadyRunAfterInsert = true;
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Account_TDTM_After_Insert, true);
 	        }
 		    
 	        // AFTER UPDATE
-	        if (!alreadyRunAfterUpdate && triggerAction == TDTM_Runnable.Action.AfterUpdate) {  
+	        if (!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Account_TDTM_After_Update) && triggerAction == TDTM_Runnable.Action.AfterUpdate) {  
 	            Integer i = 0;        
 	            for (SObject so : listNew) {
 	                Account acc = (Account)so;
@@ -108,29 +108,44 @@ public class ADDR_Account_TDTM extends TDTM_Runnable {
 	                Boolean accAddrEnabledForRecType = UTIL_CustomSettingsFacade.getSettings().Accounts_Addresses_Enabled__c != null && acc.RecordTypeId != null
                                                        && UTIL_CustomSettingsFacade.getSettings().Accounts_Addresses_Enabled__c.contains(acc.RecordTypeId);
 	                
-	                if (isHousehold || accAddrEnabledForRecType) {
-	                    
-	                    // if the address info has been cleared
-	                    if(!ADDR_Addresses_UTIL.isAccAddressEmpty(accOld) && ADDR_Addresses_UTIL.isAccAddressEmpty(acc)) {
-	                        accsAddrInfoCleared.add(acc);
-	                        
-	                    // if the account address info has changed  
-	                    } else if (ADDR_Addresses_UTIL.isAccountAddressChanged(acc, accOld)) {
-	                        newAddrInfoAccs.add(acc);
-	                    }
-	                }
+                    if (!accountIdsUpdated.contains(acc.Id)){
+                        if (isHousehold || accAddrEnabledForRecType) {
+    	                    
+    	                    // if the address info has been cleared
+    	                    if(!ADDR_Addresses_UTIL.isAccAddressEmpty(accOld) && ADDR_Addresses_UTIL.isAccAddressEmpty(acc)) {
+    	                        accsAddrInfoCleared.add(acc);
+    	                        
+    	                    // if the account address info has changed  
+    	                    } else if (ADDR_Addresses_UTIL.isAccountAddressChanged(acc, accOld)) {
+    	                        newAddrInfoAccs.add(acc);
+    	                    }
+    	                }
+                        accountIdsUpdated.add(acc.Id);
+                    }
 	            i++;
 	            }
-	            alreadyRunAfterUpdate = true;
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Account_TDTM_After_Update, true);
 	        }
 	
 	        // create any new Address objects
 	        if (newAddrInfoAccs.size() > 0)
+            {
 	            processAccsWithNewInfo(newAddrInfoAccs, dmlWrapper);
+            }
 	        
 	        // handle accs with address info removed
 	        if(accsAddrInfoCleared.size() > 0)
+            {
 	            addrInfoDeleted(accsAddrInfoCleared, dmlWrapper);
+            }
+
+        }
+        TDTM_TriggerHandler.processDML(dmlWrapper, true);
+        dmlWrapper = null;
+        if (triggerAction == TDTM_Runnable.Action.AfterInsert){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Account_TDTM_After_Insert, false);
+        }else if (triggerAction == TDTM_Runnable.Action.AfterUpdate){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Account_TDTM_After_Update, false);
         }
         return dmlWrapper;    
     }

--- a/src/classes/ADDR_Account_TDTM.cls
+++ b/src/classes/ADDR_Account_TDTM.cls
@@ -89,9 +89,9 @@ public class ADDR_Account_TDTM extends TDTM_Runnable {
     	                && UTIL_CustomSettingsFacade.getSettings().Accounts_Addresses_Enabled__c.contains(acc.RecordTypeId)) {
     	                    if (!ADDR_Addresses_UTIL.isAccAddressEmpty(acc)) {
     	                        newAddrInfoAccs.add(acc);
+                                accountIdsInserted.add(acc.Id);
     	                    }
     	                }
-                        accountIdsInserted.add(acc.Id);
                     }
 	                i++;
 		        }
@@ -118,9 +118,9 @@ public class ADDR_Account_TDTM extends TDTM_Runnable {
     	                    // if the account address info has changed  
     	                    } else if (ADDR_Addresses_UTIL.isAccountAddressChanged(acc, accOld)) {
     	                        newAddrInfoAccs.add(acc);
+                                accountIdsUpdated.add(acc.Id);
     	                    }
     	                }
-                        accountIdsUpdated.add(acc.Id);
                     }
 	            i++;
 	            }

--- a/src/classes/ADDR_Addresses_TDTM.cls
+++ b/src/classes/ADDR_Addresses_TDTM.cls
@@ -130,7 +130,8 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 
 	        // AFTER INSERT
 	        if (triggerAction == TDTM_Runnable.Action.AfterInsert && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Insert)) {
-	            for (SObject so : listNew) {
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Insert, true);
+                for (SObject so : listNew) {
 	                Address__c addr = (Address__c)so;
                     if (!addressIdsInserted.contains(addr.Id)){
     		            // a new address that is marked default or seasonal needs to propagate to the parent Account
@@ -145,7 +146,7 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	                refreshParentAndSiblings(mapParentIdAddr, dmlWrapper, triggerAction);
 	                processDmlErrors(dmlWrapper, mapParentIdAddr);
 	            }
-
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Insert, false);
 	            // enforce address records created only as children of parents
 	            verifyAddrAccContactChildOnly((List<Address__c>)listNew);
 	            // enforce Seasonal Addresses don't overlap
@@ -153,12 +154,12 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	            // delete empty addresses
 	            deleteEmptyAddrs(listNew);
 
-                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Insert, true);
 	        }
 
 	        // AFTER UPDATE
 	        if (triggerAction == TDTM_Runnable.Action.AfterUpdate && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Update)) {
-	            Integer i = 0;
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Update, true);    
+                Integer i = 0;
 	            for (SObject so : listNew) {
 	                Address__c addr = (Address__c)so;
 	                Address__c addrOld = listOld == null? null : (Address__c)listOld[i];
@@ -185,12 +186,12 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	                refreshParentAndSiblings(mapParentIdAddr, dmlWrapper, triggerAction);
 	                processDmlErrors(dmlWrapper, mapParentIdAddr);
 	            }
-
-                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Update, true);
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Update, false);                    
 	        }
 
 	        // AFTER DELETE
 	        if (triggerAction == TDTM_Runnable.Action.AfterDelete && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Delete)) {
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Delete, true);
 	            Integer i = 0;
 	            for (SObject addrOld : listOld) {
 		            // first go through all new/modified Addresses, and collect the list of parents to consider.
@@ -208,8 +209,7 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	               refreshParentAndSiblings(mapParentIdAddr, dmlWrapper, triggerAction);
 	               processDmlErrors(dmlWrapper, mapParentIdAddr);
 	            }
-
-                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Delete, true);
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Delete, false);
 	        }
         }
         TDTM_TriggerHandler.processDML(dmlWrapper, true);
@@ -218,12 +218,6 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Insert, false);
         }else if (triggerAction == TDTM_Runnable.Action.BeforeUpdate){
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Update, false);
-        }else if (triggerAction == TDTM_Runnable.Action.AfterInsert){
-            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Insert, false);
-        }else if (triggerAction == TDTM_Runnable.Action.AfterUpdate){
-            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Update, false);
-        }else if (triggerAction == TDTM_Runnable.Action.AfterDelete){
-            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Delete, false);
         }
         return dmlWrapper;
     }

--- a/src/classes/ADDR_Addresses_TDTM.cls
+++ b/src/classes/ADDR_Addresses_TDTM.cls
@@ -95,7 +95,7 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	        Map<Id, Address__c> mapParentIdAddr = new Map<Id, Address__c>();
 
 	        // BEFORE INSERT
-	        if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
+	        if (triggerAction == TDTM_Runnable.Action.BeforeInsert && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Insert)) {
 		        for (SObject so : listNew) {
 		            Address__c addr = (Address__c)so;
 	                // when an address is created as Default, we update its latest date fields
@@ -108,7 +108,7 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	        }
 
 	        // BEFORE UPDATE
-	        if (triggerAction == TDTM_Runnable.Action.BeforeUpdate) {
+	        if (triggerAction == TDTM_Runnable.Action.BeforeUpdate && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Update)) {
 	            Integer i = 0;
 		        for (SObject so : listNew) {
 		            Address__c addr = (Address__c)so;
@@ -129,7 +129,7 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	        }
 
 	        // AFTER INSERT
-	        if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
+	        if (triggerAction == TDTM_Runnable.Action.AfterInsert && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Insert)) {
 	            for (SObject so : listNew) {
 	                Address__c addr = (Address__c)so;
                     if (!addressIdsInserted.contains(addr.Id)){
@@ -157,7 +157,7 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	        }
 
 	        // AFTER UPDATE
-	        if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+	        if (triggerAction == TDTM_Runnable.Action.AfterUpdate && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Update)) {
 	            Integer i = 0;
 	            for (SObject so : listNew) {
 	                Address__c addr = (Address__c)so;
@@ -170,11 +170,13 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
     		            //An address that is marked default, of that had its seasonal info changed needs to propagate to the parent.
     		            if (changedToDefault ||seasonalChanged) {
     		                putAddrInMap(addr, mapParentIdAddr);
+                            addressIdsUpdated.add((addr.Id));
+
     		            //If it's default and its address info has changed.
     		            } else if (changed && addr.Default_Address__c) {
     		                putAddrInMap(addr, mapParentIdAddr);
+                            addressIdsUpdated.add((addr.Id));
     		            }
-                        addressIdsUpdated.add((addr.Id));
     		            i++;
                     }
 	            }
@@ -188,7 +190,7 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	        }
 
 	        // AFTER DELETE
-	        if (triggerAction == TDTM_Runnable.Action.AfterDelete) {
+	        if (triggerAction == TDTM_Runnable.Action.AfterDelete && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Delete)) {
 	            Integer i = 0;
 	            for (SObject addrOld : listOld) {
 		            // first go through all new/modified Addresses, and collect the list of parents to consider.

--- a/src/classes/ADDR_Addresses_TDTM.cls
+++ b/src/classes/ADDR_Addresses_TDTM.cls
@@ -36,27 +36,18 @@
 */
 public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 
-    /* @description Flag to prevent recursive call before insert */
-    public static boolean alreadyRunBeforeInsert = false;
-    /* @description Flag to prevent recursive call before update */
-    public static boolean alreadyRunBeforeUpdate = false;
-    /* @description Flag to prevent recursive call after insert */
-    public static boolean alreadyRunAfterInsert = false;
-    /* @description Flag to prevent recursive call after update */
-    public static boolean alreadyRunAfterUpdate = false;
-    /* @description Flag to prevent recursive call after delete */
-    public static boolean alreadyRunAfterDelete = false;
-
+    public static Set<Id> addressIdsInserted = new Set<Id>();
+    public static Set<Id> addressIdsUpdated = new Set<Id>();
     /*******************************************************************************************************
     * @description Turns class off.
     * @return void
     ********************************************************************************************************/
     public static void turnOff() {
-        alreadyRunBeforeInsert = true;
-        alreadyRunBeforeUpdate = true;
-        alreadyRunAfterInsert = true;
-        alreadyRunAfterUpdate = true;
-        alreadyRunAfterDelete = true;
+        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Insert);
+        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Update);
+        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Insert);
+        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Update);
+        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Delete);
     }
 
     /*******************************************************************************************************
@@ -64,11 +55,11 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
     * @return void
     ********************************************************************************************************/
     public static void turnOn() {
-        alreadyRunBeforeInsert = false;
-        alreadyRunBeforeUpdate = false;
-        alreadyRunAfterInsert = false;
-        alreadyRunAfterUpdate = false;
-        alreadyRunAfterDelete = false;
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Insert);
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Update);
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Insert);
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Update);
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Delete);
     }
 
     /*******************************************************************************************************
@@ -85,7 +76,11 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 
         DmlWrapper dmlWrapper = new DmlWrapper();
 
-        if(!alreadyRunBeforeInsert || !alreadyRunBeforeUpdate || !alreadyRunAfterInsert || !alreadyRunAfterUpdate || !alreadyRunAfterDelete) {
+        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Insert) 
+            || !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Update) 
+            || !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Insert) 
+            || !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Update) 
+            || !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Delete)) {
             //Turn off other address triggers
             ADDR_Account_TDTM.turnOff();
             ADDR_Contact_TDTM.turnOff();
@@ -100,7 +95,7 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	        Map<Id, Address__c> mapParentIdAddr = new Map<Id, Address__c>();
 
 	        // BEFORE INSERT
-	        if (!alreadyRunBeforeInsert && triggerAction == TDTM_Runnable.Action.BeforeInsert) {
+	        if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
 		        for (SObject so : listNew) {
 		            Address__c addr = (Address__c)so;
 	                // when an address is created as Default, we update its latest date fields
@@ -109,11 +104,11 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	                    addr.Latest_End_Date__c = null;
 	               }
 		        }
-		        alreadyRunBeforeInsert = true;
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Insert, true);
 	        }
 
 	        // BEFORE UPDATE
-	        if (!alreadyRunBeforeUpdate && triggerAction == TDTM_Runnable.Action.BeforeUpdate) {
+	        if (triggerAction == TDTM_Runnable.Action.BeforeUpdate) {
 	            Integer i = 0;
 		        for (SObject so : listNew) {
 		            Address__c addr = (Address__c)so;
@@ -130,17 +125,20 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	                }
 	                i++;
 		        }
-		        alreadyRunBeforeUpdate = true;
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Update, true);
 	        }
 
 	        // AFTER INSERT
-	        if (!alreadyRunAfterInsert && triggerAction == TDTM_Runnable.Action.AfterInsert) {
+	        if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
 	            for (SObject so : listNew) {
 	                Address__c addr = (Address__c)so;
-		            // a new address that is marked default or seasonal needs to propagate to the parent Account
-		            if (addr.Default_Address__c || ADDR_Seasonal_UTIL.isSeasonalAddr(addr)) {
-		                putAddrInMap(addr, mapParentIdAddr);
-		            }
+                    if (!addressIdsInserted.contains(addr.Id)){
+    		            // a new address that is marked default or seasonal needs to propagate to the parent Account
+    		            if (addr.Default_Address__c || ADDR_Seasonal_UTIL.isSeasonalAddr(addr)) {
+    		                putAddrInMap(addr, mapParentIdAddr);
+    		            }
+                        addressIdsInserted.add(addr.Id);
+                    }
 	            }
 
 	            if(mapParentIdAddr.size() > 0) {
@@ -155,11 +153,11 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	            // delete empty addresses
 	            deleteEmptyAddrs(listNew);
 
-	            alreadyRunAfterInsert = true;
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Insert, true);
 	        }
 
 	        // AFTER UPDATE
-	        if (!alreadyRunAfterUpdate && triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+	        if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
 	            Integer i = 0;
 	            for (SObject so : listNew) {
 	                Address__c addr = (Address__c)so;
@@ -168,14 +166,17 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 		            Boolean seasonalChanged =  ADDR_Seasonal_UTIL.isSeasonalChanged(addr, addrOld);
 		            Boolean changedToDefault = addr.Default_Address__c && (addr.Default_Address__c != addrOld.Default_Address__c);
 
-		            //An address that is marked default, of that had its seasonal info changed needs to propagate to the parent.
-		            if (changedToDefault ||seasonalChanged) {
-		                putAddrInMap(addr, mapParentIdAddr);
-		            //If it's default and its address info has changed.
-		            } else if (changed && addr.Default_Address__c) {
-		                putAddrInMap(addr, mapParentIdAddr);
-		            }
-		            i++;
+                    if (!addressIdsUpdated.contains(addr.Id)){
+    		            //An address that is marked default, of that had its seasonal info changed needs to propagate to the parent.
+    		            if (changedToDefault ||seasonalChanged) {
+    		                putAddrInMap(addr, mapParentIdAddr);
+    		            //If it's default and its address info has changed.
+    		            } else if (changed && addr.Default_Address__c) {
+    		                putAddrInMap(addr, mapParentIdAddr);
+    		            }
+                        addressIdsUpdated.add((addr.Id));
+    		            i++;
+                    }
 	            }
 
 	            if(mapParentIdAddr.size() > 0) {
@@ -183,11 +184,11 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	                processDmlErrors(dmlWrapper, mapParentIdAddr);
 	            }
 
-	            alreadyRunAfterUpdate = true;
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Update, true);
 	        }
 
 	        // AFTER DELETE
-	        if (!alreadyRunAfterDelete && triggerAction == TDTM_Runnable.Action.AfterDelete) {
+	        if (triggerAction == TDTM_Runnable.Action.AfterDelete) {
 	            Integer i = 0;
 	            for (SObject addrOld : listOld) {
 		            // first go through all new/modified Addresses, and collect the list of parents to consider.
@@ -206,8 +207,21 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	               processDmlErrors(dmlWrapper, mapParentIdAddr);
 	            }
 
-	            alreadyRunAfterDelete = true;
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Delete, true);
 	        }
+        }
+        TDTM_TriggerHandler.processDML(dmlWrapper, true);
+        dmlWrapper = null;
+        if (triggerAction == TDTM_Runnable.Action.BeforeInsert){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Insert, false);
+        }else if (triggerAction == TDTM_Runnable.Action.BeforeUpdate){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_Before_Update, false);
+        }else if (triggerAction == TDTM_Runnable.Action.AfterInsert){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Insert, false);
+        }else if (triggerAction == TDTM_Runnable.Action.AfterUpdate){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Update, false);
+        }else if (triggerAction == TDTM_Runnable.Action.AfterDelete){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Addresses_TDTM_After_Delete, false);
         }
         return dmlWrapper;
     }

--- a/src/classes/ADDR_AdminAcc_TEST.cls
+++ b/src/classes/ADDR_AdminAcc_TEST.cls
@@ -308,6 +308,7 @@ public with sharing class ADDR_AdminAcc_TEST {
         List<Address__c> listAddrOriginal = accsAddrs.addrs;
         
         // create additional addresses
+        ADDR_Addresses_TDTM.addressIdsInserted = new Set<Id>();
         List<Address__c> addrs = UTIL_UnitTestData_TEST.getMultipleTestAddresses(2);
         for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
             addrs[i].Parent_Account__c = accsAddrs.accs[i].Id;
@@ -321,6 +322,7 @@ public with sharing class ADDR_AdminAcc_TEST {
         
         // go back to original default addresses
         // added this extra set to test fix where we didn't use the correct default
+        ADDR_Addresses_TDTM.addressIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
             listAddrOriginal[i].Default_Address__c = true;
             listAddrOriginal[i].MailingStreet__c = 'Original Default Street' + i;
@@ -364,6 +366,7 @@ public with sharing class ADDR_AdminAcc_TEST {
         List<Address__c> addrs = accsAddrs.addrs;
         
         // modify some of the Account addresses directly
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
             accsAddrs.accs[i].BillingStreet = 'Direct Street Edit';
             accsAddrs.accs[i].BillingCity = 'Direct City Edit';
@@ -371,6 +374,7 @@ public with sharing class ADDR_AdminAcc_TEST {
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
         update accsAddrs.accs;
 
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
             accsAddrs.accs[i].BillingStreet = 'another Street Edit';
             accsAddrs.accs[i].BillingCity = 'another City Edit';
@@ -378,6 +382,7 @@ public with sharing class ADDR_AdminAcc_TEST {
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
         update accsAddrs.accs;
 
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
             accsAddrs.accs[i].BillingStreet = 'final Street Edit';
             accsAddrs.accs[i].BillingCity = 'final City Edit';
@@ -470,12 +475,14 @@ public with sharing class ADDR_AdminAcc_TEST {
             accsAddrs.accs[i].BillingStreet = 'Direct Street Edit';
         }
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();
         update accsAddrs.accs;
 
         for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
             accsAddrs.accs[i].BillingState = 'Washington';
         }
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();    
         update accsAddrs.accs;
 
         for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
@@ -483,8 +490,10 @@ public with sharing class ADDR_AdminAcc_TEST {
             accsAddrs.accs[i].BillingState = 'Oregon';
         }
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();    
         update accsAddrs.accs;
 
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();    
         for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
             accsAddrs.accs[i].BillingStreet = ' DIRECT STREET  EDIT ';  // only change casing.
         }
@@ -514,6 +523,7 @@ public with sharing class ADDR_AdminAcc_TEST {
             acc.BillingStreet = 'direct street  edit';
         }
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();    
         update accsAddrs.accs;
         
         // verify that the Account address
@@ -549,18 +559,21 @@ public with sharing class ADDR_AdminAcc_TEST {
         
         // modify some of the account addresses directly
         // NOTE: we only modify 1 field, so it will be treated as an update to an existing address!
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
             accsAddrs.accs[i].BillingStreet = 'Direct Street Edit';
         }
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
         update accsAddrs.accs;
 
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
             accsAddrs.accs[i].BillingState = 'Washington';
         }
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
         update accsAddrs.accs;
 
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
             accsAddrs.accs[i].BillingStreet = ' direct street  edit ';    // whitespace and casing should not count as real edit.
             accsAddrs.accs[i].BillingState = 'Oregon';

--- a/src/classes/ADDR_Contact_TDTM.cls
+++ b/src/classes/ADDR_Contact_TDTM.cls
@@ -36,20 +36,17 @@
 */
 public class ADDR_Contact_TDTM extends TDTM_Runnable {
     
-    /* @description Flag to prevent recursive call on insert */
-    public static Boolean alreadyRunAfterInsert = false;
-    /* @description Flag to prevent recursive call on update */
-    public static Boolean alreadyRunAfterUpdate = false;
     /* @description Flag used to indicate if this class is running as a result of an automatic Account creation caused by a Contact insert/update */
     public static Boolean afterAutomaticAccInsert = false;
-    
+    public static Set<Id> contactIdsInserted = new Set<Id>();
+    public static Set<Id> contactIdsUpdated = new Set<Id>();
     /*******************************************************************************************************
     * @description Turns class off.
     * @return void
     ********************************************************************************************************/
     public static void turnOff() {
-        alreadyRunAfterInsert = true;
-        alreadyRunAfterUpdate = true;
+        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Contact_TDTM_After_Insert);
+        TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Contact_TDTM_After_Update);
     }
     
     /*******************************************************************************************************
@@ -57,8 +54,8 @@ public class ADDR_Contact_TDTM extends TDTM_Runnable {
     * @return void
     ********************************************************************************************************/
     public static void turnOn() {
-        alreadyRunAfterInsert = false;
-        alreadyRunAfterUpdate = false;
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Contact_TDTM_After_Insert);
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Contact_TDTM_After_Update);
     }
     
     /*******************************************************************************************************
@@ -85,8 +82,9 @@ public class ADDR_Contact_TDTM extends TDTM_Runnable {
     TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
         
         DmlWrapper dmlWrapper = new DmlWrapper();
-            
-        if(!alreadyRunAfterInsert || !alreadyRunAfterUpdate) {
+           
+        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Contact_TDTM_After_Insert) 
+        	|| !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Contact_TDTM_After_Update)) {
 	    
 	       //Turn off other address triggers
             ADDR_Account_TDTM.turnOff();
@@ -118,8 +116,8 @@ public class ADDR_Contact_TDTM extends TDTM_Runnable {
 	        //contactsAddrGetFromHh should have a value in their Current_Address__c field
 	        	        
 	        // AFTER INSERT
-	        if (!alreadyRunAfterInsert && triggerAction == TDTM_Runnable.Action.AfterInsert) {
-	            alreadyRunAfterInsert = true;
+	        if (!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Contact_TDTM_After_Insert) && triggerAction == TDTM_Runnable.Action.AfterInsert) {
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Contact_TDTM_After_Insert, true);
 	            
 	            contactIDToAccRecTypeID = getContactIdToAccRecTypeId(listNew);
 	            	            
@@ -127,34 +125,39 @@ public class ADDR_Contact_TDTM extends TDTM_Runnable {
 	                Contact contact = (Contact)so;
 	                Boolean childOfHousehold = contactIDToAccRecTypeID.get(contact.ID) != null &&
 	                                           contactIDToAccRecTypeID.get(contact.ID) == UTIL_CustomSettingsFacade.getSettings().Household_Addresses_RecType__c;
-		            
-		            if (childOfHousehold) {
-		                if (ADDR_Addresses_UTIL.isContactAddressEmpty(contact)) {
-                           // if the contact has no address specified, pick up the HH default.
-                           contactsAddrInfoReset.add(contact);
-                        } else { //address info not empty
-	                        if (contact.is_Address_Override__c) {
-	                            //create non-default address record
-	                            contactsCreateAddrFrom.add(contact);
-	                        } else {
-	                            //Address record needs to be created as child of parent Account (can be done in the Before cuz we already have the ID to populate Parent_Account__c)
-	                            contactsCreateAddrFrom.add(contact);
-	                            //Address needs to be copied to parent Household, and all siblings that don't have an override.
-	                            contactIdParentIdAddrPropagate.put(contact.ID, contact.AccountID);
-	                        }
-		                }
-                    //For new Contacts that are using address management and are not children of Household, create the address object. We do it in the after, so that the
-                    //Parent_Contact__c field in Address can point back to the Contact.
-                    } else if (!childOfHousehold && UTIL_CustomSettingsFacade.getSettings().Contacts_Addresses_Enabled__c == true
-                    && !ADDR_Addresses_UTIL.isContactAddressEmpty(contact) && !afterAutomaticAccInsert) {
-		                contactsCreateAddrFrom.add(contact);
-		            }
+		            if (!contactIdsInserted.contains(contact.Id)){
+			            if (childOfHousehold) {
+			                if (ADDR_Addresses_UTIL.isContactAddressEmpty(contact)) {
+	                           // if the contact has no address specified, pick up the HH default.
+	                           contactsAddrInfoReset.add(contact);
+	                        } else { //address info not empty
+		                        if (contact.is_Address_Override__c) {
+		                            //create non-default address record
+		                            contactsCreateAddrFrom.add(contact);
+		                        } else {
+		                            //Address record needs to be created as child of parent Account (can be done in the Before cuz we already have the ID to populate Parent_Account__c)
+		                            contactsCreateAddrFrom.add(contact);
+		                            //Address needs to be copied to parent Household, and all siblings that don't have an override.
+		                            contactIdParentIdAddrPropagate.put(contact.ID, contact.AccountID);
+		                        }
+			                }
+	                    //For new Contacts that are using address management and are not children of Household, create the address object. We do it in the after, so that the
+	                    //Parent_Contact__c field in Address can point back to the Contact.
+	                    } else if (!childOfHousehold && UTIL_CustomSettingsFacade.getSettings().Contacts_Addresses_Enabled__c == true
+	                    && !ADDR_Addresses_UTIL.isContactAddressEmpty(contact) && !afterAutomaticAccInsert) {
+			                contactsCreateAddrFrom.add(contact);
+			            }
+			            if (!contactIdsInserted.contains(contact.Id)){
+			            	contactIdsInserted.add(contact.Id);
+			            }
+			        }
 	            }
 	        }
 	        
 	        // AFTER UPDATE
-	        if (!alreadyRunAfterUpdate && triggerAction == TDTM_Runnable.Action.AfterUpdate) {
-                alreadyRunAfterUpdate = true;
+	        if (!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Contact_TDTM_After_Update) 
+	        	&& triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+                TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Contact_TDTM_After_Update, true);
                 
                 //To know if a contact belongs to a household (if the parent account has Household record type)
                 contactIDToAccRecTypeID = getContactIdToAccRecTypeId(listNew);
@@ -169,75 +172,78 @@ public class ADDR_Contact_TDTM extends TDTM_Runnable {
 	                Boolean addrInfoChanged = ADDR_Addresses_UTIL.isContactAddressChanged(contact, contactOld);
 	                Boolean addrInfoCleared = !ADDR_Addresses_UTIL.iscontactAddressEmpty(contactOld) && ADDR_Addresses_UTIL.iscontactAddressEmpty(contact);
 	                Boolean currentAddressChanged = contact.Current_Address__c != contactOld.Current_Address__c && contact.Current_Address__c != null;
-	                	                
 	                // if they are changing to a new Current Address, but address info doesn't change, refill from it (both household and not household)
-                    if (currentAddressChanged) {
-                        if(!addrInfoChanged) {
-		                    contactsAddrGetFromHh.add(contact);
-		                    if(contact.is_Address_Override__c == true && contactOld.is_Address_Override__c == false)
-		                        addrIdsOverride.put(contact.Current_Address__c, true);
-                        }  else {
-                            UTIL_Debug.debug('****Current address changed & address info also changed');
-                        }
-                    } else {
-			            //If Contact Addresses are enabled, and the Contact is not the child of a HH
-			            if(!childOfHousehold && UTIL_CustomSettingsFacade.getSettings().Contacts_Addresses_Enabled__c == true) {
-			                //Non-household Contact addr info changed
-			                if(addrInfoChanged && !addrInfoCleared && !currentAddressChanged) {
-			                   contactsCreateAddrFrom.add(contact);
-			                //Non-household Contact addr info cleared
-			                } else if(addrInfoCleared) {
-			                   contactsAddrInfoCleared.add(contact);
-			                }
-			            } else if(childOfHousehold) {
-			                
-			                // if the Contact has been changed to a different household
-	                        if(contactOld != null && contact.AccountID != contactOld.AccountID && !currentAddressChanged) {
-	                            
-	                            // if no override, refill from the Default Address
-	                            if (!contact.is_Address_Override__c) {
-	                                //Refilling address info from parent Household (unless parent account address info is empty),
-	                                //and unless we are coming from the automatic parent Account creation.
-	                                if(!afterAutomaticAccInsert) {
-	                                   contactsAddrInfoReset.add(contact);
-	                                } else {
-	                                   contactsCreateAddrFrom.add(contact);
-	                                }
-	                            
-	                            //if override, create new Address record in new household
-	                            } else if(contact.is_Address_Override__c && !addrInfoChanged) {
-	                                contactsCreateAddrFrom.add(contact);
-	                            }
-			                //Contact not switching household
-	                        } else {
-				                // if household Contact addr info changed
-				                if (addrInfoChanged && !addrInfoCleared && !currentAddressChanged) {
-			                        //create new Address as child of parent Account
-			                        contactsCreateAddrFrom.add(contact);
-			                        if(!contact.is_Address_Override__c)
-			                            //Address needs to be copied to parent Household, and all siblings that don't have an override.
-			                            contactIdParentIdAddrPropagate.put(contact.ID, contact.AccountID);
-			                    
-			                    // if household Contact addr info cleare
-			                    } else if (addrInfoCleared) {
-				                    contactsAddrInfoCleared.add(contact);
-				                    //if the contact was not override, but pointing to the default Address instead
-				                    if(!contact.is_Address_Override__c)
-				                        contactsAddrPropagateDelete.add(contact);
-			                    
-			                    // if they are clearing isAddressOverride, refill from the Default Address
-				                } else if (!contact.is_Address_Override__c && contact.is_Address_Override__c != contactOld.is_Address_Override__c) {
-		                            contactsAddrInfoReset.add(contact);
-		                            // if tthere is an address to fill contact info from
-		                            if (contactOld.Current_Address__c != null) {
-		                                // old current address (before clearing override) needs to have Latest_End_Date updated
-		                                addrIdsOverride.put(contactOld.Current_Address__c, false);
+	                if (!contactIdsUpdated.contains(contact.Id)){
+	                    if (currentAddressChanged) {
+	                        if(!addrInfoChanged) {
+			                    contactsAddrGetFromHh.add(contact);
+			                    if(contact.is_Address_Override__c == true && contactOld.is_Address_Override__c == false)
+			                        addrIdsOverride.put(contact.Current_Address__c, true);
+	                        }  else {
+	                            UTIL_Debug.debug('****Current address changed & address info also changed');
+	                        }
+	                    } else {
+				            //If Contact Addresses are enabled, and the Contact is not the child of a HH
+				            if(!childOfHousehold && UTIL_CustomSettingsFacade.getSettings().Contacts_Addresses_Enabled__c == true) {
+				                //Non-household Contact addr info changed
+				                if(addrInfoChanged && !addrInfoCleared && !currentAddressChanged) {
+				                   contactsCreateAddrFrom.add(contact);
+				                //Non-household Contact addr info cleared
+				                } else if(addrInfoCleared) {
+				                   contactsAddrInfoCleared.add(contact);
+				                }
+				            } else if(childOfHousehold) {
+				                // if the Contact has been changed to a different household
+		                        if(contactOld != null && contact.AccountID != contactOld.AccountID && !currentAddressChanged) {
+		                            
+		                            // if no override, refill from the Default Address
+		                            if (!contact.is_Address_Override__c) {
+		                                //Refilling address info from parent Household (unless parent account address info is empty),
+		                                //and unless we are coming from the automatic parent Account creation.
+		                                if(!afterAutomaticAccInsert) {
+		                                   contactsAddrInfoReset.add(contact);
+		                                } else {
+		                                   contactsCreateAddrFrom.add(contact);
+		                                }
+		                            
+		                            //if override, create new Address record in new household
+		                            } else if(contact.is_Address_Override__c && !addrInfoChanged) {
+		                                contactsCreateAddrFrom.add(contact);
 		                            }
-		                        }
-			                }
-			            }
-                    }
-		            i++;
+				                //Contact not switching household
+		                        } else {
+					                // if household Contact addr info changed
+					                if (addrInfoChanged && !addrInfoCleared && !currentAddressChanged) {
+				                        //create new Address as child of parent Account
+				                        contactsCreateAddrFrom.add(contact);
+				                        if(!contact.is_Address_Override__c)
+				                            //Address needs to be copied to parent Household, and all siblings that don't have an override.
+				                            contactIdParentIdAddrPropagate.put(contact.ID, contact.AccountID);
+				                    
+				                    // if household Contact addr info cleare
+				                    } else if (addrInfoCleared) {
+					                    contactsAddrInfoCleared.add(contact);
+					                    //if the contact was not override, but pointing to the default Address instead
+					                    if(!contact.is_Address_Override__c)
+					                        contactsAddrPropagateDelete.add(contact);
+				                    
+				                    // if they are clearing isAddressOverride, refill from the Default Address
+					                } else if (!contact.is_Address_Override__c && contact.is_Address_Override__c != contactOld.is_Address_Override__c) {
+			                            contactsAddrInfoReset.add(contact);
+			                            // if tthere is an address to fill contact info from
+			                            if (contactOld.Current_Address__c != null) {
+			                                // old current address (before clearing override) needs to have Latest_End_Date updated
+			                                addrIdsOverride.put(contactOld.Current_Address__c, false);
+			                            }
+			                        }
+				                }
+				            }
+                    	}
+						if (!contactIdsUpdated.contains(contact.Id)){
+			            	contactIdsUpdated.add(contact.Id);
+			            }			            
+			            i++;
+		        	}
 	            }
 	        }
 
@@ -269,6 +275,15 @@ public class ADDR_Contact_TDTM extends TDTM_Runnable {
 	        if(contactsAddrPropagateDelete.size() > 0)
 	            propagateAddrInfoDelete(contactsAddrPropagateDelete, dmlWrapper);
         }
+
+		TDTM_TriggerHandler.processDML(dmlWrapper, true);
+		dmlWrapper = null;
+		if (triggerAction == TDTM_Runnable.Action.AfterInsert){
+			TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Contact_TDTM_After_Insert, false);
+		}else if (triggerAction == TDTM_Runnable.Action.AfterUpdate){
+        	TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.ADDR_Contact_TDTM_After_Update, false);
+		}
+
         return dmlWrapper;
     }
     

--- a/src/classes/ADDR_Contact_TEST.cls
+++ b/src/classes/ADDR_Contact_TEST.cls
@@ -450,6 +450,7 @@ public with sharing class ADDR_Contact_TEST {
         List<Address__c> ListAddrOriginal = contactsAddrs.addrs;
         
         // create additional addresses
+        ADDR_Addresses_TDTM.addressIdsInserted = new Set<Id>();
         List<Address__c> addrs = UTIL_UnitTestData_TEST.getMultipleTestAddresses(2);
         for (Integer i = 0; i < contactsAddrs.contacts.size(); i++) {
             addrs[i].Parent_Contact__c = contactsAddrs.contacts[i].Id;
@@ -459,7 +460,6 @@ public with sharing class ADDR_Contact_TEST {
         }
         turnOnAllAddrTriggers();
         insert addrs;
-        turnOnAllAddrTriggers();
         
         // go back to original default addresses
         // added this extra set to test fix where we didn't use the correct default
@@ -469,6 +469,7 @@ public with sharing class ADDR_Contact_TEST {
             ListAddrOriginal[i].MailingCity__c = 'Original Default City' + i;
         }
         turnOnAllAddrTriggers();
+        ADDR_Addresses_TDTM.addressIdsUpdated = new Set<Id>();
         Test.startTest();
         update ListAddrOriginal;
         turnOnAllAddrTriggers();
@@ -602,23 +603,23 @@ public with sharing class ADDR_Contact_TEST {
         turnOnAllAddrTriggers();
         update contactsAddrs.contacts;
 
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < contactsAddrs.contacts.size(); i++) {
             contactsAddrs.contacts[i].MailingState = 'Washington';
         }
-        turnOnAllAddrTriggers();
         update contactsAddrs.contacts;
 
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < contactsAddrs.contacts.size(); i++) {
             contactsAddrs.contacts[i].MailingStreet = ' direct street  edit ';  // whitespace and casing should not count as a real edit.
             contactsAddrs.contacts[i].MailingState = 'Oregon';
         }
-        turnOnAllAddrTriggers();
         update contactsAddrs.contacts;
 
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < contactsAddrs.contacts.size(); i++) {
             contactsAddrs.contacts[i].MailingStreet = ' DIRECT STREET  EDIT ';  // only change casing.
         }
-        turnOnAllAddrTriggers();
         Test.startTest();
         update contactsAddrs.contacts;
         Test.stopTest();
@@ -644,6 +645,7 @@ public with sharing class ADDR_Contact_TEST {
             Contact contact = contactsAddrs.contacts[i];
             contact.MailingStreet = 'direct street  edit';
         }
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         turnOnAllAddrTriggers();
         update contactsAddrs.contacts;
         
@@ -686,17 +688,17 @@ public with sharing class ADDR_Contact_TEST {
         turnOnAllAddrTriggers();
         update contactsAddrs.contacts;
 
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < contactsAddrs.contacts.size(); i++) {
             contactsAddrs.contacts[i].MailingState = 'Washington';
         }
-        turnOnAllAddrTriggers();
         update contactsAddrs.contacts;
 
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < contactsAddrs.contacts.size(); i++) {
             contactsAddrs.contacts[i].MailingStreet = ' direct street  edit ';    // whitespace and casing should not count as real edit.
             contactsAddrs.contacts[i].MailingState = 'Oregon';
         }
-        turnOnAllAddrTriggers();
         Test.startTest();
         update contactsAddrs.contacts;
         Test.stopTest();

--- a/src/classes/ADDR_HouseholdAcc_TEST.cls
+++ b/src/classes/ADDR_HouseholdAcc_TEST.cls
@@ -572,6 +572,7 @@ public with sharing class ADDR_HouseholdAcc_TEST {
         
         List<Address__c> listAddrOriginal = consAccsAddrs.addrs;
         
+        ADDR_Addresses_TDTM.addressIdsInserted = new Set<Id>();
         // create additional addresses
         List<Address__c> addrs = UTIL_UnitTestData_TEST.getMultipleTestAddresses(2);
         for (Integer i = 0; i < 2; i++) {
@@ -582,8 +583,8 @@ public with sharing class ADDR_HouseholdAcc_TEST {
         }
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
         insert addrs;
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
-        
+ 
+         ADDR_Addresses_TDTM.addressIdsUpdated = new Set<Id>();       
         // go back to original default addresses
         // added this extra set to test fix where we didn't use the correct default
         for (Integer i = 0; i < 2; i++) {
@@ -591,10 +592,8 @@ public with sharing class ADDR_HouseholdAcc_TEST {
             listAddrOriginal[i].MailingStreet__c = 'Original Default Street' + i;
             listAddrOriginal[i].MailingCity__c = 'Original Default City' + i;
         }
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
         Test.startTest();
         update listAddrOriginal;
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
         Test.stopTest();
 
         // verify that the HH and Contacts share the same address and it's new!
@@ -887,13 +886,14 @@ public with sharing class ADDR_HouseholdAcc_TEST {
             listCon.add(con);
         }
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         update listCon;
 
         for (Integer i = 0; i < 2; i++) {
             Contact con = consAccsAddrs.contacts[i*2 + i];
             con.MailingState = 'Washington';
         }
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         update listCon;
 
         for (Integer i = 0; i < 2; i++) {
@@ -901,7 +901,7 @@ public with sharing class ADDR_HouseholdAcc_TEST {
             con.MailingStreet = ' direct street  edit ';  // whitespace and casing should not count as a real edit.
             con.MailingState = 'Oregon';
         }
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         Test.startTest();
         update listCon;
         Test.stopTest();
@@ -941,6 +941,7 @@ public with sharing class ADDR_HouseholdAcc_TEST {
         
         // modify some of the contact addresses directly
         // NOTE: we only modify 1 field, so it will be treated as an update to an existing address!
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         List<Contact> listCon = new List<Contact>();
         for (Integer i = 0; i < 2; i++) {
             Contact con = consAccsAddrs.contacts[i*2 + i];
@@ -950,26 +951,26 @@ public with sharing class ADDR_HouseholdAcc_TEST {
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
         update listCon;
 
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < 2; i++) {
             Contact con = consAccsAddrs.contacts[i*2 + i];
             con.MailingState = 'Washington';
         }
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
         update listCon;
 
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < 2; i++) {
             Contact con = consAccsAddrs.contacts[i*2 + i];
             con.MailingStreet = ' direct street  edit ';  // whitespace and casing should not count as a real edit.
             con.MailingState = 'Oregon';
         }
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
         update listCon;
 
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < 2; i++) {
             Contact con = consAccsAddrs.contacts[i*2 + i];
             con.MailingStreet = ' DIRECT STREET  EDIT ';  // only change casing.
         }
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
         Test.startTest();
         update listCon;
         Test.stopTest();
@@ -993,6 +994,7 @@ public with sharing class ADDR_HouseholdAcc_TEST {
             System.assert(addr.MailingStreet__c.equals('DIRECT STREET  EDIT'));
         }
         
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();
         // now test that changing the case from the account updates all addresses
         for (Integer i = 0; i < 2; i++) {
             Account acc = consAccsAddrs.accs[i];
@@ -1034,6 +1036,7 @@ public with sharing class ADDR_HouseholdAcc_TEST {
         // this creates a default Address for each Account
         UTIL_UnitTestData_TEST.ContactsAccsWithAddrs consAccsAddrs = UTIL_UnitTestData_TEST.createTestConsAccsAddrs(2, 2, UTIL_Describe.getHhAccRecTypeID());
         
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();
         // modify some of the account addresses directly
         for (Integer i = 0; i < 2; i++) {
             Account acc = consAccsAddrs.accs[i];
@@ -1043,20 +1046,20 @@ public with sharing class ADDR_HouseholdAcc_TEST {
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
         update consAccsAddrs.accs;
 
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < 2; i++) {
             Account acc = consAccsAddrs.accs[i];
             acc.BillingStreet = 'another Street Edit';
             acc.BillingCity = 'another City Edit';
         }
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
         update consAccsAddrs.accs;
 
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < 2; i++) {
             Account acc = consAccsAddrs.accs[i];
             acc.BillingStreet = 'final Street Edit';
             acc.BillingCity = 'final City Edit';
         }
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
         Test.startTest();
         update consAccsAddrs.accs;
         Test.stopTest();
@@ -1106,19 +1109,19 @@ public with sharing class ADDR_HouseholdAcc_TEST {
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
         update consAccsAddrs.accs;
 
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < 2; i++) {
             Account acc = consAccsAddrs.accs[i];
             acc.BillingState = 'Washington';
         }
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
         update consAccsAddrs.accs;
 
+        ADDR_Account_TDTM.accountIdsUpdated = new Set<Id>();
         for (Integer i = 0; i < 2; i++) {
             Account acc = consAccsAddrs.accs[i];
             acc.BillingStreet = ' direct street  edit ';    // whitespace and casing should not count as real edit.
             acc.BillingState = 'Oregon';
         }
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
         Test.startTest();
         update consAccsAddrs.accs;
         Test.stopTest();
@@ -1424,8 +1427,7 @@ public with sharing class ADDR_HouseholdAcc_TEST {
         // Hack!  by setting our trigger handler as run,
         // we can insert the new seasonal addresses but not have them processed.
         // this way we can test the scheduled job!
-        ADDR_Addresses_TDTM.alreadyRunBeforeInsert = true;
-        ADDR_Addresses_TDTM.alreadyRunAfterInsert = true;
+        ADDR_Addresses_TDTM.turnOff();
         insert addrs;
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
 
@@ -1611,17 +1613,20 @@ public with sharing class ADDR_HouseholdAcc_TEST {
         UTIL_UnitTestData_TEST.ContactsAccsWithAddrs consAccsAddrs = UTIL_UnitTestData_TEST.createTestConsAccsAddrs(2, 2, UTIL_Describe.getHhAccRecTypeID());
 
         // create additional addresses
+        ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        ADDR_Addresses_TDTM.addressIdsInserted = new Set<Id>();
         List<Address__c> addrs = UTIL_UnitTestData_TEST.getMultipleTestAddresses(2);
+        ADDR_Addresses_TDTM.addressIdsInserted = new Set<Id>();
         for (Integer i = 0; i < 2; i++) {
             addrs[i].Parent_Account__c = consAccsAddrs.accs[i].Id;
             addrs[i].Default_Address__c = false;
             addrs[i].MailingStreet__c = 'override' + i;
             addrs[i].MailingCity__c = 'override' + i;
         }
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         insert addrs;
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
-        
+    
+        ADDR_Contact_TEST.turnOnAllAddrTriggers();    
         // set the contacts' address overrides
         List<Contact> listCon = new List<Contact>();
         for (Integer i = 0; i < 2; i++) {
@@ -1630,15 +1635,16 @@ public with sharing class ADDR_HouseholdAcc_TEST {
             con.is_Address_Override__c = true;
             listCon.add(con);
         }
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         update listCon;
  
+        ADDR_Contact_TEST.turnOnAllAddrTriggers();
         // modify override contact address info directly
         for (Contact con : listCon) {
             con.MailingStreet = 'Direct Street Edit';
             con.MailingCity = 'Direct City Edit';
         }
-        ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        ADDR_Contact_TDTM.contactIdsUpdated = new Set<Id>();
         Test.startTest();
         update listCon;
         Test.stopTest();

--- a/src/classes/ADDR_Seasonal_TEST.cls
+++ b/src/classes/ADDR_Seasonal_TEST.cls
@@ -654,8 +654,7 @@ private with sharing class ADDR_Seasonal_TEST {
         // Hack!  by setting our trigger handler as run,
         // we can insert the new seasonal addresses but not have them processed.
         // this way we can test the scheduled job!
-        ADDR_Addresses_TDTM.alreadyRunBeforeInsert = true;
-        ADDR_Addresses_TDTM.alreadyRunAfterInsert = true;
+        ADDR_Addresses_TDTM.turnoff();
         insert allNewAddrs;
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
 
@@ -805,8 +804,7 @@ private with sharing class ADDR_Seasonal_TEST {
         }
 
         // Turn off triggers because we need to update the addresses to test the batch.
-        ADDR_Addresses_TDTM.alreadyRunBeforeUpdate = true;
-        ADDR_Addresses_TDTM.alreadyRunAfterUpdate = true;
+        ADDR_Addresses_TDTM.turnOff();
         update allNewAddrs;
         ADDR_Contact_TEST.turnOnAllAddrTriggers();
 

--- a/src/classes/AFFL_AccChange_TDTM.cls
+++ b/src/classes/AFFL_AccChange_TDTM.cls
@@ -37,11 +37,6 @@
 public with sharing class AFFL_AccChange_TDTM extends TDTM_Runnable {
 
     /*******************************************************************************************************
-    * @description Static flags to prevent recursive call.
-    ********************************************************************************************************/
-    public static boolean afflAccChangeAlreadyRun = false;
-
-    /*******************************************************************************************************
     * @description Handles Affiliation management.
     * @param listNew the list of Accounts from trigger new.
     * @param listOld the list of Accounts from trigger old.
@@ -53,8 +48,7 @@ public with sharing class AFFL_AccChange_TDTM extends TDTM_Runnable {
     TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
 
         DmlWrapper dmlWrapper = new DmlWrapper();
-
-        if(!afflAccChangeAlreadyRun) {
+        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_AccChange_TDTM)) {
 
             AFFL_MultiRecordType_TDTM afflMulti = new AFFL_MultiRecordType_TDTM();
             Map<ID, Contact> relatedContactsMap;
@@ -112,11 +106,17 @@ public with sharing class AFFL_AccChange_TDTM extends TDTM_Runnable {
                            relatedContact.put(lookupFieldNameOld, null);
                            dmlWrapper.objectsToUpdate.add(relatedContact);
                        }
+                       TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_AccChange_TDTM, true);
                    }
                    i++;
                }
            }
-           afflAccChangeAlreadyRun = true;
+        }
+        TDTM_TriggerHandler.processDML(dmlWrapper, true);
+        dmlWrapper = null;  
+        if(triggerAction == TDTM_Runnable.Action.AfterUpdate)
+        {      
+          TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_AccChange_TDTM, false);
         }
         return dmlWrapper;
     }

--- a/src/classes/AFFL_AccRecordType_TDTM.cls
+++ b/src/classes/AFFL_AccRecordType_TDTM.cls
@@ -61,7 +61,6 @@ public class AFFL_AccRecordType_TDTM extends TDTM_Runnable {
          //
          //    B. If that account did not have a record type:
          //         --> the key affl lookup field for that type in Contacts affiliated to it needs to be populated
-
     	 if(newlist != null && newlist.size() > 0 && oldlist != null && oldlist.size() > 0) {
     	 	for (Integer i = 0; i < newlist.size(); i++) {
     	 	    SObject so = newlist[i];
@@ -90,7 +89,6 @@ public class AFFL_AccRecordType_TDTM extends TDTM_Runnable {
 			        }
     	 		}
 		    }
-
 		    updatePrimaryAfflsOnChange(accsTypeChanged, dmlWrapper);
             updatePrimaryAfflsOnAdd(accsTypeAdded, dmlWrapper);
     	 }

--- a/src/classes/AFFL_AccRecordType_TEST.cls
+++ b/src/classes/AFFL_AccRecordType_TEST.cls
@@ -76,7 +76,6 @@ public with sharing class AFFL_AccRecordType_TEST {
         //Change the account record type to Business Organization
         acc.RecordTypeId = orgRecTypeID;
         Test.startTest();
-        AFFL_MultiRecordType_TDTM.afflMultiHasRunBefore = false;
         update acc;
         Test.stopTest();
         
@@ -110,7 +109,7 @@ public with sharing class AFFL_AccRecordType_TEST {
         Account bizOrg = new Account(Name = 'BizOrg', RecordTypeId = orgRecTypeID);
         insert bizOrg;
         Affiliation__c bizAffl = new Affiliation__c(Contact__c = contact.ID, Account__c = bizOrg.ID, Primary__c = true);
-        AFFL_MultiRecordType_TDTM.afflMultiHasRunBefore = false;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before, false);
         insert bizAffl;
         
         //Verify the primary business organization field was populated
@@ -122,7 +121,6 @@ public with sharing class AFFL_AccRecordType_TEST {
         household.RecordTypeId = orgRecTypeID;
         bizOrg.RecordTypeId = householdRecTypeID;
         Test.startTest();
-        AFFL_MultiRecordType_TDTM.afflMultiHasRunBefore = false;
         update new Account[]{household, bizOrg};
         Test.stopTest();
         
@@ -157,7 +155,7 @@ public with sharing class AFFL_AccRecordType_TEST {
         insert bizOrg;
         UTIL_Debug.debug('****Biz org ID: ' + bizOrg.ID);
         Affiliation__c bizAffl = new Affiliation__c(Contact__c = contact.ID, Account__c = bizOrg.ID, Primary__c = true);
-        AFFL_MultiRecordType_TDTM.afflMultiHasRunBefore = false;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before, false);
         insert bizAffl;
         
         //Verify the primary business organization field was populated
@@ -169,7 +167,6 @@ public with sharing class AFFL_AccRecordType_TEST {
         //Change the account record type of parent Household to Business Organization
         household.RecordTypeId = orgRecTypeID;
         Test.startTest();
-        AFFL_MultiRecordType_TDTM.afflMultiHasRunBefore = false;
         update household;
         Test.stopTest();
         
@@ -196,7 +193,7 @@ public with sharing class AFFL_AccRecordType_TEST {
         Account acc = new Account(Name = 'AccNoType', RecordTypeId = UTIL_Describe.getAdminAccRecTypeID());
         insert acc;
         Affiliation__c affl = new Affiliation__c(Contact__c = contact.ID, Account__c = acc.ID, Primary__c = true);
-        AFFL_MultiRecordType_TDTM.afflMultiHasRunBefore = false;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before, false);
         insert affl;
         
         //Verify Primary Business Organization field was not populated

--- a/src/classes/AFFL_AccRecordType_TEST.cls
+++ b/src/classes/AFFL_AccRecordType_TEST.cls
@@ -72,7 +72,7 @@ public with sharing class AFFL_AccRecordType_TEST {
         contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
         System.assertNotEquals(null, contact.Primary_Household__c);
         
-        AFFL_MultiRecordType_TDTM.afflMadePrimary = false;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary, false);
         Account acc = [select RecordTypeId from Account where ID=:contact.Account.ID];
         //Change the account record type to Business Organization
         acc.RecordTypeId = orgRecTypeID;
@@ -121,7 +121,7 @@ public with sharing class AFFL_AccRecordType_TEST {
         household.RecordTypeId = orgRecTypeID;
         bizOrg.RecordTypeId = householdRecTypeID;
         Test.startTest();
-        AFFL_MultiRecordType_TDTM.afflMadePrimary = false;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary, false);
         update new Account[]{household, bizOrg};
         Test.stopTest();
         
@@ -168,7 +168,7 @@ public with sharing class AFFL_AccRecordType_TEST {
         //Change the account record type of parent Household to Business Organization
         household.RecordTypeId = orgRecTypeID;
         Test.startTest();
-        AFFL_MultiRecordType_TDTM.afflMadePrimary = false;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary, false);
         update household;
         Test.stopTest();
         

--- a/src/classes/AFFL_AccRecordType_TEST.cls
+++ b/src/classes/AFFL_AccRecordType_TEST.cls
@@ -72,6 +72,7 @@ public with sharing class AFFL_AccRecordType_TEST {
         contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
         System.assertNotEquals(null, contact.Primary_Household__c);
         
+        AFFL_MultiRecordType_TDTM.afflMadePrimary = false;
         Account acc = [select RecordTypeId from Account where ID=:contact.Account.ID];
         //Change the account record type to Business Organization
         acc.RecordTypeId = orgRecTypeID;
@@ -109,7 +110,6 @@ public with sharing class AFFL_AccRecordType_TEST {
         Account bizOrg = new Account(Name = 'BizOrg', RecordTypeId = orgRecTypeID);
         insert bizOrg;
         Affiliation__c bizAffl = new Affiliation__c(Contact__c = contact.ID, Account__c = bizOrg.ID, Primary__c = true);
-        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before, false);
         insert bizAffl;
         
         //Verify the primary business organization field was populated
@@ -121,6 +121,7 @@ public with sharing class AFFL_AccRecordType_TEST {
         household.RecordTypeId = orgRecTypeID;
         bizOrg.RecordTypeId = householdRecTypeID;
         Test.startTest();
+        AFFL_MultiRecordType_TDTM.afflMadePrimary = false;
         update new Account[]{household, bizOrg};
         Test.stopTest();
         
@@ -155,7 +156,7 @@ public with sharing class AFFL_AccRecordType_TEST {
         insert bizOrg;
         UTIL_Debug.debug('****Biz org ID: ' + bizOrg.ID);
         Affiliation__c bizAffl = new Affiliation__c(Contact__c = contact.ID, Account__c = bizOrg.ID, Primary__c = true);
-        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before, false);
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert, false);
         insert bizAffl;
         
         //Verify the primary business organization field was populated
@@ -167,6 +168,7 @@ public with sharing class AFFL_AccRecordType_TEST {
         //Change the account record type of parent Household to Business Organization
         household.RecordTypeId = orgRecTypeID;
         Test.startTest();
+        AFFL_MultiRecordType_TDTM.afflMadePrimary = false;
         update household;
         Test.stopTest();
         
@@ -193,7 +195,7 @@ public with sharing class AFFL_AccRecordType_TEST {
         Account acc = new Account(Name = 'AccNoType', RecordTypeId = UTIL_Describe.getAdminAccRecTypeID());
         insert acc;
         Affiliation__c affl = new Affiliation__c(Contact__c = contact.ID, Account__c = acc.ID, Primary__c = true);
-        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before, false);
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert, false);
         insert affl;
         
         //Verify Primary Business Organization field was not populated

--- a/src/classes/AFFL_ContactAccChange_TEST.cls
+++ b/src/classes/AFFL_ContactAccChange_TEST.cls
@@ -180,11 +180,11 @@ public with sharing class AFFL_ContactAccChange_TEST {
     public static void resetAfflFlags() {
         TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM);
         
-        CON_PrimaryAffls_TDTM.keyAfflLookupUpdated = false;
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated);
         TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Insert);
         TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
         
-        AFFL_MultiRecordType_TDTM.afflMadePrimary = false;
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary);
         TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert);
         TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update);
     }    

--- a/src/classes/AFFL_ContactAccChange_TEST.cls
+++ b/src/classes/AFFL_ContactAccChange_TEST.cls
@@ -178,14 +178,14 @@ public with sharing class AFFL_ContactAccChange_TEST {
     }
     
     public static void resetAfflFlags() {
-        AFFL_ContactChange_TDTM.afflContactChangeAlreadyRun = false;
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM);
         
         CON_PrimaryAffls_TDTM.keyAfflLookupUpdated = false;
-        CON_PrimaryAffls_TDTM.alreadyRunAfterInsert = false;
-        CON_PrimaryAffls_TDTM.alreadyRunAfterUpdate = false;
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
         
         AFFL_MultiRecordType_TDTM.afflMadePrimary = false;
-        AFFL_MultiRecordType_TDTM.afflMultiHasRunBefore = false;
-        AFFL_MultiRecordType_TDTM.afflMultiHasRunAfter = false;
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before);
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After);
     }    
 }

--- a/src/classes/AFFL_ContactAccChange_TEST.cls
+++ b/src/classes/AFFL_ContactAccChange_TEST.cls
@@ -181,11 +181,11 @@ public with sharing class AFFL_ContactAccChange_TEST {
         TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM);
         
         CON_PrimaryAffls_TDTM.keyAfflLookupUpdated = false;
-        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Insert);
         TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
         
         AFFL_MultiRecordType_TDTM.afflMadePrimary = false;
-        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before);
-        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After);
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert);
+        TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update);
     }    
 }

--- a/src/classes/AFFL_ContactChange_TDTM.cls
+++ b/src/classes/AFFL_ContactChange_TDTM.cls
@@ -37,11 +37,6 @@
 public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 
     /*******************************************************************************************************
-    * @description Static flags to prevent recursive call.
-    ********************************************************************************************************/
-    public static boolean afflContactChangeAlreadyRun = false;
-
-    /*******************************************************************************************************
     * @description Handles Affiliation management.
     * @param listNew the list of Accounts from trigger new.
     * @param listOld the list of Accounts from trigger old.
@@ -54,7 +49,7 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 
         DmlWrapper dmlWrapper = new DmlWrapper();
 
-        if(!afflContactChangeAlreadyRun) {
+        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM)) {
 
             AFFL_MultiRecordType_TDTM afflMulti = new AFFL_MultiRecordType_TDTM();
             Map<ID, Contact> newRelatedContactsMap, oldRelatedContactsMap;
@@ -116,8 +111,11 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 	               i++;
 	           }
 	       }
-	       afflContactChangeAlreadyRun = true;
+           TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM, true);
         }
+        TDTM_TriggerHandler.processDML(dmlWrapper, true);
+        dmlWrapper = null;        
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM, false);
         return dmlWrapper;
     }
 }

--- a/src/classes/AFFL_MultiRecordType_TDTM.cls
+++ b/src/classes/AFFL_MultiRecordType_TDTM.cls
@@ -59,7 +59,9 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
     	 DmlWrapper dmlWrapper = new DmlWrapper();
 		 List<Affiliation__c> afflsMadePrimary = new List<Affiliation__c>();
 
-		 if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before)) {
+		 if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert)
+		 	|| !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update)
+		 	|| !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Insert)) {
 
 			 //Query all the primary affiliation lookup fields on the contact - they are not available in the trigger.
 			 Map<ID, Contact> relatedContactsMap;
@@ -80,16 +82,17 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 
 		            //BEFORE INSERT - we do it in the Before so we don't get the affiliation we just created when we query for
 		            //affls of the same type.
-		            if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
+		            if (triggerAction == TDTM_Runnable.Action.BeforeInsert && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert)) {
 		                if (affl.Primary__c && affl.Contact__c != null && affl.Account__c != null) {
 		            	    afflsMadePrimary.add(affl);
 		            	    afflMadePrimary = true;
 		            	    populateKeyAffls(affl, lookupFieldName, relatedContact, dmlWrapper);
 		                }
+                        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert, true);
 		            }
 
 		            // AFTER UPDATE
-		            if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+		            if (triggerAction == TDTM_Runnable.Action.AfterUpdate && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update)) {
 		                Affiliation__c afflOld = (Affiliation__c)oldlist[i];
 
 		                //If a primary affiliation is made nonprimary the key affiliation field on the contact needs to be cleared.
@@ -99,6 +102,7 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 		                	     relatedContact.put(lookupFieldName, null);
 		                	     dmlWrapper.objectsToUpdate.add(relatedContact);
 		                	}
+	                        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update, true);
 		                }
 
 		                //If a non-primary affiliation is made primary the key affiliation field on the contact needs to be filled,
@@ -130,23 +134,26 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 		            }
 		    	 }
 	    	 }
-           TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before, true);
         }
 
         //AFTER INSERT
-        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After) && triggerAction == TDTM_Runnable.Action.AfterInsert) {
+        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Insert) && triggerAction == TDTM_Runnable.Action.AfterInsert) {
 			 if(newlist != null && newlist.size() > 0) {
 		    	 for (SObject so : newlist) {
 		            Affiliation__c affl = (Affiliation__c)so;
 					createProgramEnrollmentIfNecessary(affl, dmlWrapper);
 		    	 }
 			 }
-           TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After, true);
+           TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Insert, true);
 		}
 		TDTM_TriggerHandler.processDML(dmlWrapper, true);
         dmlWrapper = null;
         if (triggerAction == TDTM_Runnable.Action.AfterInsert){
-            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After, false);
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Insert, false);
+        }else if (triggerAction == TDTM_Runnable.Action.BeforeInsert){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert, false);        	
+        }else if (triggerAction == TDTM_Runnable.Action.AfterUpdate){
+        	TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update, false);
         }
 
     	return dmlWrapper;

--- a/src/classes/AFFL_MultiRecordType_TDTM.cls
+++ b/src/classes/AFFL_MultiRecordType_TDTM.cls
@@ -39,12 +39,6 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
     //Get the primary affiliation fields defined in the Affiliation Mappings
     public static AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
 
-    /*******************************************************************************************************
-    * @description Static flag to prevent CON_PrimaryAffls_TDTM from creating a new Affiliations when an existing
-    * Affiliation is made primary.
-    ********************************************************************************************************/
-    public static Boolean afflMadePrimary = false;
-
 	/*******************************************************************************************************
     * @description Handles Affiliation management.
     * @param listNew the list of Accounts from trigger new.
@@ -58,7 +52,6 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 
     	 DmlWrapper dmlWrapper = new DmlWrapper();
 		 List<Affiliation__c> afflsMadePrimary = new List<Affiliation__c>();
-
 		 if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert)
 		 	|| !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update)
 		 	|| !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Insert)) {
@@ -85,7 +78,7 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 		            if (triggerAction == TDTM_Runnable.Action.BeforeInsert && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert)) {
 		                if (affl.Primary__c && affl.Contact__c != null && affl.Account__c != null) {
 		            	    afflsMadePrimary.add(affl);
-		            	    afflMadePrimary = true;
+            				TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary, true);
 		            	    populateKeyAffls(affl, lookupFieldName, relatedContact, dmlWrapper);
 		                }
                         TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert, true);
@@ -98,20 +91,20 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 		                //If a primary affiliation is made nonprimary the key affiliation field on the contact needs to be cleared.
 		                if (afflOld.Primary__c && !affl.Primary__c && relatedContact.get(lookupFieldName) == affl.Account__c) {
 		                    UTIL_Debug.debug('****AFFL_MultiRecordType_TDTM - clearing field ' + lookupFieldName);
-		                	if(CON_PrimaryAffls_TDTM.keyAfflLookupUpdated == false) {
+		                	if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated)) {
 		                	     relatedContact.put(lookupFieldName, null);
 		                	     dmlWrapper.objectsToUpdate.add(relatedContact);
 		                	}
-	                        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update, true);
 		                }
 
 		                //If a non-primary affiliation is made primary the key affiliation field on the contact needs to be filled,
 		                //an any other primary affiliation of the same type needs to be made non-primary.
 		                if (affl.Primary__c && !afflOld.Primary__c && affl.Contact__c != null && affl.Account__c != null) {
 	                        afflsMadePrimary.add(affl);
-	                        afflMadePrimary = true;
+            				TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary, true);
                             populateKeyAffls(affl, lookupFieldName, relatedContact, dmlWrapper);
 		                }
+                        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update, true);
 		            }
 		        	i++;
 		    	 }
@@ -162,7 +155,7 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
     public void processAfflDeleted(Affiliation__c afflOld, Contact relatedContact, String lookupFieldName, DmlWrapper dmlWrapper) {
         //If the affl is primary, and the lookup field of this type is pointing to the account that is part of the affl ==> clear the lookup
 	    if(afflOld.Primary__c && lookupFieldName != null && relatedContact.get(lookupFieldName) == afflOld.Account__c) {
-	        if(CON_PrimaryAffls_TDTM.keyAfflLookupUpdated == false) {
+	        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated)) {
 	            relatedContact.put(lookupFieldName, null);
 	            dmlWrapper.objectsToUpdate.add(relatedContact);
 	        }
@@ -206,7 +199,7 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
     private void populateKeyAffls(Affiliation__c affl, String lookupFieldName, Contact relatedContact, DmlWrapper dmlWrapper) {
         //If the reason why Affiliations have been made primary is that key affiliation fields on Contact have been populated,
         //we don't need to try populating them. In fact, this causes an error notification to be sent (W-009272).
-        if(CON_PrimaryAffls_TDTM.keyAfflLookupUpdated == false) {
+        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated)) {
 	        //If we have a mapping, populate the lookup field defined in the mapping.
 	        if(!String.isBlank(lookupFieldName)) {
 	        	UTIL_Debug.debug('****MRT: populating lookup field ' + lookupFieldName + ' on contact');

--- a/src/classes/AFFL_MultiRecordType_TDTM.cls
+++ b/src/classes/AFFL_MultiRecordType_TDTM.cls
@@ -81,7 +81,6 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
             				TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary, true);
 		            	    populateKeyAffls(affl, lookupFieldName, relatedContact, dmlWrapper);
 		                }
-                        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert, true);
 		            }
 
 		            // AFTER UPDATE
@@ -104,10 +103,17 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
             				TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary, true);
                             populateKeyAffls(affl, lookupFieldName, relatedContact, dmlWrapper);
 		                }
-                        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update, true);
 		            }
 		        	i++;
 		    	 }
+		    	 if (triggerAction == TDTM_Runnable.Action.BeforeInsert)
+		    	 {
+	             	TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert, true);
+	             }else if (triggerAction == TDTM_Runnable.Action.AfterUpdate)
+	             {
+                    TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update, true);
+
+	             }
 		    	 if(afflsMadePrimary.size() > 0) {
 		    	     uncheckOtherPrimariesSameType(afflsMadePrimary, dmlWrapper);
 		    	 }
@@ -144,9 +150,11 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
         if (triggerAction == TDTM_Runnable.Action.AfterInsert){
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Insert, false);
         }else if (triggerAction == TDTM_Runnable.Action.BeforeInsert){
-            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert, false);        	
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert, false);
+			TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary);        	
         }else if (triggerAction == TDTM_Runnable.Action.AfterUpdate){
         	TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update, false);
+			TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary);        	
         }
 
     	return dmlWrapper;

--- a/src/classes/AFFL_MultiRecordType_TDTM.cls
+++ b/src/classes/AFFL_MultiRecordType_TDTM.cls
@@ -46,12 +46,6 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
     public static Boolean afflMadePrimary = false;
 
 	/*******************************************************************************************************
-    * @description Static flags to prevent recursive call.
-    ********************************************************************************************************/
-    public static boolean afflMultiHasRunBefore = false;
-	public static boolean afflMultiHasRunAfter = false;
-
-	/*******************************************************************************************************
     * @description Handles Affiliation management.
     * @param listNew the list of Accounts from trigger new.
     * @param listOld the list of Accounts from trigger old.
@@ -65,7 +59,7 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
     	 DmlWrapper dmlWrapper = new DmlWrapper();
 		 List<Affiliation__c> afflsMadePrimary = new List<Affiliation__c>();
 
-		 if(!afflMultiHasRunBefore) {
+		 if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before)) {
 
 			 //Query all the primary affiliation lookup fields on the contact - they are not available in the trigger.
 			 Map<ID, Contact> relatedContactsMap;
@@ -136,21 +130,26 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 		            }
 		    	 }
 	    	 }
-	    	 afflMultiHasRunBefore = true;
+           TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before, true);
         }
 
         //AFTER INSERT
-        if(!afflMultiHasRunAfter && triggerAction == TDTM_Runnable.Action.AfterInsert) {
+        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After) && triggerAction == TDTM_Runnable.Action.AfterInsert) {
 			 if(newlist != null && newlist.size() > 0) {
 		    	 for (SObject so : newlist) {
 		            Affiliation__c affl = (Affiliation__c)so;
 					createProgramEnrollmentIfNecessary(affl, dmlWrapper);
 		    	 }
 			 }
-			 afflMultiHasRunAfter = true;
+           TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After, true);
 		}
+		TDTM_TriggerHandler.processDML(dmlWrapper, true);
+        dmlWrapper = null;
+        if (triggerAction == TDTM_Runnable.Action.AfterInsert){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After, false);
+        }
 
-        return dmlWrapper;
+    	return dmlWrapper;
     }
 
     public void processAfflDeleted(Affiliation__c afflOld, Contact relatedContact, String lookupFieldName, DmlWrapper dmlWrapper) {

--- a/src/classes/CCON_ConnectionBackfill_TEST.cls
+++ b/src/classes/CCON_ConnectionBackfill_TEST.cls
@@ -51,7 +51,7 @@ public with sharing class CCON_ConnectionBackfill_TEST {
 
     private static void setup() {
 
-        COFF_Affiliation_TDTM.hasRunCoffTrigger = true;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, true);
 
         // Create university
         university = new Account(Name = 'Advanced University');
@@ -63,6 +63,7 @@ public with sharing class CCON_ConnectionBackfill_TEST {
         // Create Psychology department
         psychologyDept = new Account(Name = 'Psychology Department', Parent = university);
 
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, true);
         insert new List<Account>{
             biologyDept,
             psychologyDept
@@ -79,21 +80,25 @@ public with sharing class CCON_ConnectionBackfill_TEST {
         psychologyCourse = new Course__c(Course_ID__c = 'Psychology 101', Account__c = psychologyDept.Id, Credit_Hours__c = 40,
            Description__c = 'Psychology 101');
 
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, true);
         insert new List<SObject>{
             term,
             biologyCourse,
             psychologyCourse
         };
 
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, true);
         facultyContacts = new List<Contact>();
         facultyContacts = createContacts(20, 'faculty');
         insert facultyContacts;
 
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, true);
         studentContacts = new List<Contact>();
         studentContacts = createContacts(20, 'student');
         insert studentContacts;
 
         // Create Biology Offerings and Psychology Offerings
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, true);
         offeringsList = new List<Course_Offering__c>();
         facultyConnections = new List<Course_Enrollment__c>();
         createCourseOfferingsWithFaculty(biologyCourse.Id, term.Id, facultyContacts);
@@ -111,7 +116,6 @@ public with sharing class CCON_ConnectionBackfill_TEST {
                 Student_RecType__c = UTIL_Describe.getStudentConnectionRecType()
             )
         );
-        COFF_Affiliation_TDTM.hasRunCoffTrigger = false;
     }
 
     @isTest

--- a/src/classes/CCON_Faculty_TEST.cls
+++ b/src/classes/CCON_Faculty_TEST.cls
@@ -334,6 +334,7 @@ public with sharing class CCON_Faculty_TEST {
             System.assertEquals(faculty.Id, offering.Faculty__c);
 
             // Mark the second Course Connection as Primary.
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
             conn2.Primary__c = true;
             Test.startTest();
             update conn2;
@@ -484,7 +485,7 @@ public with sharing class CCON_Faculty_TEST {
 
     @isTest
     public static void testGetAffiliations() {
-        COFF_Affiliation_TDTM.hasRunCoffTrigger = true;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, true);
         setup();
 
         Affiliation__c affl = new Affiliation__c(Contact__c = faculty.Id, Account__c = dpt.Id, Role__c = 'Faculty');
@@ -508,7 +509,7 @@ public with sharing class CCON_Faculty_TEST {
 
     @isTest
     public static void testGetContactIdAccountIdAffiliationsList() {
-        COFF_Affiliation_TDTM.hasRunCoffTrigger = true;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, true);
         setup();
 
         Affiliation__c affl = new Affiliation__c(Contact__c = faculty.Id, Account__c = dpt.Id, Role__c = 'Faculty');

--- a/src/classes/COFF_Affiliation_TDTM.cls
+++ b/src/classes/COFF_Affiliation_TDTM.cls
@@ -37,11 +37,6 @@
 public class COFF_Affiliation_TDTM extends TDTM_Runnable {
 
    /*******************************************************************************************************
-    * @description static flag to prevent recursive call
-    */
-    public static boolean hasRunCoffTrigger = false;
-
-   /*******************************************************************************************************
     * @description Handles Affiliation management for Course Offering.
                    Populates Start and End Date from Term, if fields are empty.
     * @param listNew the list of Accounts from trigger new.
@@ -54,9 +49,8 @@ public class COFF_Affiliation_TDTM extends TDTM_Runnable {
     TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
 
         DmlWrapper dmlWrapper = new DmlWrapper();
-
         // prevent recursion
-        if (!hasRunCoffTrigger) {
+        if (!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM)) {
 
             List<Course_Offering__c> offsWithNewFaculty = new List<Course_Offering__c>();
             Set<Id> offsWithChangedFaculty = new Set<Id>();
@@ -179,7 +173,6 @@ public class COFF_Affiliation_TDTM extends TDTM_Runnable {
                     }
                 }
             }
-
             // If new faculty added to existing Course Offering
             if (offsWithNewFaculty.size() > 0) {
                 if (UTIL_CustomSettingsFacade.courseConnectionsEnabled()) {
@@ -213,10 +206,15 @@ public class COFF_Affiliation_TDTM extends TDTM_Runnable {
                 deleteAfflsEnrolls(facultyCleanupIDs, offsWithRemovedFaculty, dmlWrapper); //Passing dmlWrapper because there's more than one DML to perform
             }
 
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, true);
+
             dmlWrapper.objectsToUpdate.addAll(objectsToUpdate);
             dmlWrapper.objectsToInsert.addAll(objectsToInsert);
             dmlWrapper.objectsToDelete.addAll(objectsToDelete);
         }
+        TDTM_TriggerHandler.processDML(dmlWrapper, true);
+        dmlWrapper = null;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
         return dmlWrapper;
     }
 
@@ -228,7 +226,6 @@ public class COFF_Affiliation_TDTM extends TDTM_Runnable {
     private void createOrLinkAffls(List<Course_Offering__c> offsWithNewFaculty, List<Id> newFacultyIDs, List<Course_Enrollment__c> courseEnrllsToInsert) {
          //Find all Affls for all Faculty members in the trigger.
          Map<Id, List<Affiliation__c>> facultyIDtoAffls = getAfflsForContact(newFacultyIDs);
-
          //Automatically create an Affiliation record if a Course Offering record with a value in the Faculty field has been created,
          //and no Affl to the parent Department exists.
          List<Affiliation__c> afflsToInsert = new List<Affiliation__c>();

--- a/src/classes/COFF_Affiliation_TEST.cls
+++ b/src/classes/COFF_Affiliation_TEST.cls
@@ -138,6 +138,7 @@ public with sharing class COFF_Affiliation_TEST {
         //Add faculty to offering
         offering.Faculty__c = faculty.Id;
         Test.startTest();
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
         update offering;
         Test.stopTest();
 
@@ -181,6 +182,7 @@ public with sharing class COFF_Affiliation_TEST {
         //Add faculty to offering
         offering.Faculty__c = faculty.Id;
         Test.startTest();
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
         update offering;
         Test.stopTest();
 
@@ -222,6 +224,7 @@ public with sharing class COFF_Affiliation_TEST {
         //Update Offering
         offering.Faculty__c = faculty2.Id;
         Test.startTest();
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);        
         update offering;
         Test.stopTest();
 
@@ -275,6 +278,7 @@ public with sharing class COFF_Affiliation_TEST {
             //Update Offering
             offering.Faculty__c = faculty2.Id;
             Test.startTest();
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
             update offering;
             Test.stopTest();
 
@@ -321,6 +325,7 @@ public with sharing class COFF_Affiliation_TEST {
             //Update Offering
             offering.Faculty__c = faculty.Id;
             Test.startTest();
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
             update offering;
             Test.stopTest();
 
@@ -357,6 +362,7 @@ public with sharing class COFF_Affiliation_TEST {
             //Update Offering
             offering.Faculty__c = faculty2.Id;
             Test.startTest();
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
             update offering;
             Test.stopTest();
 
@@ -391,6 +397,7 @@ public with sharing class COFF_Affiliation_TEST {
         //Update Offering
         offering.Faculty__c = null;
         Test.startTest();
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
         update offering;
         Test.stopTest();
 
@@ -411,7 +418,8 @@ public with sharing class COFF_Affiliation_TEST {
         Course_Offering__c firstOffering = new Course_Offering__c(Section_Id__c = 'BIO-101 Spring 16 - 1', Course__c = course.Id,
         Faculty__c = faculty.Id, Term__c = term.Id, Capacity__c = 200);
         insert firstOffering;
-
+            
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
         //Create second Course Offering with Faculty member
         Course_Offering__c secondOffering = new Course_Offering__c(Section_Id__c = 'BIO-101 Spring 16 - 2', Course__c = course.Id,
         Faculty__c = faculty.Id, Term__c = term.Id, Capacity__c = 200);
@@ -435,6 +443,7 @@ public with sharing class COFF_Affiliation_TEST {
         // Update first Offering
         firstOffering.Faculty__c = null;
         Test.startTest();
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
         update firstOffering;
         Test.stopTest();
 
@@ -460,6 +469,7 @@ public with sharing class COFF_Affiliation_TEST {
         insert firstOffering;
 
         //Create second Course Offering with Faculty member
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
         Course_Offering__c secondOffering = new Course_Offering__c(Section_Id__c = 'BIO-101 Spring 16 - 2', Course__c = course.Id,
         Faculty__c = faculty.Id, Term__c = term.Id, Capacity__c = 200);
         insert secondOffering;
@@ -480,6 +490,7 @@ public with sharing class COFF_Affiliation_TEST {
         System.assertEquals(affls[0].Id, enrolls[1].Affiliation__c);
 
         Test.startTest();
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
         delete new List<Course_Offering__c>{
             firstOffering,
             secondOffering
@@ -524,6 +535,7 @@ public with sharing class COFF_Affiliation_TEST {
             //Update Offering
             offering.Faculty__c = null;
             Test.startTest();
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
             update offering;
             Test.stopTest();
 
@@ -559,6 +571,7 @@ public with sharing class COFF_Affiliation_TEST {
         System.assertEquals(affls[0].Id, enrolls[0].Affiliation__c);
 
         Test.startTest();
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);        
         delete offering;
         Test.stopTest();
 
@@ -672,7 +685,7 @@ public with sharing class COFF_Affiliation_TEST {
     @isTest
     public static void testUpdateConnectionsOnFacultyChangeUpdateExisting() {
         setup();
-        COFF_Affiliation_TDTM.hasRunCoffTrigger = true;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, true);
 
         //Create Course Offering with Faculty member
         Course_Offering__c offering = new Course_Offering__c(Section_ID__c = 'BIO-101 Spring 16', Course__c = course.ID,
@@ -704,6 +717,7 @@ public with sharing class COFF_Affiliation_TEST {
         COFF_Affiliation_TDTM cls = new COFF_Affiliation_TDTM();
 
         Test.startTest();
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
         cls.updateConnectionsOnFacultyChange(outdatedFaculty, updatedFaculty, offerings, objectsToInsert, objectsToUpdate);
         Test.stopTest();
 
@@ -717,7 +731,7 @@ public with sharing class COFF_Affiliation_TEST {
     public static void testUpdateConnectionsOnFacultyChangeInsertNew() {
         setup();
 
-        COFF_Affiliation_TDTM.hasRunCoffTrigger = true;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, true);
 
         //Create Course Offering with Faculty member
         Course_Offering__c offering = new Course_Offering__c(Section_ID__c = 'BIO-101 Spring 16', Course__c = course.ID,
@@ -780,14 +794,12 @@ public with sharing class COFF_Affiliation_TEST {
     public static void testUpdateConnectionsOnFacultyAddInsertNew() {
         setup();
 
-        COFF_Affiliation_TDTM.hasRunCoffTrigger = true;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, true);
 
         //Create Course Offering with Faculty member
         Course_Offering__c offering = new Course_Offering__c(Section_ID__c = 'BIO-101 Spring 16', Course__c = course.ID,
         Faculty__c = faculty.Id, Term__c = term.Id, Capacity__c = 200);
         insert offering;
-
-        COFF_Affiliation_TDTM.hasRunCoffTrigger = false;
 
         List<Course_Offering__c> offerings = new List<Course_Offering__c>{offering};
 
@@ -797,6 +809,7 @@ public with sharing class COFF_Affiliation_TEST {
         COFF_Affiliation_TDTM cls = new COFF_Affiliation_TDTM();
 
         Test.startTest();
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
         cls.updateConnectionsOnFacultyAdd(offerings, objectsToInsert, objectsToUpdate);
         Test.stopTest();
 
@@ -809,7 +822,7 @@ public with sharing class COFF_Affiliation_TEST {
     public static void testUpdateConnectionsOnFacultyAddUpdateExisting() {
         setup();
 
-        COFF_Affiliation_TDTM.hasRunCoffTrigger = true;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, true);
 
         //Create Course Offering with Faculty member
         Course_Offering__c offering = new Course_Offering__c(Section_ID__c = 'BIO-101 Spring 16', Course__c = course.ID,
@@ -859,6 +872,7 @@ public with sharing class COFF_Affiliation_TEST {
 
         Test.startTest();
         offering2.Faculty__c = newFaculty.Id;
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.COFF_Affiliation_TDTM, false);
         update offering2;
         Test.stopTest();
 

--- a/src/classes/CON_Email_TEST.cls
+++ b/src/classes/CON_Email_TEST.cls
@@ -144,7 +144,7 @@ private class CON_Email_TEST {
         	contacts[0].WorkEmail__c = null;
         }
 
-	    CON_Preferred_TDTM.alreadyRunBefore = false; // need to re-activate the trigger
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, false);
 
 		Test.startTest();
         update contacts;
@@ -197,11 +197,11 @@ private class CON_Email_TEST {
 				}
 	        }
 
-	        CON_Preferred_TDTM.alreadyRunBefore = true; // need to turn off the trigger for this test
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, true);
 	        update contacts;
         }
 
-	    CON_Preferred_TDTM.alreadyRunBefore = false; // need to activate these for the batch
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, false);
 		// Run Batch
 		Test.startTest();
 	    CON_Email_BATCH contbatch = new CON_Email_BATCH(null);

--- a/src/classes/CON_Preferred_TDTM.cls
+++ b/src/classes/CON_Preferred_TDTM.cls
@@ -36,9 +36,6 @@
 */
 public class CON_Preferred_TDTM extends TDTM_Runnable {
 
-    /* @description Flag to prevent recursive call on beforeInsert and BeforeUpdate */
-    public static Boolean alreadyRunBefore = false;
-
     /*******************************************************************************************************
     * @description Updates default email and phone fields based to the preferred email and preferred phone values.
     * @return dmlWrapper
@@ -46,9 +43,9 @@ public class CON_Preferred_TDTM extends TDTM_Runnable {
     public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
         TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
              
-        if( !alreadyRunBefore && (triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) && newlist != null) {
+        if( !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM) && (triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) && newlist != null) {
 
-            alreadyRunBefore = true;
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, true);
 
             for(SObject so : newlist) {
                 Contact contact = (Contact)so;

--- a/src/classes/CON_Preferred_TEST.cls
+++ b/src/classes/CON_Preferred_TEST.cls
@@ -91,7 +91,7 @@ public with sharing class CON_Preferred_TEST {
 		contact3.PreferredPhone__c = 'Other';
 		contact4.PreferredPhone__c = 'Mobile';
 
-	    CON_Preferred_TDTM.alreadyRunBefore = false; // need to re-activate the trigger since this is all the same transaction
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, false);
 		Test.startTest();
 		update contacts;
 		Test.stopTest();

--- a/src/classes/CON_PrimaryAffls_TDTM.cls
+++ b/src/classes/CON_PrimaryAffls_TDTM.cls
@@ -144,9 +144,10 @@ public class CON_PrimaryAffls_TDTM extends TDTM_Runnable {
         dmlWrapper = null;
         if (triggerAction == TDTM_Runnable.Action.AfterInsert){
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Insert, false);
+            TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated);            
         }else if (triggerAction == TDTM_Runnable.Action.AfterUpdate){
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update, false);
-            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary, false);
+            TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated);            
         }
         return dmlWrapper;
     }

--- a/src/classes/CON_PrimaryAffls_TDTM.cls
+++ b/src/classes/CON_PrimaryAffls_TDTM.cls
@@ -41,12 +41,6 @@ public class CON_PrimaryAffls_TDTM extends TDTM_Runnable {
     private static AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
 
     /*******************************************************************************************************
-    * @description Static flag to prevent AFFL_MultiRecordType_TDTM from updating the primary affiliation fields
-    * when they are updated directly in the Contact.
-    ********************************************************************************************************/
-    public static Boolean keyAfflLookupUpdated = false;
-
-    /*******************************************************************************************************
     * @description Handles primary affiliation fields.
     * @param listNew the list of Accounts from trigger new.
     * @param listOld the list of Accounts from trigger old.
@@ -66,7 +60,6 @@ public class CON_PrimaryAffls_TDTM extends TDTM_Runnable {
 
         // AFTER INSERT
         if( newlist != null && triggerAction == TDTM_Runnable.Action.AfterInsert  && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Insert)) {
-
             // Loop over contact list
             for (integer i=0; i<newlist.size(); i++) {
 
@@ -87,7 +80,6 @@ public class CON_PrimaryAffls_TDTM extends TDTM_Runnable {
                     }
                 }
             }
-
             // Set reentrant Flag
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Insert, true);
         }
@@ -154,16 +146,17 @@ public class CON_PrimaryAffls_TDTM extends TDTM_Runnable {
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Insert, false);
         }else if (triggerAction == TDTM_Runnable.Action.AfterUpdate){
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update, false);
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary, false);
         }
         return dmlWrapper;
     }
 
     private void createAfflFromLookup(Contact newContact, Integer j, List<Affiliation__c> afflsToInsert) {
-        if(!AFFL_MultiRecordType_TDTM.afflMadePrimary) {
+        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary)) {
 	        ID accID = (ID)newContact.get(afflMapper.primaryAfflFieldNames[j]);
 	        if(accID != null)
 	          afflsToInsert.add(new Affiliation__c(Contact__c = newContact.ID, Account__c = accID, Primary__c = true)); //Role and Status?
-	        keyAfflLookupUpdated = true;
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated, true);
         }
     }
 

--- a/src/classes/CON_PrimaryAffls_TDTM.cls
+++ b/src/classes/CON_PrimaryAffls_TDTM.cls
@@ -47,12 +47,6 @@ public class CON_PrimaryAffls_TDTM extends TDTM_Runnable {
     public static Boolean keyAfflLookupUpdated = false;
 
     /*******************************************************************************************************
-    * @description Static flags to prevent recursive call.
-    ********************************************************************************************************/
-    public static boolean alreadyRunAfterInsert = false;
-    public static boolean alreadyRunAfterUpdate = false;
-
-    /*******************************************************************************************************
     * @description Handles primary affiliation fields.
     * @param listNew the list of Accounts from trigger new.
     * @param listOld the list of Accounts from trigger old.
@@ -71,7 +65,7 @@ public class CON_PrimaryAffls_TDTM extends TDTM_Runnable {
         Map<ID, List<ID>> changedConToAccsMap = new Map<ID, List<ID>>();
 
         // AFTER INSERT
-        if( newlist != null && triggerAction == TDTM_Runnable.Action.AfterInsert  && !alreadyRunAfterInsert) {
+        if( newlist != null && triggerAction == TDTM_Runnable.Action.AfterInsert  && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Insert)) {
 
             // Loop over contact list
             for (integer i=0; i<newlist.size(); i++) {
@@ -95,11 +89,11 @@ public class CON_PrimaryAffls_TDTM extends TDTM_Runnable {
             }
 
             // Set reentrant Flag
-            alreadyRunAfterInsert = true;
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Insert, true);
         }
 
         // BEFORE UPDATE
-        if ( newlist != null && triggerAction == TDTM_Runnable.Action.AfterUpdate && !alreadyRunAfterUpdate) {
+        if ( newlist != null && triggerAction == TDTM_Runnable.Action.AfterUpdate && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update)) {
             for (integer i=0; i<newlist.size(); i++) {
                 Contact newContact = (Contact)newlist[i];
                 Contact oldContact = (Contact)oldlist[i];
@@ -142,7 +136,7 @@ public class CON_PrimaryAffls_TDTM extends TDTM_Runnable {
             }
 
             // Set reentrant Flag
-            alreadyRunAfterUpdate = true;
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update, true);
         }
 
         if(afflsToInsert.size() > 0) {
@@ -154,6 +148,13 @@ public class CON_PrimaryAffls_TDTM extends TDTM_Runnable {
             dmlWrapper.objectsToUpdate.addAll((List<SObject>)makeOtherAfflsNotPrimary(changedConToAccsMap));
         }
 
+        TDTM_TriggerHandler.processDML(dmlWrapper, true);
+        dmlWrapper = null;
+        if (triggerAction == TDTM_Runnable.Action.AfterInsert){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Insert, false);
+        }else if (triggerAction == TDTM_Runnable.Action.AfterUpdate){
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update, false);
+        }
         return dmlWrapper;
     }
 

--- a/src/classes/STG_InstallScript_TEST.cls
+++ b/src/classes/STG_InstallScript_TEST.cls
@@ -44,10 +44,10 @@ public with sharing class STG_InstallScript_TEST {
             LastName = 'Test',
             Email = 'joe@domain.com'
         );
-        CON_Preferred_TDTM.alreadyRunBefore = true; // need to turn off the trigger for this test
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, false);// need to turn off the trigger for this test
         insert cont;
 
-        CON_Preferred_TDTM.alreadyRunBefore = false; // back on for install script
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, true); // back on for install script
 
         Test.startTest();
 		//Run the install script

--- a/src/classes/TDTM_DMLgt200_TEST.cls
+++ b/src/classes/TDTM_DMLgt200_TEST.cls
@@ -368,7 +368,6 @@ private class TDTM_DMLgt200_TEST {
         	MailingCity = 'Austin', MailingState = 'Texas', MailingPostalcode = '78701', MailingCountry = 'United States');
         	testContacts.add(contact);       	
         }
-        system.debug(testContacts.size());
         Test.startTest();
         insert testContacts;
         Test.stopTest();

--- a/src/classes/TDTM_DMLgt200_TEST.cls
+++ b/src/classes/TDTM_DMLgt200_TEST.cls
@@ -452,4 +452,45 @@ private class TDTM_DMLgt200_TEST {
         
     }
 
+    /*********************************************************************************************************
+    @description Insert 200+ contacts with Primary_Education_Institution__c
+    verify:
+        certain amounts of affiliations are created
+    **********************************************************************************************************/    
+    @isTest
+    public static void createContactsWithOrg() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe.getHhAccRecTypeID()));
+
+        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
+        mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = 'Primary Business Organization'));
+        mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = 'Primary Household'));
+        insert mappings;
+
+        Id orgRecTypeID = UTIL_Describe.getBizAccRecTypeID();
+        Id householdRecTypeID = UTIL_Describe.getHhAccRecTypeID();
+
+        //Create account of Business Organization record type
+        Account bizOrg1 = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
+        insert bizOrg1;
+
+        List<Contact> newContacts = new List<Contact>();
+        for (Integer i = 0; i < inputSize; i++){
+            Contact newContact = new Contact(FirstName = 'New' + i, LastName = 'Testerson', Primary_Organization__c = bizOrg1.Id);
+            newContacts.add(newContact);
+        }
+
+        Test.startTest();
+        insert newContacts;
+        Test.stopTest();
+
+        //Verify
+        List<Affiliation__c> affls = [select Affiliation_Type__c, Account__c, Primary__c from Affiliation__c];
+        System.assertEquals(inputSize, affls.size());
+
+        for (Affiliation__c affl : affls)
+        {
+            System.assertEquals('Business Organization', affl.Affiliation_Type__c);
+        }
+    }
+
 }

--- a/src/classes/TDTM_DMLgt200_TEST.cls
+++ b/src/classes/TDTM_DMLgt200_TEST.cls
@@ -1,0 +1,421 @@
+@isTest
+private class TDTM_DMLgt200_TEST {
+	
+	static Integer inputSize = 210;
+
+    /*********************************************************************************************************
+    * @description Test Method for inserting large amounts of Contacts
+    */
+	@isTest static void testInsertContact() {
+		// test data set up
+		List<Contact> testContacts = new List<Contact>();
+		for (Integer i = 0; i < inputSize; i++)
+		{
+			Contact testContact = new Contact(LastName = 'testLastName ' + i);
+			testContacts.add(testContact);
+		}
+		insert testContacts;
+
+		//assert
+		List<Account> assertAccounts = [SELECT Id FROM Account];
+		system.assertEquals(inputSize, assertAccounts.size());
+	}
+
+    /*********************************************************************************************************
+    * @description Test Method for inserting and updating large amounts of Contact
+    */
+    @isTest
+    public static void insertUpdateContact() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe.getAdminAccRecTypeID()));
+
+        String newContactMailingStreet = '123 Elm St';
+
+		List<Contact> testContacts = new List<Contact>();
+
+		for (Integer i = 0; i < inputSize; i++)
+		{
+        	Contact con = new Contact(
+            FirstName='Test',
+            LastName='Contact_forTests',
+            MailingStreet = newContactMailingStreet,
+            WorkEmail__c = 'junk@test.net',
+            Preferred_Email__c = 'Work',
+            WorkPhone__c = '206-777-8888',
+            PreferredPhone__c = 'Work');
+            testContacts.add(con);
+        }
+        insert testContacts;
+
+        List<Contact> insertedContacts = [	Select FirstName, LastName, AccountId, Account.Name,Account.Primary_Contact__c,MailingStreet,
+        									   Account.BillingStreet 
+        							    	from Contact];
+
+        //one contact should have been created
+        system.assertEquals(inputSize, insertedContacts.size());
+
+        //relationship should be bi-directional
+        for (Contact con : insertedContacts)
+        {
+	        system.assertEquals(con.id, con.Account.Primary_Contact__c);   
+            con.LastName = 'Contact_forTestsChange';
+        	con.OtherCity = 'Seattle';  
+        }
+        update insertedContacts;
+
+        List<Contact> updatedContacts = [Select FirstName, LastName, AccountId, Account.Name,Account.Primary_Contact__c
+                                         from Contact];
+
+        //relationship should be bi-directional
+        for (Contact con : updatedContacts)
+        {
+        	system.assertEquals(con.id, con.Account.Primary_Contact__c);
+        }
+        system.assertEquals(inputSize, updatedContacts.size());
+	}	
+
+    /*********************************************************************************************************
+    * @description Delete large amounts of Contacts and verify its parent Account is deleted.
+    */
+     @isTest
+     public static void deleteContactNoOpps() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(
+                    Account_Processor__c = UTIL_Describe.getAdminAccRecTypeID(),
+                    Accounts_to_Delete__c = UTIL_Describe.getAdminAccRecTypeID()));
+
+		List<Contact> testContacts = new List<Contact>();
+        for (Integer i = 0; i < inputSize; i++)
+        {
+	        Contact con = new Contact(
+	            FirstName='Test',
+	            LastName='Contact_forTests',
+	            MailingStreet = '123 Elm St',
+	            WorkEmail__c = 'junk@test.net',
+	            Preferred_Email__c = 'Work',
+	            WorkPhone__c = '206-777-8888',
+	            PreferredPhone__c = 'Work');
+	        testContacts.add(con);
+	    }
+        insert testContacts;
+
+        List<Account> insertedAccounts = [Select Id from Account];
+        system.assertEquals(inputSize,insertedAccounts.size());
+
+        Test.startTest();
+        delete testContacts;
+        Test.stopTest();
+
+        insertedAccounts = [Select Id from Account];
+        system.assertEquals(0,insertedAccounts.size());
+    }
+
+    /*********************************************************************************************************
+    @description Update existing large amounts of default Addresses.  
+    verify: account billing address fields updated
+    **********************************************************************************************************/            
+    @isTest 
+    public static void updateDefaultAddr() {
+        Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
+            Accounts_Addresses_Enabled__c = UTIL_Describe.getAdminAccRecTypeID() + ';',
+            Simple_Address_Change_Treated_as_Update__c = true);
+        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        
+        // this creates a default Address for each Account
+        UTIL_UnitTestData_TEST.AccsWithAddrs accsAddrs = UTIL_UnitTestData_TEST.createTestAccsAddrs(inputSize, UTIL_Describe.getAdminAccRecTypeID());
+        List<Address__c> addrs = accsAddrs.addrs;        
+        // now let's update the Addresses
+        for (Integer i = 0; i < addrs.size(); i++) {
+            Address__c addr = addrs[i];
+            addr.MailingStreet__c = 'New Street' + i;
+            addr.MailingCity__c = 'New City' + i;
+        }
+
+        Test.startTest();
+        update addrs;
+        Test.stopTest();
+    
+        map<Id, Account> mapAccIdAcc = new map<Id, Account>([select Id, Name, BillingStreet, BillingCity, BillingState, 
+        BillingPostalCode, BillingCountry, BillingLatitude, BillingLongitude, Current_Address__c
+        from Account]);
+        
+        for (Account acc : mapAccIdAcc.values()) {
+            System.assert(acc.BillingStreet.contains('New Street'));
+            System.assert(acc.BillingCity.contains('New City'));
+            System.assertNotEquals(null, acc.Current_Address__c);
+        }
+    }
+
+    /*********************************************************************************************************
+    @description Delete existing large amounts of default Addresses.  
+    verify: Account billing address fields cleared.
+    **********************************************************************************************************/            
+    @isTest 
+    static void deleteDefaultAddr() {
+        Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
+            Accounts_Addresses_Enabled__c = UTIL_Describe.getAdminAccRecTypeID() + ';',
+            Simple_Address_Change_Treated_as_Update__c = true);
+        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+
+        // this creates a default Address for each Account
+        UTIL_UnitTestData_TEST.AccsWithAddrs accsAddrs = UTIL_UnitTestData_TEST.createTestAccsAddrs(inputSize, UTIL_Describe.getAdminAccRecTypeID());
+        List<Address__c> addrs = accsAddrs.addrs;
+       
+        // now let's delete the Addresses
+        Test.startTest();
+        delete addrs;
+        Test.stopTest();
+    
+        // verify that the Account address fields are cleared
+        map<Id, Account> mapAccIdAcc = new map<Id, Account>([select Id, Name, BillingStreet, BillingCity, BillingState, 
+        BillingPostalCode, BillingCountry, BillingLatitude, BillingLongitude, Current_Address__c from Account]);
+        
+        for (Account acc : mapAccIdAcc.values()) {
+            System.assertEquals(null, acc.BillingStreet);
+            System.assertEquals(null, acc.BillingCity);
+        }
+    }
+
+    /*********************************************************************************************************
+    @description Delete existing large amounts of non-default override Addresses.  
+    verify: Account billing address fields not changed.
+    **********************************************************************************************************/            
+    @isTest
+    static void deleteNonDefaultOverrideAddr() {
+        Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
+            Accounts_Addresses_Enabled__c = UTIL_Describe.getAdminAccRecTypeID() + ';',
+            Simple_Address_Change_Treated_as_Update__c = true);
+        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        
+        UTIL_UnitTestData_TEST.AccsWithAddrs accsAddrs = UTIL_UnitTestData_TEST.createTestAccsAddrs(inputSize, UTIL_Describe.getAdminAccRecTypeID());
+        List<Address__c> addrs = accsAddrs.addrs;
+        
+        // create additional addresses
+        addrs = UTIL_UnitTestData_TEST.getMultipleTestAddresses(inputSize);
+        
+        for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
+            addrs[i].Parent_Account__c = accsAddrs.accs[i].Id;
+            addrs[i].Default_Address__c = false;
+            addrs[i].MailingStreet__c = 'override' + i;
+            addrs[i].MailingCity__c = 'override' + i;
+        }
+        ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        insert addrs;
+        
+        // set the accounts' current address
+        for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
+            Account acc = accsAddrs.accs[i];
+            acc.Current_Address__c = addrs[i].Id;
+        }
+        ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        update accsAddrs.accs;        
+        
+        // now let's delete the current Addresses
+        ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        Test.startTest();
+        delete addrs;
+        Test.stopTest();
+    
+        // verify that the Account address fields went back to the default
+        map<Id, Account> mapAccIdAcc = new map<Id, Account>([select Id, Name, BillingStreet, BillingCity, BillingState, 
+        BillingPostalCode, BillingCountry, BillingLatitude, BillingLongitude, Current_Address__c from Account]);
+        
+        for (Account acc : mapAccIdAcc.values()) {
+            System.assert(acc.BillingStreet.contains('Street'));
+            System.assert(acc.BillingCity.contains('City')); 
+            System.assertNotEquals(null, acc.Current_Address__c);                
+        }
+    }
+
+    /*********************************************************************************************************
+    @description Making an Address non-default. That is, the address is no longer the default one for the Account.  
+    verify: no change to account address
+    **********************************************************************************************************/            
+    @isTest
+    public static void updateNonDefaultAddr() {
+        Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
+            Accounts_Addresses_Enabled__c = UTIL_Describe.getAdminAccRecTypeID() + ';',
+            Simple_Address_Change_Treated_as_Update__c = true);
+        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        
+        // this creates a default Address for each Account
+        UTIL_UnitTestData_TEST.AccsWithAddrs accsAddrs = UTIL_UnitTestData_TEST.createTestAccsAddrs(inputSize, UTIL_Describe.getAdminAccRecTypeID());
+        List<Address__c> addrs = accsAddrs.addrs;
+        
+        // now let's update the Addresses
+        for (Integer i = 0; i < addrs.size(); i++) {
+            Address__c addr = addrs[i];
+            addr.Default_Address__c = false;
+        }
+        Test.startTest();
+        update addrs;
+        Test.stopTest();
+    
+        // verify that the Account and Contacts don't share the same address and it's new for the Account!
+        map<Id, Account> mapAccIdAcc = new map<Id, Account>([select Id, Name, BillingStreet, BillingCity, BillingState, 
+        BillingPostalCode, BillingCountry, BillingLatitude, BillingLongitude, Current_Address__c 
+        from Account]);
+        
+        for (Account acc : mapAccIdAcc.values()) {
+            System.assertEquals(null, acc.BillingStreet); //address information has been cleared because address is no longer the default
+            System.assertEquals(null, acc.BillingCity); //address information has been cleared because address is no longer the default
+            System.assertEquals(null, acc.Current_Address__c); //account no longer has a current address, since address is no longer the defaults
+        }
+    }
+
+    /*********************************************************************************************************
+    @description Insert large amounts of new default addresses to Account w/ existing default addresses  
+    verify:
+        Account address matches new default
+        old default addresses no longer marked default
+    **********************************************************************************************************/            
+    @isTest
+    public static void insertNewDefaultAddr() {
+        Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
+            Accounts_Addresses_Enabled__c = UTIL_Describe.getAdminAccRecTypeID() + ';',
+            Simple_Address_Change_Treated_as_Update__c = true);
+        UTIL_CustomSettingsFacade.getSettingsForTests(hs);          
+        // this creates a default Address for each Account
+        UTIL_UnitTestData_TEST.AccsWithAddrs accsAddrs = UTIL_UnitTestData_TEST.createTestAccsAddrs(inputSize, UTIL_Describe.getAdminAccRecTypeID());
+        List<Address__c> addrs = accsAddrs.addrs;
+        
+        // create additional addresses
+        addrs = UTIL_UnitTestData_TEST.getMultipleTestAddresses(inputSize);
+        for (Integer i = 0; i < accsAddrs.accs.size(); i++) {
+            addrs[i].Parent_Account__c = accsAddrs.accs[i].Id;
+            addrs[i].Default_Address__c = true;
+            addrs[i].MailingStreet__c = 'New Default Street' + i;
+            addrs[i].MailingCity__c = 'New Default City' + i;
+        }
+        ADDR_Contact_TEST.turnOnAllAddrTriggers();
+        Test.startTest();
+        insert addrs;
+        ADDR_Contact_TEST.turnOnAllAddrTriggers();        
+        Test.stopTest();
+
+        // verify that the Account addresses are new
+        map<Id, Account> mapAccIdAcc = new map<Id, Account>([select Id, Name, BillingStreet, BillingCity, BillingState, 
+        BillingPostalCode, BillingCountry, BillingLatitude, BillingLongitude, Current_Address__c from Account]);
+        
+        for (Account acc : mapAccIdAcc.values()) {
+            System.assert(acc.BillingStreet.contains('New Default Street'));
+            System.assert(acc.BillingCity.contains('New Default City'));
+            System.assertNotEquals(null, acc.Current_Address__c);
+        }
+        
+        // verify the previous addresses got Default cleared.
+        // and verify latest start date and latest end date appropriately set.
+        List<Address__c> listAddr = [select Id, Default_Address__c, MailingStreet__c, Parent_Account__c, Latest_Start_Date__c, 
+        Latest_End_Date__c from Address__c];
+        System.assertEquals(inputSize + inputSize, listAddr.size());
+        for (Address__c addr : listAddr) {
+            boolean fNewDefault = (addr.MailingStreet__c.contains('New Default Street'));
+            System.assertEquals(fNewDefault, addr.Default_Address__c);
+            if (fNewDefault) {
+               System.assertEquals(System.today(), addr.Latest_Start_Date__c);
+               System.assertEquals(null, addr.Latest_End_Date__c);
+            } else {
+               System.assertEquals(System.today(), addr.Latest_End_Date__c);                
+            }
+        }        
+    }
+
+	@isTest
+    public static void noContactToAccPropagation() {
+        Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
+            Account_Processor__c = UTIL_Describe.getAdminAccRecTypeID(),
+            Accounts_Addresses_Enabled__c = UTIL_Describe.getAdminAccRecTypeID() + ';',
+            Contacts_Addresses_Enabled__c = true,
+            Simple_Address_Change_Treated_as_Update__c = true);
+        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        
+        List<Contact> testContacts = new List<Contact>();
+        for (Integer i = 0; i < inputSize; i++){
+ 			Contact contact = new Contact(LastName = 'Testerson' + i, MailingStreet = '123 Main St', 
+        	MailingCity = 'Austin', MailingState = 'Texas', MailingPostalcode = '78701', MailingCountry = 'United States');
+        	testContacts.add(contact);       	
+        }
+        system.debug(testContacts.size());
+        Test.startTest();
+        insert testContacts;
+        Test.stopTest();
+        
+        //Verify parent account was automatically created
+        List<Contact> insertedContacts = [select AccountID from Contact];
+        Set<Id> setInsertedContactsIds = new Set<Id>();
+        for (Contact insertedContact : insertedContacts){
+        	setInsertedContactsIds.add(insertedContact.Id);
+        	System.assertNotEquals(null, contact.AccountID);
+        }
+        
+        //Verify child address record was created
+        List<Address__c> addrs = [select Parent_Account__c from Address__c]; 
+		System.assertEquals(inputSize, addrs.size());
+        for (Address__c addr : addrs){
+        	System.assertEquals(null, addr.Parent_Account__c);       	
+        }
+
+        
+        //Verify no address record was created as child of the parent account
+        addrs = [select ID from Address__c where Parent_Account__c in :setInsertedContactsIds];
+        System.assertEquals(0, addrs.size()); 
+        
+        //Verify parent account has no address info
+        List<Account> accs = [select BillingStreet, BillingCity, BillingState, BillingPostalCode, BillingCountry
+        from Account];
+        for (Account acc : accs){
+			System.assertEquals(null, acc.BillingStreet);
+	        System.assertEquals(null, acc.BillingState);
+	        System.assertEquals(null, acc.BillingPostalCode);
+	        if (!ADDR_Addresses_UTIL.isStateCountryPickListsEnabled) {
+	            System.assertEquals(null, acc.BillingCountry);   
+	        }
+        }
+    }
+
+    /*********************************************************************************************************
+    @description Change contacts for large amounts of affiliations
+    verify:
+        Account address matches new default
+        old default addresses no longer marked default
+    **********************************************************************************************************/    
+    @isTest
+    public static void changeContact() {
+    	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe.getHhAccRecTypeID()));
+
+        Id orgRecTypeID = UTIL_Describe.getBizAccRecTypeID();
+        Id householdRecTypeID = UTIL_Describe.getHhAccRecTypeID();
+
+    	Contact oldContact = new Contact(FirstName = 'Old', LastName = 'Testerson');
+    	insert oldContact;
+
+    	List<Contact> newContacts = new List<Contact>();
+    	for (Integer i = 0; i < inputSize; i++){
+    		Contact newContact = new Contact(FirstName = 'New' + i, LastName = 'Testerson');
+    		newContacts.add(newContact);
+    	}
+    	insert newContacts;
+
+		//Create accounts of Business Organization record type
+        Account bizOrg1 = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
+        insert bizOrg1;
+
+        List<Affiliation__c> testAffls = new List<Affiliation__c>();
+    	for (Integer i = 0; i < inputSize; i++){
+    		Affiliation__c testAffl = new Affiliation__c(Contact__c = newContacts[i].ID, Account__c = bizOrg1.ID, Primary__c = true);
+    		testAffls.add(testAffl);
+    	}
+    	insert testAffls;
+
+        Test.startTest();
+        for (Integer i = 0; i < inputSize; i++){
+        	testAffls[i].Contact__c = newContacts[i].Id;
+        }
+        update testAffls;
+        Test.stopTest();
+        
+        //Confirm Primary Business Organization field has been cleared in contact
+        Contact contact = [select Primary_Organization__c from Contact where Id =:oldContact.Id];
+        System.assertEquals(null, contact.Primary_Organization__c);
+        
+    }
+
+}

--- a/src/classes/TDTM_DMLgt200_TEST.cls
+++ b/src/classes/TDTM_DMLgt200_TEST.cls
@@ -1,7 +1,42 @@
+/*
+    Copyright (c) 2017, Salesforce.org
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+ * @author Salesforce.org
+ * @date 2017
+ * @group TDTM
+ * @group-content ../../ApexDocContent/TDTM.htm
+ * @description Test class to validate behavior changes related to TDTM Static Flag handling, primarily focused on
+ * dml operations with more than 200 records.
+ *
+***/
 @isTest
 private class TDTM_DMLgt200_TEST {
 	
-	static Integer inputSize = 210;
+	static Integer inputSize = 500;
 
     /*********************************************************************************************************
     * @description Test Method for inserting large amounts of Contacts

--- a/src/classes/TDTM_DMLgt200_TEST.cls-meta.xml
+++ b/src/classes/TDTM_DMLgt200_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>34.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/TDTM_DMLgt200_TEST.cls-meta.xml
+++ b/src/classes/TDTM_DMLgt200_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>34.0</apiVersion>
+    <apiVersion>40.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -94,12 +94,12 @@ public without sharing class TDTM_DefaultConfig {
         // Addresses on Contact object - creates Address__c record from Contact
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
               Class__c = 'ADDR_Contact_TDTM', Load_Order__c = 2, Object__c = 'Contact', 
-              Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'AfterInsert;AfterUpdate'));
+              Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'BeforeInsert;BeforeUpdate;AfterInsert;AfterUpdate'));
         
         // Addresses on Account object - creates Address__c record from Account
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
               Class__c = 'ADDR_Account_TDTM', Load_Order__c = 1, Object__c = 'Account', 
-              Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'AfterInsert;AfterUpdate'));
+              Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'BeforeInsert;BeforeUpdate;AfterInsert;AfterUpdate'));
         
         // Do Not Contact and related operations on Contact object
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -94,12 +94,12 @@ public without sharing class TDTM_DefaultConfig {
         // Addresses on Contact object - creates Address__c record from Contact
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
               Class__c = 'ADDR_Contact_TDTM', Load_Order__c = 2, Object__c = 'Contact', 
-              Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'BeforeInsert;BeforeUpdate;AfterInsert;AfterUpdate'));
+              Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'AfterInsert;AfterUpdate'));
         
         // Addresses on Account object - creates Address__c record from Account
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
               Class__c = 'ADDR_Account_TDTM', Load_Order__c = 1, Object__c = 'Account', 
-              Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'BeforeInsert;BeforeUpdate;AfterInsert;AfterUpdate'));
+              Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'AfterInsert;AfterUpdate'));
         
         // Do Not Contact and related operations on Contact object
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 

--- a/src/classes/TDTM_ProcessControl.cls
+++ b/src/classes/TDTM_ProcessControl.cls
@@ -1,0 +1,99 @@
+/*
+    Copyright (c) 2016, Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2017
+* @group TDTM
+* @group-content ../../ApexDocContent/TDTM.htm
+* @description Primary class for recursion process control logic shared across all TDTM classes
+*/
+public class TDTM_ProcessControl {
+  	/*******************************************************************************************************
+  	* @description Enum to define the various recursion prevention types used by all the related TDTM classes
+  	*/
+    public enum registeredTrigger {
+        ACCT_IndividualAccounts_TDTM_After_Delete,
+        ACCT_IndividualAccounts_TDTM_After_Insert,
+        ACCT_IndividualAccounts_TDTM_After_Update,
+        ADDR_Account_TDTM_After_Insert,
+        ADDR_Account_TDTM_After_Update,
+        ADDR_Addresses_TDTM_Before_Insert,
+        ADDR_Addresses_TDTM_Before_Update,
+        ADDR_Addresses_TDTM_After_Insert,
+        ADDR_Addresses_TDTM_After_Update,
+        ADDR_Addresses_TDTM_After_Delete,
+        ADDR_Contact_TDTM_After_Insert,
+        ADDR_Contact_TDTM_After_Update,
+        AFFL_AccChange_TDTM,
+        AFFL_ContactChange_TDTM,
+        AFFL_MultiRecordType_TDTM_Before,
+        AFFL_MultiRecordType_TDTM_After,
+        COFF_Affiliation_TDTM,
+        CON_Preferred_TDTM,
+        CON_PrimaryAffls_TDTM_After_Insert,
+        CON_PrimaryAffls_TDTM_After_Update
+    }
+
+    /*******************************************************************************************************
+    * @description Map to track the specific recursion type status
+    */
+    private static Map<registeredTrigger, Integer> recursionMap = new Map<registeredTrigger, Integer>();
+
+    public static void setRecursionFlag(registeredTrigger f, boolean b){
+       Integer recursionFlag = (recursionMap.containsKey(f) ? recursionMap.get(f) : 0);
+       recursionFlag += (b ? 1 : -1);
+       if (recursionFlag < 0){
+           recursionFlag = 0;
+       }
+       recursionMap.put(f, recursionFlag);
+    }
+
+    /*******************************************************************************************************
+    * @description Map to track the specific recursion type status
+    */
+    public static Boolean getRecursionFlag(registeredTrigger f) {
+       return (recursionMap.containsKey(f) ? recursionMap.get(f) : 0) > 0;
+    }
+
+    /*******************************************************************************************************
+    * @description turn off the recursion flag manually. Set as 1001 because the limit is 1000 dml per transaction
+    */
+    public static void turnOffRecursionFlag(registeredTrigger f){
+       recursionMap.put(f, 1001);
+    }
+
+    /*******************************************************************************************************
+    * @description turn off the recursion flag manually. Set as 1001 because the limit is 1000 dml per transaction
+    */
+    public static void resetRecursionFlag(registeredTrigger f){
+       recursionMap.put(f, 0);
+    }        
+
+}

--- a/src/classes/TDTM_ProcessControl.cls
+++ b/src/classes/TDTM_ProcessControl.cls
@@ -59,7 +59,9 @@ public class TDTM_ProcessControl {
         COFF_Affiliation_TDTM,
         CON_Preferred_TDTM,
         CON_PrimaryAffls_TDTM_After_Insert,
-        CON_PrimaryAffls_TDTM_After_Update
+        CON_PrimaryAffls_TDTM_After_Update,
+        AFFL_MultiRecordType_TDTM_afflMadePrimary,
+        CON_PrimaryAffls_TDTM_keyAfflLookupUpdated
     }
 
     /*******************************************************************************************************
@@ -91,7 +93,7 @@ public class TDTM_ProcessControl {
     }
 
     /*******************************************************************************************************
-    * @description turn off the recursion flag manually. Set as 1001 because the limit is 1000 dml per transaction
+    * @description reset the recursion flag
     */
     public static void resetRecursionFlag(registeredTrigger f){
        recursionMap.put(f, 0);

--- a/src/classes/TDTM_ProcessControl.cls
+++ b/src/classes/TDTM_ProcessControl.cls
@@ -53,8 +53,9 @@ public class TDTM_ProcessControl {
         ADDR_Contact_TDTM_After_Update,
         AFFL_AccChange_TDTM,
         AFFL_ContactChange_TDTM,
-        AFFL_MultiRecordType_TDTM_Before,
-        AFFL_MultiRecordType_TDTM_After,
+        AFFL_MultiRecordType_TDTM_Before_Insert,
+        AFFL_MultiRecordType_TDTM_After_Insert,
+        AFFL_MultiRecordType_TDTM_After_Update,
         COFF_Affiliation_TDTM,
         CON_Preferred_TDTM,
         CON_PrimaryAffls_TDTM_After_Insert,
@@ -94,6 +95,5 @@ public class TDTM_ProcessControl {
     */
     public static void resetRecursionFlag(registeredTrigger f){
        recursionMap.put(f, 0);
-    }        
-
+    }  
 }

--- a/src/classes/TDTM_ProcessControl.cls
+++ b/src/classes/TDTM_ProcessControl.cls
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2016, Salesforce.org
+    Copyright (c) 2017, Salesforce.org
     All rights reserved.
     
     Redistribution and use in source and binary forms, with or without

--- a/src/classes/TDTM_ProcessControl.cls-meta.xml
+++ b/src/classes/TDTM_ProcessControl.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>34.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/TDTM_ProcessControl.cls-meta.xml
+++ b/src/classes/TDTM_ProcessControl.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>34.0</apiVersion>
+    <apiVersion>40.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -102,8 +102,8 @@ public class UTIL_UnitTestData_TEST {
             addr.MailingState__c = 'Washington';
             addr.MailingPostalCode__c = 'Zip' + i;
             addr.MailingCountry__c = 'United States';
-            addr.Geolocation__Latitude__s = 47.6097 + i;
-            addr.Geolocation__Longitude__s = -122.3331 + i;
+            addr.Geolocation__Latitude__s = 47.6097;
+            addr.Geolocation__Longitude__s = -122.3331;
             addrs.add(addr);            
         }
         return addrs;

--- a/src/package.xml
+++ b/src/package.xml
@@ -75,12 +75,14 @@
         <members>STG_InstallScript</members>
         <members>STG_InstallScript_TEST</members>
         <members>TDTM_Config</members>
+        <members>TDTM_DMLgt200_TEST</members>
         <members>TDTM_DefaultConfig</members>
         <members>TDTM_Filter</members>
         <members>TDTM_Filter_TEST</members>
         <members>TDTM_Global_API</members>
         <members>TDTM_Manager</members>
         <members>TDTM_Manager_TEST</members>
+        <members>TDTM_ProcessControl</members>
         <members>TDTM_Runnable</members>
         <members>TDTM_TriggerActionHelper</members>
         <members>TDTM_TriggerHandler</members>
@@ -460,6 +462,12 @@
         <members>Trigger_Handler__c.All</members>
         <members>Trigger_Handler__c.All_Main_Fields</members>
         <name>ListView</name>
+    </types>
+    <types>
+        <members>Course_Enrollment__c.Default</members>
+        <members>Course_Enrollment__c.Faculty</members>
+        <members>Course_Enrollment__c.Student</members>
+        <name>RecordType</name>
     </types>
     <types>
         <members>Relationship__c.Related_Contact_Do_Not_Change</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -464,12 +464,6 @@
         <name>ListView</name>
     </types>
     <types>
-        <members>Course_Enrollment__c.Default</members>
-        <members>Course_Enrollment__c.Faculty</members>
-        <members>Course_Enrollment__c.Student</members>
-        <name>RecordType</name>
-    </types>
-    <types>
         <members>Relationship__c.Related_Contact_Do_Not_Change</members>
         <name>ValidationRule</name>
     </types>


### PR DESCRIPTION
# Critical Changes

# Changes
We redesigned how static flag variables are used by TDTM triggers for recursion control. These changes will ensure that the static flags work as expected when a single DML operation has more than 200 records. If you implemented custom code that results in insert/update of more than 200 records at a time, we recommend thorough testing in your Sandbox.

# Issues Closed
Fixes #472