### PR TITLE
Avoid sending email in the unit test

### DIFF
--- a/src/classes/CON_Email_BATCH.cls
+++ b/src/classes/CON_Email_BATCH.cls
@@ -109,7 +109,11 @@ public class CON_Email_BATCH implements Database.Batchable<sObject>,Database.Sta
             mail.setToAddresses(toAddresses);        
             mail.setSubject(label.stgPreferredEmailBatchEmailSubject + ' ' + a.Status);
             mail.setPlainTextBody(emailBody);
-            Messaging.sendEmail(new Messaging.SingleEmailMessage[] { mail });
+
+            //Prevent sending email in the unit test
+            if(!Test.isRunningTest()) {
+                Messaging.sendEmail(new Messaging.SingleEmailMessage[] { mail });
+            }
         }
 
 	}

--- a/src/classes/CON_EthnicityRace_BATCH.cls
+++ b/src/classes/CON_EthnicityRace_BATCH.cls
@@ -81,7 +81,11 @@ global class CON_EthnicityRace_BATCH implements Database.Batchable<sObject> {
 		mail.setToAddresses(toAddresses);
 		mail.setSubject('Ethnicity and Race field backfill: ' + a.Status);
 		mail.setPlainTextBody(emailBody);
-		Messaging.sendEmail(new Messaging.SingleEmailMessage[] { mail });
+
+		//Prevent sending email in the unit test
+		if(!Test.isRunningTest()) {
+			Messaging.sendEmail(new Messaging.SingleEmailMessage[] { mail });
+		}
 		
 	}
 

--- a/src/classes/COUR_DescriptionCopy_BATCH.cls
+++ b/src/classes/COUR_DescriptionCopy_BATCH.cls
@@ -85,8 +85,12 @@ global class COUR_DescriptionCopy_BATCH implements Database.Batchable<sObject> {
 
 		mail.setSubject(label.stgCourseDescriptionCopyEmailSubject + ' ' + a.Status);
 		mail.setPlainTextBody(emailBody);
-		Messaging.sendEmail(new Messaging.SingleEmailMessage[] { mail });
-		
+
+		//Prevent sending email in the unit test
+		if(!Test.isRunningTest()) {
+			Messaging.sendEmail(new Messaging.SingleEmailMessage[] { mail });
+		}
+
 	}
 
 }

--- a/src/classes/ERR_Notifier.cls
+++ b/src/classes/ERR_Notifier.cls
@@ -126,7 +126,12 @@ public class ERR_Notifier {
 
         if (!errors.isEmpty() && !sendList.isEmpty()) {
             Messaging.SingleEmailMessage sme = createEmailMessage(context, errors, sendList);
-            Messaging.sendEmail(new Messaging.SingleEmailMessage[]{sme});
+
+            //Prevent sending email in the unit test
+            if(!Test.isRunningTest()) {
+                Messaging.sendEmail(new Messaging.SingleEmailMessage[]{sme});
+            }
+
 
             for(Error__c error : errors)
                 error.Email_Sent__c = true;


### PR DESCRIPTION
Updated the code to prevent sending email when running the apex unit test.

# Critical Changes

# Changes
Suppress email notifications for Apex unit tests.
# Issues Closed
Fixes #490 
# New Metadata

# Deleted Metadata
