### PR TITLE
Support namespaced orgs and fix issue with setting Account record types in ci_master flow

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -15,7 +15,6 @@ project:
         repo_dir: ApexDocumentation
 
 tasks:
-
     deploy_dev_config:
         description: Deploys configuration for Development. Assigns page layouts, compact layouts, and sets tab visibilities. Record type visibilities are set the update_admin_profile task
         class_path: cumulusci.tasks.salesforce.DeployNamespacedBundles

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -144,6 +144,8 @@ flows:
         tasks:
             9:
                 options:
+                    managed: True
+                    namespaced_org: True
                     skip_record_types: True
 
     dev_org:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -21,6 +21,7 @@ tasks:
         class_path: cumulusci.tasks.salesforce.DeployNamespacedBundles
         options:
             path: dev_config/src
+            unmanaged: True
             namespace_token: '%%%NAMESPACE%%%'
             filename_token: '___NAMESPACE___'
 
@@ -145,7 +146,7 @@ flows:
             7:
                 task: deploy_dev_config
                 options:
-                    managed: True
+                    unmanaged: False
 
     dev_org:
         tasks:
@@ -162,7 +163,7 @@ flows:
             6:
                 task: deploy_dev_config
                 options:
-                    managed: True
+                    unmanaged: False
 
     release_beta:
         tasks:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -17,12 +17,11 @@ project:
 tasks:
     deploy_dev_config:
         description: Deploys configuration for Development. Assigns page layouts, compact layouts, and sets tab visibilities. Record type visibilities are set the update_admin_profile task
-        class_path: cumulusci.tasks.salesforce.DeployNamespacedBundles
+        class_path: cumulusci.tasks.salesforce.DeployBundles
         options:
+            namespace_inject: $project_config.project__package__namespace
             path: dev_config/src
             unmanaged: True
-            namespace_token: '%%%NAMESPACE%%%'
-            filename_token: '___NAMESPACE___'
 
     delete_dev_config:
         description: Removes Development configuration. Sets page layouts, compact layouts to system defaults. Removes record type visibilites.
@@ -121,12 +120,6 @@ flows:
             6.2:
                 task: execute_install_apex
     
-    ci_master:
-        tasks:
-            9:
-                options:
-                    skip_record_types: True  
-    
     ci_beta:
         tasks:
             6:
@@ -147,8 +140,24 @@ flows:
                 options:
                     unmanaged: False
 
+    ci_master:
+        tasks:
+            9:
+                options:
+                    skip_record_types: True
+
     dev_org:
         tasks:
+            8:
+                task: deploy_dev_config
+            9:
+                task: execute_install_apex
+
+    dev_org_namespaced:
+        tasks:
+            6:
+                options:
+                    namespaced_org: True
             8:
                 task: deploy_dev_config
             9:

--- a/dev_config/src/admin_config/profiles/Admin.profile
+++ b/dev_config/src/admin_config/profiles/Admin.profile
@@ -10,31 +10,31 @@
     </layoutAssignments>
     <layoutAssignments>
         <layout>Account-%%%NAMESPACE%%%HEDA Organization Layout</layout>
-        <recordType>Account.Academic_Program</recordType>
+        <recordType>Account.%%%NAMESPACED_ORG%%%Academic_Program</recordType>
     </layoutAssignments>
     <layoutAssignments>
         <layout>Account-%%%NAMESPACE%%%HEDA Organization Layout</layout>
-        <recordType>Account.Administrative</recordType>
+        <recordType>Account.%%%NAMESPACED_ORG%%%Administrative</recordType>
     </layoutAssignments>
     <layoutAssignments>
         <layout>Account-%%%NAMESPACE%%%HEDA Organization Layout</layout>
-        <recordType>Account.Business_Organization</recordType>
+        <recordType>Account.%%%NAMESPACED_ORG%%%Business_Organization</recordType>
     </layoutAssignments>
     <layoutAssignments>
         <layout>Account-%%%NAMESPACE%%%HEDA Organization Layout</layout>
-        <recordType>Account.Educational_Institution</recordType>
+        <recordType>Account.%%%NAMESPACED_ORG%%%Educational_Institution</recordType>
     </layoutAssignments>
     <layoutAssignments>
         <layout>Account-%%%NAMESPACE%%%HEDA Household Layout</layout>
-        <recordType>Account.HH_Account</recordType>
+        <recordType>Account.%%%NAMESPACED_ORG%%%HH_Account</recordType>
     </layoutAssignments>
     <layoutAssignments>
         <layout>Account-%%%NAMESPACE%%%HEDA Organization Layout</layout>
-        <recordType>Account.Sports_Organization</recordType>
+        <recordType>Account.%%%NAMESPACED_ORG%%%Sports_Organization</recordType>
     </layoutAssignments>
     <layoutAssignments>
         <layout>Account-%%%NAMESPACE%%%HEDA Organization Layout</layout>
