### PR TITLE
Feature/xinnanli/contact name changes account

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -182,7 +182,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
 
                     // if the last name of contact has changed and it is using admin account model 
                     // change the related admin account last name
-                    if (c.LastName != oldContacts[i].LastName && defaultRecTypeID == UTIL_Describe.getAdminAccRecTypeID())
+                    if (c.LastName != oldContacts[i].LastName && c.AccountId != null)
                     {
                         listContactsChangedLastName.add(c);
                     }

--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -102,6 +102,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         List<Contact> listContactNeedAccount = new List<Contact>();
         List<Contact> listContactNeedAccountUpdate = new List<Contact>();
         List<Contact> listContactAccountDelete = new List<Contact>();
+        List<Contact> listContactsChangedLastName = new List<Contact>();
 
         Map<Id,Id> mapAccountIdContactId = new Map<Id,Id>();
 
@@ -178,6 +179,13 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                     if (c.OwnerId != oldContacts[i].OwnerId) {
                     	mapContactIdContactOwnerChange.put(c.Id, c);
                     }
+
+                    // if the last name of contact has changed and it is using admin account model 
+                    // change the related admin account last name
+                    if (c.LastName != oldContacts[i].LastName && defaultRecTypeID == UTIL_Describe.getAdminAccRecTypeID())
+                    {
+                        listContactsChangedLastName.add(c);
+                    }
                 }
                 i += 1;
             }
@@ -222,6 +230,9 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         	UTIL_Debug.debug('****Number of accs to delete: ' + listContactAccountDelete.size());
             // check all old accounts to delete is they are left hanging around
             deleteContactAccountsIfEmpty(listContactAccountDelete, dmlWrapper);
+        }
+        if (listContactsChangedLastName.size() > 0) {
+            updateAccountsLastName(listContactsChangedLastName, dmlWrapper);
         }
 
     	return dmlWrapper;
@@ -525,5 +536,28 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
     */
     public static String strNameAccountForContact(Contact con) {
         return con.LastName + ' ' + system.label.DefaultAccountName;
+    }
+
+    private void updateAccountsLastName(List<Contact> listContactsChangedLastName, DmlWrapper dmlWrapper) 
+    {
+        list<Account> listAccToUpdate = new list<Account>();
+        map<Id, Contact> mapAccIdToCon = new map<Id, Contact>();
+        for (Contact con : listContactsChangedLastName) {
+            mapAccIdToCon.put(con.AccountId, con);
+        }
+
+        list<Account> listAcc = [SELECT Id, RecordTypeId 
+                                 FROM Account
+                                 WHERE Id IN :mapAccIdToCon.keySet()];
+
+        for (Account acc : listAcc) {
+            // only consider Admin Accounts
+            if (acc.RecordTypeId == UTIL_Describe.getAdminAccRecTypeID()) {
+                acc.Name = strNameAdmAccountForContact(mapAccIdToCon.get(acc.Id));
+                listAccToUpdate.add(acc);
+            }
+        }
+        // add all accounts needing updating to our list
+        dmlWrapper.objectsToUpdate.addAll((List<SObject>)listAccToUpdate);
     }
 }

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -201,6 +201,8 @@ private class ACCT_IndividualAccounts_TEST {
 
     /*********************************************************************************************************
     * @description Update a contact's Lastname in the Account
+    * Based on lastest requirement, if there is a change on contact's last name, 
+    * admin account's lastname should be changed accordingly. 
     */
     @isTest
     public static void contactInNormalOrgNameChangem() {
@@ -231,7 +233,7 @@ private class ACCT_IndividualAccounts_TEST {
         update con2;
 
         Contact[] updatedContacts = [Select Account.Name, AccountId from Contact where id=:con.id];
-        system.assertEquals(acctName,updatedContacts[0].Account.Name);
+        system.assertEquals(con2.LastName + ' ' + Label.DefaultAdminName, updatedContacts[0].Account.Name);
     }
 
     /*********************************************************************************************************


### PR DESCRIPTION
# Critical Changes

# Changes
When a Contact's last name is updated, we now automatically rename the Contact's Administrative Account to match.
# Issues Closed
Fixes #380
# New Metadata

# Deleted Metadata
