### PR TITLE
Fix 404 error for courses ApexDoc page. Added version number to home …

### DIFF
--- a/ApexDocContent/Courses.htm
+++ b/ApexDocContent/Courses.htm
@@ -1,0 +1,9 @@
+<html>
+    <body>
+        <h2>Courses Related Classes</h2>
+        <p>The classes involved with Course include:</p>
+        <ul>
+            <li>COUR_DescriptionCopy_BATCH - Copies Course descriptions to the Extended Description field.</li>
+        </ul>
+    </body>
+</html>

--- a/ApexDocContent/Courses.htm
+++ b/ApexDocContent/Courses.htm
@@ -4,6 +4,7 @@
         <p>The classes involved with Course include:</p>
         <ul>
             <li>COUR_DescriptionCopy_BATCH - Copies Course descriptions to the Extended Description field.</li>
+            <li>STG_Courses - This class is to be used as a controller for Courses Settings.</li>
         </ul>
     </body>
 </html>

--- a/ApexDocContent/homepage.htm
+++ b/ApexDocContent/homepage.htm
@@ -1,7 +1,6 @@
 <html>
     <body>
         <h2>HEDA Codebase Documentation</h2>
-        <p>Version 1.40</p>
         <p>Welcome to the wonderful world of development in HEDA. We've tried hard to fully document our codebase so that external developers can get acclimated and quickly contribute to the project. Thanks for taking the time to review this documentation and consider contributing to the project!</p>
     </body>
 </html>

--- a/ApexDocContent/homepage.htm
+++ b/ApexDocContent/homepage.htm
@@ -2,6 +2,6 @@
     <body>
         <h2>HEDA Codebase Documentation</h2>
         <p>Version 1.40</p>
-        <p>Welcome to the wonderful world of development in the HEDA project. We've tried hard to fully document our codebase so that external developers can get acclimated and quickly contribute to the project. Thanks for taking the time to review this documentation and considering contributing to the project!</p>
+        <p>Welcome to the wonderful world of development in HEDA. We've tried hard to fully document our codebase so that external developers can get acclimated and quickly contribute to the project. Thanks for taking the time to review this documentation and consider contributing to the project!</p>
     </body>
 </html>

--- a/ApexDocContent/homepage.htm
+++ b/ApexDocContent/homepage.htm
@@ -1,6 +1,7 @@
 <html>
     <body>
         <h2>HEDA Codebase Documentation</h2>
+        <p>Version 1.40</p>
         <p>Welcome to the wonderful world of development in the HEDA project. We've tried hard to fully document our codebase so that external developers can get acclimated and quickly contribute to the project. Thanks for taking the time to review this documentation and considering contributing to the project!</p>
     </body>
 </html>

--- a/src/classes/ACCT_CannotDelete_TEST.cls
+++ b/src/classes/ACCT_CannotDelete_TEST.cls
@@ -30,7 +30,7 @@
 /**
 * @author Salesforce.org
 * @date 2016
-* @group Contacts
+* @group Accounts
 * @group-content ../../ApexDocContent/Accounts.htm
 * @description Tests for ACCT_CannotDelete_TDTM.
 */


### PR DESCRIPTION
…page.

# Critical Changes

# Changes
On the [ApexDocumentation home page](http://developer.salesforce.org/HEDAP/ApexDocumentation/index.html), fixed the Courses link and added a version number.

# Issues Closed
Fixes #470 
Fixes #482 