-        <recordType>Account.University_Department</recordType>
+        <recordType>Account.%%%NAMESPACED_ORG%%%University_Department</recordType>
     </layoutAssignments>
     <layoutAssignments>
         <layout>Contact-%%%NAMESPACE%%%HEDA Contact Layout</layout>
@@ -44,15 +44,15 @@
     </layoutAssignments>
     <layoutAssignments>
         <layout>%%%NAMESPACE%%%Course_Enrollment__c-%%%NAMESPACE%%%HEDA Course Enrollment Layout</layout>
-        <recordType>%%%NAMESPACE%%%Course_Enrollment__c.Default</recordType>
+        <recordType>%%%NAMESPACE%%%Course_Enrollment__c.%%%NAMESPACED_ORG%%%Default</recordType>
     </layoutAssignments>
     <layoutAssignments>
         <layout>%%%NAMESPACE%%%Course_Enrollment__c-%%%NAMESPACE%%%HEDA Course Enrollment Layout</layout>
-        <recordType>%%%NAMESPACE%%%Course_Enrollment__c.Faculty</recordType>
+        <recordType>%%%NAMESPACE%%%Course_Enrollment__c.%%%NAMESPACED_ORG%%%Faculty</recordType>
     </layoutAssignments>
     <layoutAssignments>
         <layout>%%%NAMESPACE%%%Course_Enrollment__c-%%%NAMESPACE%%%HEDA Course Enrollment Layout</layout>
-        <recordType>%%%NAMESPACE%%%Course_Enrollment__c.Student</recordType>
+        <recordType>%%%NAMESPACE%%%Course_Enrollment__c.%%%NAMESPACED_ORG%%%Student</recordType>
     </layoutAssignments>
     <tabVisibilities>
         <tab>%%%NAMESPACE%%%Address__c</tab>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,6 +5,6 @@
       "default": true
     }
   ],
-  "namespace": "",
+  "namespace": "hed",
   "sourceApiVersion": "35.0"
 }

--- a/tasks/salesforce.py
+++ b/tasks/salesforce.py
@@ -56,9 +56,6 @@ class UpdateAdminProfile(BaseUpdateAdminProfile):
     def _process_metadata(self):
         super(UpdateAdminProfile, self)._process_metadata()
        
-        if self.options['skip_record_types']:
-            return
- 
         # Strip record type visibilities
         findReplaceRegex(
             '<recordTypeVisibilities>([^\$]+)</recordTypeVisibilities>',
@@ -72,20 +69,6 @@ class UpdateAdminProfile(BaseUpdateAdminProfile):
             'namespaced_org': self.namespaced_org_prefix,
         }
         
-        # Set record type visibilities for Course Connections
-        self._set_record_type(
-            '{managed}Course_Enrollment__c.{namespaced_org}Default'.format(**namespace_args),
-            'false',
-        )
-        self._set_record_type(
-            '{managed}Course_Enrollment__c.{namespaced_org}Faculty'.format(**namespace_args),
-            'false',
-        )
-        self._set_record_type(
-            '{managed}Course_Enrollment__c.{namespaced_org}Student'.format(**namespace_args),
-            'true',
-        )
-
         # Set record type visibilities for Accounts
         self._set_record_type(
             'Account.{namespaced_org}Administrative'.format(**namespace_args),
@@ -115,6 +98,24 @@ class UpdateAdminProfile(BaseUpdateAdminProfile):
             'Account.{namespaced_org}University_Department'.format(**namespace_args),
             'false',
         )
+
+        if self.options['skip_record_types']:
+            return
+ 
+        # Set record type visibilities for Course Connections
+        self._set_record_type(
+            '{managed}Course_Enrollment__c.{namespaced_org}Default'.format(**namespace_args),
+            'false',
+        )
+        self._set_record_type(
+            '{managed}Course_Enrollment__c.{namespaced_org}Faculty'.format(**namespace_args),
+            'false',
+        )
+        self._set_record_type(
+            '{managed}Course_Enrollment__c.{namespaced_org}Student'.format(**namespace_args),
+            'true',
+        )
+
 
     def _set_record_type(self, name, default):
         rt = rt_visibility_template.format(default, name)

--- a/tasks/salesforce.py
+++ b/tasks/salesforce.py
@@ -1,4 +1,5 @@
 import os
+from cumulusci.core.utils import process_bool_arg
 from cumulusci.tasks.salesforce import UpdateAdminProfile as BaseUpdateAdminProfile
 from cumulusci.utils import findReplace
 from cumulusci.utils import findReplaceRegex
@@ -17,6 +18,10 @@ task_options['managed'] = {
     'description': 'If True, uses the namespace prefix where appropriate.  Use if running against an org with the managed package installed.  Defaults to False',
     'required': True,
 }
+task_options['namespaced_org'] = {
+    'description': 'If True, attempts to prefix all unmanaged metadata references with the namespace prefix for deployment to the packaging org or a namespaced scratch org',
+    'required': True,
+}
 task_options['skip_record_types'] = {
     'description': 'If True, setting record types will be skipped.  This is necessary when deploying to packaging as the ci_master flow does not deploy unpackaged/post.',
     'required': True,
@@ -29,14 +34,24 @@ class UpdateAdminProfile(BaseUpdateAdminProfile):
 
     def _init_options(self, kwargs):
         super(UpdateAdminProfile, self)._init_options(kwargs)
-        if 'skip_record_types' not in self.options:
-            self.options['skip_record_types'] = False
-        if self.options['skip_record_types'] == 'False':
-            self.options['skip_record_types'] = False
-        if 'managed' not in self.options:
-            self.options['managed'] = False
-        if self.options['managed'] == 'False':
-            self.options['managed'] = False
+        self.options['skip_record_types'] = process_bool_arg(
+            self.options.get('skip_record_types', False)
+        )
+        self.options['managed'] = process_bool_arg(
+            self.options.get('managed', False)
+        )
+        self.options['namespaced_org'] = process_bool_arg(
+            self.options.get('namespaced_org', False)
+        )
+        # For namespaced orgs, managed should always be True
+        if self.options['namespaced_org']:
+            self.options['managed'] = True
+
+        # Set up namespace prefix strings
+        namespace_prefix = '{}__'.format(self.project_config.project__package__namespace)
+        self.namespace_prefix = namespace_prefix if self.options['managed'] else ''
+        self.namespaced_org_prefix = namespace_prefix if self.options['namespaced_org'] else ''
+
         
     def _process_metadata(self):
         super(UpdateAdminProfile, self)._process_metadata()
@@ -51,25 +66,55 @@ class UpdateAdminProfile(BaseUpdateAdminProfile):
             os.path.join(self.tempdir, 'profiles'),
             'Admin.profile'
         )
-        
-        # Set up namespace
-        namespace_prefix = ''
-        if self.options['managed']:
-            namespace_prefix = '{}__'.format(self.project_config.project__package__namespace)
 
+        namespace_args = {
+            'managed': self.namespace_prefix,
+            'namespaced_org': self.namespaced_org_prefix,
+        }
+        
         # Set record type visibilities for Course Connections
-        self._set_record_type('{}Course_Enrollment__c.Default'.format(namespace_prefix), 'false')
-        self._set_record_type('{}Course_Enrollment__c.Faculty'.format(namespace_prefix), 'false')
-        self._set_record_type('{}Course_Enrollment__c.Student'.format(namespace_prefix), 'true')
+        self._set_record_type(
+            '{managed}Course_Enrollment__c.{namespaced_org}Default'.format(**namespace_args),
+            'false',
+        )
+        self._set_record_type(
+            '{managed}Course_Enrollment__c.{namespaced_org}Faculty'.format(**namespace_args),
+            'false',
+        )
+        self._set_record_type(
+            '{managed}Course_Enrollment__c.{namespaced_org}Student'.format(**namespace_args),
+            'true',
+        )
 
         # Set record type visibilities for Accounts
-        self._set_record_type('Account.Administrative', 'true')
-        self._set_record_type('Account.Academic_Program', 'false')
-        self._set_record_type('Account.Business_Organization', 'false')
-        self._set_record_type('Account.Educational_Institution', 'false')
-        self._set_record_type('Account.HH_Account', 'false')
-        self._set_record_type('Account.Sports_Organization', 'false')
-        self._set_record_type('Account.University_Department', 'false')
+        self._set_record_type(
+            'Account.{namespaced_org}Administrative'.format(**namespace_args),
+            'true',
+        )
+        self._set_record_type(
+            'Account.{namespaced_org}Academic_Program'.format(**namespace_args),
+            'false',
+        )
+        self._set_record_type(
+            'Account.{namespaced_org}Business_Organization'.format(**namespace_args),
+            'false',
+        )
+        self._set_record_type(
+            'Account.{namespaced_org}Educational_Institution'.format(**namespace_args),
+            'false',
+        )
+        self._set_record_type(
+            'Account.{namespaced_org}HH_Account'.format(**namespace_args),
+            'false',
+        )
+        self._set_record_type(
+            'Account.{namespaced_org}Sports_Organization'.format(**namespace_args),
+            'false',
+        )
+        self._set_record_type(
+            'Account.{namespaced_org}University_Department'.format(**namespace_args),
+            'false',
+        )
 
     def _set_record_type(self, name, default):
         rt = rt_visibility_template.format(default, name)


### PR DESCRIPTION
This is a build script only change.  It allows for deployments to namespaced scratch orgs and handles setting the Account record types on the Admin profile but not setting the Course Connection record types in `ci_master`, the flow used to deploy to the packaging org, since Course Connection record types are not deployed to packaging.  Previously all record types were skipped in `ci_master`'s `update_admin_profile` task.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
