### PR TITLE
Enable Catalan for HEDA

### DIFF
--- a/src/objectTranslations/Account-ca.objectTranslation
+++ b/src/objectTranslations/Account-ca.objectTranslation
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <help>L&apos;adreça actual que omplen els camps de facturació del compte.</help>
+        <label>Adreça actual</label>
+        <name>Current_Address__c</name>
+        <relationshipLabel>Comptes (adreça actual)</relationshipLabel>
+    </fields>
+    <fields>
+        <label><!-- _SYSTEM: One2OneContact --></label>
+        <name>Primary_Contact__c</name>
+        <relationshipLabel>Compte</relationshipLabel>
+    </fields>
+    <layouts>
+        <layout>HEDA Household Layout</layout>
+        <sections>
+            <label>Adreça</label>
+            <section>Address</section>
+        </sections>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+        <sections>
+            <label><!-- Description --></label>
+            <section>Description</section>
+        </sections>
+        <sections>
+            <label>Camps</label>
+            <section>Fields</section>
+        </sections>
+    </layouts>
+    <layouts>
+        <layout>HEDA Organization Layout</layout>
+        <sections>
+            <label>Adreça</label>
+            <section>Address</section>
+        </sections>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+        <sections>
+            <label><!-- Description --></label>
+            <section>Description</section>
+        </sections>
+        <sections>
+            <label>Camps</label>
+            <section>Fields</section>
+        </sections>
+    </layouts>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Account-ca.objectTranslation
+++ b/src/objectTranslations/Account-ca.objectTranslation
@@ -1,5 +1,959 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Compte</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Comptes</value>
+    </caseValues>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Accés de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_access</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nivell d’accés de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_access_level</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Funció de contacte de compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Funcions de contactes de comptes</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_contact_role</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Creador de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_creator</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Divisa de compte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_currency</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Descripció de compte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_description</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Pàgina de detall de compte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_detail_page</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Divisió de compte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_division</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Modificació de compte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_edit</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Fax de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_fax</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Camp de compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Campos de comptes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_field</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>General de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_general</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Jerarquia de compte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_hierarchy</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Historial de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_history</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Arxiu d’historial de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_history_archive</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Informe d’historial de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_history_report</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Id. de Compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_id</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Informació de compte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_information</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nom de compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Noms de comptes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_name</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nombre de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_number</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Propietari de compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Propietaris de comptes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_owner</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Àlies de propietari de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_owner_alias</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Informe de propietari de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_owner_report</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Funció de propietari de compte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_owner_role</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Propietat de compte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_ownership</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Telèfon de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_phone</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Qualificació de compte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_rating</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Registre de compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Registres de comptes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_record</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Tipus de registre del compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Tipus de registres de comptes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_record_type</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Informe de compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Informes de comptes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_report</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Col·laboració de compte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_sharing</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Lloc de compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Llocs de comptes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_site</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Origen de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_source</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Id. de Etapa de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_stage_id</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Equip de compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Equips de comptes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_team</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Membre d’equip de compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Membres d&apos;equips de comptes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_team_member</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Id. de Membre d’equip de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_team_member_id</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Informe d’equip de compte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_team_report</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Territori de compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Territoris de comptes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_territory</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Eina de compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Eines de comptes</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_tool</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Tipus de compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Tipus de comptes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>account_type</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Vista de compte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Vistes de comptes</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>account_view</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Adreça</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>address_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Informació d’adreça</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>address_information_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Ingressos anuals</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>annual_revenue_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Precisió de geocodi de facturació</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>billing_accuracy_geocode_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Adreça de facturació</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>billing_address_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Ciutat de facturació</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>billing_city_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>País de facturació</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>billing_country_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Codi de país de facturació</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>billing_country_code_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Latitud de facturació</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>billing_latitude_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Longitud de facturació</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>billing_longitude_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Estat/província de facturació</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>billing_state_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Codi d’estat/província de facturació</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>billing_state_code_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Carrer de facturació</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>billing_street_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Codi postal de facturació</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>billing_zip_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Ciutat</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>city_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Estat de neteja</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>cleanstatus_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>País</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>country_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Divisa</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>currency_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Clau de Data.com</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>datadotcom_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Descripció</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>description_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nombre D-U-N-S</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>duns_number</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Empleats</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>employees_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Part global</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>global_party_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Indústria</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>industry_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Codi NAICS</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>naics_code</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Descripció NAICS</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>naics_description</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Propietat</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>ownership_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Compte principal</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Comptes principals</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>parent_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Divisió de compte principal</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>parent_account_division</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Id. de Compte principal</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>parent_account_id</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Lloc de compte principal</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>parent_account_site</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Registre de compte personal</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Registres de comptes principals</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>person_account_record</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Telèfon</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>phone_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Qualificació</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>rating_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Precisió de geocodi d’enviament</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>shipping_accuracy_geocode_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Adreça d’enviament</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>shipping_address_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Ciutat d’enviament</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>shipping_city_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>País d’enviament</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>shipping_country_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Codi de país d’enviament</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>shipping_country_code_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Latitud d’enviament</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>shipping_latitude_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Longitud d’enviament</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>shipping_longitude_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Estat/província d’enviament</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>shipping_state_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Codi d’estat/província d’enviament</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>shipping_state_code_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Carrer d’enviament</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>shipping_street_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Codi postal d’enviament</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>shipping_zip_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Codi SIC</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>sic_code</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Descripció SIC</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>sic_description</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Lloc</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>site_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Estat</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>state_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Carrer</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>street_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Símbol de teletip</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>ticker_symbol_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Estil mercantil</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>tradestyle</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Tipus</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>type_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Lloc web</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>website_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Any d’inici</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>year_started</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Codi postal</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>zip_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
     <fields>
         <help>L&apos;adreça actual que omplen els camps de facturació del compte.</help>
         <label>Adreça actual</label>
@@ -11,6 +965,7 @@
         <name>Primary_Contact__c</name>
         <relationshipLabel>Compte</relationshipLabel>
     </fields>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Household Layout</layout>
         <sections>
@@ -49,4 +1004,5 @@
             <section>Fields</section>
         </sections>
     </layouts>
+    <startsWith>Consonant</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Address__c-ca.objectTranslation
+++ b/src/objectTranslations/Address__c-ca.objectTranslation
@@ -1,0 +1,479 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Address --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Address --></value>
+    </caseValues>
+    <fields>
+        <label>Tipus d&apos;adreça</label>
+        <name>Address_Type__c</name>
+        <picklistValues>
+            <masterLabel>Home</masterLabel>
+            <translation>Llar</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Other</masterLabel>
+            <translation>Altres</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Vacation Residence</masterLabel>
+            <translation>Residència de vacances</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation>Feina</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>És aquesta l&apos;adreça predeterminada per a la llar i els seus contactes?</help>
+        <label>Adreça predeterminada</label>
+        <name>Default_Address__c</name>
+    </fields>
+    <fields>
+        <label>Adreça postal</label>
+        <name>Formula_MailingAddress__c</name>
+    </fields>
+    <fields>
+        <label>Adreça de correu postal</label>
+        <name>Formula_MailingStreetAddress__c</name>
+    </fields>
+    <fields>
+        <help>Ubicació expressada com a latitud i longitud.</help>
+        <label>Geolocalització</label>
+        <name>Geolocation__c</name>
+    </fields>
+    <fields>
+        <help>S&apos;ha utilitzat la data de finalització més recent per a aquesta llar.</help>
+        <label>Última data de finalització</label>
+        <name>Latest_End_Date__c</name>
+    </fields>
+    <fields>
+        <help>S&apos;ha utilitzat la data d&apos;inici més recent per a aquesta llar.</help>
+        <label>Última data d&apos;inici</label>
+        <name>Latest_Start_Date__c</name>
+    </fields>
+    <fields>
+        <label>Ciutat de correu postal</label>
+        <name>MailingCity__c</name>
+    </fields>
+    <fields>
+        <label>País de correu postal</label>
+        <name>MailingCountry__c</name>
+    </fields>
+    <fields>
+        <label>Codi postal de correu postal</label>
+        <name>MailingPostalCode__c</name>
+    </fields>
+    <fields>
+        <label>Estat/Província de correu postal</label>
+        <name>MailingState__c</name>
+    </fields>
+    <fields>
+        <label>Carrer2 de correu postal</label>
+        <name>MailingStreet2__c</name>
+    </fields>
+    <fields>
+        <label>Carrer de correu postal</label>
+        <name>MailingStreet__c</name>
+    </fields>
+    <fields>
+        <help>El compte per a aquesta adreça.</help>
+        <label>Compte principal</label>
+        <name>Parent_Account__c</name>
+        <relationshipLabel>Adreces</relationshipLabel>
+    </fields>
+    <fields>
+        <help>El contacte per al qual és aquesta adreça.</help>
+        <label>Contacte principal</label>
+        <name>Parent_Contact__c</name>
+        <relationshipLabel>Adreces</relationshipLabel>
+    </fields>
+    <fields>
+        <help>El dia del mes en què aquesta adreça ja no substitueix l&apos;adreça predeterminada.</help>
+        <label>Dia de finalització estacional</label>
+        <name>Seasonal_End_Day__c</name>
+        <picklistValues>
+            <masterLabel>1</masterLabel>
+            <translation><!-- 1 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>10</masterLabel>
+            <translation><!-- 10 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>11</masterLabel>
+            <translation><!-- 11 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>12</masterLabel>
+            <translation><!-- 12 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>13</masterLabel>
+            <translation><!-- 13 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>14</masterLabel>
+            <translation><!-- 14 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>15</masterLabel>
+            <translation><!-- 15 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>16</masterLabel>
+            <translation><!-- 16 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>17</masterLabel>
+            <translation><!-- 17 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>18</masterLabel>
+            <translation><!-- 18 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>19</masterLabel>
+            <translation><!-- 19 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>2</masterLabel>
+            <translation><!-- 2 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>20</masterLabel>
+            <translation><!-- 20 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>21</masterLabel>
+            <translation><!-- 21 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>22</masterLabel>
+            <translation><!-- 22 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>23</masterLabel>
+            <translation><!-- 23 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>24</masterLabel>
+            <translation><!-- 24 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>25</masterLabel>
+            <translation><!-- 25 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>26</masterLabel>
+            <translation><!-- 26 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>27</masterLabel>
+            <translation><!-- 27 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>28</masterLabel>
+            <translation><!-- 28 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>29</masterLabel>
+            <translation><!-- 29 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>3</masterLabel>
+            <translation><!-- 3 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>30</masterLabel>
+            <translation><!-- 30 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>31</masterLabel>
+            <translation><!-- 31 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>4</masterLabel>
+            <translation><!-- 4 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>5</masterLabel>
+            <translation><!-- 5 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>6</masterLabel>
+            <translation><!-- 6 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>7</masterLabel>
+            <translation><!-- 7 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>8</masterLabel>
+            <translation><!-- 8 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>9</masterLabel>
+            <translation><!-- 9 --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>El mes de l&apos;any en què aquesta adreça ja no substitueix l&apos;adreça predeterminada.</help>
+        <label>Mes de finalització estacional</label>
+        <name>Seasonal_End_Month__c</name>
+        <picklistValues>
+            <masterLabel>1</masterLabel>
+            <translation><!-- 1 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>10</masterLabel>
+            <translation><!-- 10 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>11</masterLabel>
+            <translation><!-- 11 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>12</masterLabel>
+            <translation><!-- 12 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>2</masterLabel>
+            <translation><!-- 2 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>3</masterLabel>
+            <translation><!-- 3 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>4</masterLabel>
+            <translation><!-- 4 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>5</masterLabel>
+            <translation><!-- 5 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>6</masterLabel>
+            <translation><!-- 6 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>7</masterLabel>
+            <translation><!-- 7 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>8</masterLabel>
+            <translation><!-- 8 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>9</masterLabel>
+            <translation><!-- 9 --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>L&apos;any en què aquesta adreça ja no substitueix l&apos;adreça predeterminada.</help>
+        <label>Any de finalització estacional</label>
+        <name>Seasonal_End_Year__c</name>
+    </fields>
+    <fields>
+        <help>El dia del mes en què aquesta adreça substitueix l&apos;adreça predeterminada.</help>
+        <label>Dia d&apos;inici estacional</label>
+        <name>Seasonal_Start_Day__c</name>
+        <picklistValues>
+            <masterLabel>1</masterLabel>
+            <translation><!-- 1 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>10</masterLabel>
+            <translation><!-- 10 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>11</masterLabel>
+            <translation><!-- 11 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>12</masterLabel>
+            <translation><!-- 12 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>13</masterLabel>
+            <translation><!-- 13 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>14</masterLabel>
+            <translation><!-- 14 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>15</masterLabel>
+            <translation><!-- 15 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>16</masterLabel>
+            <translation><!-- 16 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>17</masterLabel>
+            <translation><!-- 17 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>18</masterLabel>
+            <translation><!-- 18 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>19</masterLabel>
+            <translation><!-- 19 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>2</masterLabel>
+            <translation><!-- 2 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>20</masterLabel>
+            <translation><!-- 20 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>21</masterLabel>
+            <translation><!-- 21 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>22</masterLabel>
+            <translation><!-- 22 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>23</masterLabel>
+            <translation><!-- 23 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>24</masterLabel>
+            <translation><!-- 24 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>25</masterLabel>
+            <translation><!-- 25 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>26</masterLabel>
+            <translation><!-- 26 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>27</masterLabel>
+            <translation><!-- 27 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>28</masterLabel>
+            <translation><!-- 28 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>29</masterLabel>
+            <translation><!-- 29 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>3</masterLabel>
+            <translation><!-- 3 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>30</masterLabel>
+            <translation><!-- 30 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>31</masterLabel>
+            <translation><!-- 31 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>4</masterLabel>
+            <translation><!-- 4 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>5</masterLabel>
+            <translation><!-- 5 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>6</masterLabel>
+            <translation><!-- 6 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>7</masterLabel>
+            <translation><!-- 7 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>8</masterLabel>
+            <translation><!-- 8 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>9</masterLabel>
+            <translation><!-- 9 --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>El mes de l&apos;any en què aquesta adreça substitueix l&apos;adreça predeterminada.</help>
+        <label>Mes d&apos;inici estacional</label>
+        <name>Seasonal_Start_Month__c</name>
+        <picklistValues>
+            <masterLabel>1</masterLabel>
+            <translation><!-- 1 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>10</masterLabel>
+            <translation><!-- 10 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>11</masterLabel>
+            <translation><!-- 11 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>12</masterLabel>
+            <translation><!-- 12 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>2</masterLabel>
+            <translation><!-- 2 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>3</masterLabel>
+            <translation><!-- 3 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>4</masterLabel>
+            <translation><!-- 4 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>5</masterLabel>
+            <translation><!-- 5 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>6</masterLabel>
+            <translation><!-- 6 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>7</masterLabel>
+            <translation><!-- 7 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>8</masterLabel>
+            <translation><!-- 8 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>9</masterLabel>
+            <translation><!-- 9 --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>L&apos;any en què aquesta adreça substitueix l&apos;adreça predeterminada.</help>
+        <label>Any d&apos;inici estacional</label>
+        <name>Seasonal_Start_Year__c</name>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <layouts>
+        <layout>HEDA Address Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Address ID --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Address__c-ca.objectTranslation
+++ b/src/objectTranslations/Address__c-ca.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Address --></value>
+        <value>Adreça</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Address --></value>
+        <value>Adreces</value>
     </caseValues>
     <fields>
         <label>Tipus d&apos;adreça</label>
@@ -466,7 +466,7 @@
         <label>Any d&apos;inici estacional</label>
         <name>Seasonal_Start_Year__c</name>
     </fields>
-    <gender><!-- Feminine --></gender>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Address Layout</layout>
         <sections>
@@ -474,6 +474,6 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <nameFieldLabel><!-- Address ID --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <nameFieldLabel>ID d&apos;adreça</nameFieldLabel>
+    <startsWith>Vowel</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Affiliation__c-ca.objectTranslation
+++ b/src/objectTranslations/Affiliation__c-ca.objectTranslation
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Affiliation --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Affiliation --></value>
+    </caseValues>
+    <fields>
+        <label>Organització</label>
+        <name>Account__c</name>
+        <relationshipLabel>Contactes afiliats</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Tipus d&apos;afiliació</label>
+        <name>Affiliation_Type__c</name>
+    </fields>
+    <fields>
+        <label>Contacte</label>
+        <name>Contact__c</name>
+        <relationshipLabel>Comptes afiliats</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Descripció</label>
+        <name>Description__c</name>
+    </fields>
+    <fields>
+        <label>Data de finalització</label>
+        <name>EndDate__c</name>
+    </fields>
+    <fields>
+        <help>Si es marca, l&apos;organització d&apos;afiliació es desa al Registre de contactes.</help>
+        <label>Primari</label>
+        <name>Primary__c</name>
+    </fields>
+    <fields>
+        <label>Funció</label>
+        <name>Role__c</name>
+        <picklistValues>
+            <masterLabel>Applicant</masterLabel>
+            <translation>Sol·licitant</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Employee</masterLabel>
+            <translation>Empleat</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Faculty</masterLabel>
+            <translation>Facultat</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Prospect</masterLabel>
+            <translation>Perspectiva</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Student</masterLabel>
+            <translation>Estudiant</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>Data d&apos;inici</label>
+        <name>StartDate__c</name>
+    </fields>
+    <fields>
+        <label>Estat</label>
+        <name>Status__c</name>
+        <picklistValues>
+            <masterLabel>Current</masterLabel>
+            <translation>Actual</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Former</masterLabel>
+            <translation>Antic</translation>
+        </picklistValues>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <layouts>
+        <layout>HEDA Affiliation Layout</layout>
+        <sections>
+            <label>Informació d&apos;afiliació</label>
+            <section>Affiliation Information</section>
+        </sections>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Affiliation Key --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Affiliation__c-ca.objectTranslation
+++ b/src/objectTranslations/Affiliation__c-ca.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Affiliation --></value>
+        <value>Afiliació</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Affiliation --></value>
+        <value>Afiliacions</value>
     </caseValues>
     <fields>
         <label>Organització</label>
@@ -75,7 +75,7 @@
             <translation>Antic</translation>
         </picklistValues>
     </fields>
-    <gender><!-- Feminine --></gender>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Affiliation Layout</layout>
         <sections>
@@ -87,6 +87,6 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <nameFieldLabel><!-- Affiliation Key --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <nameFieldLabel>Clau d&apos;afiliació</nameFieldLabel>
+    <startsWith>Vowel</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Affl_Mappings__c-ca.objectTranslation
+++ b/src/objectTranslations/Affl_Mappings__c-ca.objectTranslation
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Affl Mappings --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Affl Mappings --></value>
+    </caseValues>
+    <fields>
+        <help>L&apos;etiqueta Tipus de registre del compte.</help>
+        <label>Tipus de registre del compte</label>
+        <name>Account_Record_Type__c</name>
+    </fields>
+    <fields>
+        <label>Funció d&apos;inscripció automàtica</label>
+        <name>Auto_Program_Enrollment_Role__c</name>
+    </fields>
+    <fields>
+        <label>Estat d&apos;inscripció automàtica</label>
+        <name>Auto_Program_Enrollment_Status__c</name>
+    </fields>
+    <fields>
+        <help>Si està marcada, es crearà automàticament un registre d&apos;inscripció del programa quan l&apos;usuari crea una Afiliació a un compte d&apos;aquest tipus.</help>
+        <label>Inscripció automàtica</label>
+        <name>Auto_Program_Enrollment__c</name>
+    </fields>
+    <fields>
+        <help>L&apos;etiqueta del camp de cerca en el contacte que apunta al compte principal del Tipus de registre especificat.</help>
+        <label>Camp d&apos;afiliació primària</label>
+        <name>Primary_Affl_Field__c</name>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Contact-ca.objectTranslation
+++ b/src/objectTranslations/Contact-ca.objectTranslation
@@ -1,0 +1,3655 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <help>El correu electrònic alternatiu és un quart correu electrònic opcional: no és un correu electrònic personal, preferit ni de treball.</help>
+        <label>Correu electrònic alternatiu</label>
+        <name>AlternateEmail__c</name>
+    </fields>
+    <fields>
+        <label>Ciutadania</label>
+        <name>Citizenship__c</name>
+        <picklistValues>
+            <masterLabel>Afghanistan</masterLabel>
+            <translation>Afganistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Albania</masterLabel>
+            <translation>Albània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Algeria</masterLabel>
+            <translation>Algèria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>American Samoa</masterLabel>
+            <translation>Samoa Nord-americana</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Andorra</masterLabel>
+            <translation><!-- Andorra --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Angola</masterLabel>
+            <translation><!-- Angola --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Anguilla</masterLabel>
+            <translation><!-- Anguilla --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Antarctica</masterLabel>
+            <translation>Antàrtida</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Antigua and Barbuda</masterLabel>
+            <translation>Antigua i Barbuda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Argentina</masterLabel>
+            <translation><!-- Argentina --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Armenia</masterLabel>
+            <translation>Armènia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Aruba</masterLabel>
+            <translation><!-- Aruba --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Australia</masterLabel>
+            <translation>Austràlia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Austria</masterLabel>
+            <translation>Àustria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Azerbaijan</masterLabel>
+            <translation>Azerbaidjan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bahamas (the)</masterLabel>
+            <translation>Bahames (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bahrain</masterLabel>
+            <translation><!-- Bahrain --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bangladesh</masterLabel>
+            <translation>Bangla Desh</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Barbados</masterLabel>
+            <translation><!-- Barbados --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belarus</masterLabel>
+            <translation>Bielorússia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belgium</masterLabel>
+            <translation>Bèlgica</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belize</masterLabel>
+            <translation><!-- Belize --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Benin</masterLabel>
+            <translation>Benín</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bermuda</masterLabel>
+            <translation>Bermudes (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bhutan</masterLabel>
+            <translation><!-- Bhutan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bolivia (Plurinational State of)</masterLabel>
+            <translation>Bolívia (Estat Plurinacional de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bonaire, Sint Eustatius and Saba</masterLabel>
+            <translation>Bonaire, Sint Eustatius i Saba</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bosnia and Herzegovina</masterLabel>
+            <translation>Bòsnia i Hercegovina</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Botswana</masterLabel>
+            <translation><!-- Botswana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bouvet Island</masterLabel>
+            <translation>Illa de Bouvet</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Brazil</masterLabel>
+            <translation>Brasil</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>British Antarctic Territory</masterLabel>
+            <translation>Territori Antàrtic Britànic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>British Indian Ocean Territory (the)</masterLabel>
+            <translation>Territori Britànic de l&apos;Oceà Índic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Brunei Darussalam</masterLabel>
+            <translation><!-- Brunei Darussalam --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bulgaria</masterLabel>
+            <translation>Bulgària</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burkina Faso</masterLabel>
+            <translation><!-- Burkina Faso --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burma</masterLabel>
+            <translation>Birmània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burundi</masterLabel>
+            <translation><!-- Burundi --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Byelorussian SSR</masterLabel>
+            <translation>RSS de Bielorússia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cabo Verde</masterLabel>
+            <translation>Cap Verd</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cambodia</masterLabel>
+            <translation>Cambodja</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cameroon</masterLabel>
+            <translation>Camerun</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Canada</masterLabel>
+            <translation><!-- Canada --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Canton and Enderbury Islands</masterLabel>
+            <translation>Illes de Canton i Enderbury</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cayman Islands (the)</masterLabel>
+            <translation>Illes Caiman (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Central African Republic (the)</masterLabel>
+            <translation>República Centreafricana (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Chad</masterLabel>
+            <translation>Txad</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Chile</masterLabel>
+            <translation>Xile</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>China</masterLabel>
+            <translation>Xina</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Christmas Island</masterLabel>
+            <translation>Illa Christmas</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cocos (Keeling) Islands (the)</masterLabel>
+            <translation>Illes Cocos (Keeling) (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Colombia</masterLabel>
+            <translation>Colòmbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Comoros (the)</masterLabel>
+            <translation>Comores (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Congo (the Democratic Republic of the)</masterLabel>
+            <translation>Congo (República Democràtica del)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Congo (the)</masterLabel>
+            <translation>Congo (el)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cook Islands (the)</masterLabel>
+            <translation>Illes Cook (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Costa Rica</masterLabel>
+            <translation><!-- Costa Rica --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Croatia</masterLabel>
+            <translation>Croàcia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cuba</masterLabel>
+            <translation><!-- Cuba --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Curaçao</masterLabel>
+            <translation><!-- Curaçao --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cyprus</masterLabel>
+            <translation>Xipre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Czech Republic (the)</masterLabel>
+            <translation>República Txeca (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Czechoslovakia</masterLabel>
+            <translation>Txecoslovàquia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Côte d&apos;Ivoire</masterLabel>
+            <translation>Costa d&apos;Ivori</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dahomey</masterLabel>
+            <translation><!-- Dahomey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Denmark</masterLabel>
+            <translation>Dinamarca</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Djibouti</masterLabel>
+            <translation><!-- Djibouti --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dominica</masterLabel>
+            <translation><!-- Dominica --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dominican Republic (the)</masterLabel>
+            <translation>República Dominicana (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dronning Maud Land</masterLabel>
+            <translation>Terra de la Reina Maud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>East Timor</masterLabel>
+            <translation>Timor Oriental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ecuador</masterLabel>
+            <translation>Equador</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Egypt</masterLabel>
+            <translation>Egipte</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>El Salvador</masterLabel>
+            <translation><!-- El Salvador --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Equatorial Guinea</masterLabel>
+            <translation>Guinea Equatorial</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Eritrea</masterLabel>
+            <translation><!-- Eritrea --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Estonia</masterLabel>
+            <translation>Estònia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ethiopia</masterLabel>
+            <translation>Etiòpia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Falkland Islands (the) [Malvinas]</masterLabel>
+            <translation>Illes Malvines (les) [Falkland]</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Faroe Islands (the)</masterLabel>
+            <translation>Illes Fèroe (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Fiji</masterLabel>
+            <translation><!-- Fiji --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Finland</masterLabel>
+            <translation>Finlàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>France</masterLabel>
+            <translation>França</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>France, Metropolitan</masterLabel>
+            <translation>França, Metropolitana</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Afars and Issas</masterLabel>
+            <translation>Territori Francès dels Àfars i dels Isses</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Guiana</masterLabel>
+            <translation>Guaiana Francesa</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Polynesia</masterLabel>
+            <translation>Polinèsia Francesa</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Southern Territories (the)</masterLabel>
+            <translation>Terres Australs Franceses (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Southern and Antarctic Territories</masterLabel>
+            <translation>Terres Australs i Antàrtiques Franceses (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gabon</masterLabel>
+            <translation><!-- Gabon --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gambia (the)</masterLabel>
+            <translation>Gàmbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Georgia</masterLabel>
+            <translation>Geòrgia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>German Democratic Republic</masterLabel>
+            <translation>República Democràtica Alemanya</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Germany</masterLabel>
+            <translation>Alemanya</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ghana</masterLabel>
+            <translation><!-- Ghana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gibraltar</masterLabel>
+            <translation><!-- Gibraltar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gilbert and Ellice Islands</masterLabel>
+            <translation>Illes Gilbert i Ellice</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Greece</masterLabel>
+            <translation>Grècia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Greenland</masterLabel>
+            <translation>Groenlàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grenada</masterLabel>
+            <translation><!-- Grenada --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guadeloupe</masterLabel>
+            <translation>Guadalupe</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guam</masterLabel>
+            <translation><!-- Guam --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guatemala</masterLabel>
+            <translation><!-- Guatemala --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guernsey</masterLabel>
+            <translation><!-- Guernsey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guinea</masterLabel>
+            <translation><!-- Guinea --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guinea-Bissau</masterLabel>
+            <translation>Guinea Bissau</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guyana</masterLabel>
+            <translation><!-- Guyana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Haiti</masterLabel>
+            <translation>Haití</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Heard Island and McDonal Islands</masterLabel>
+            <translation>Illes Heard i McDonald</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Holy See (the)</masterLabel>
+            <translation>Santa Seu (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Honduras</masterLabel>
+            <translation>Hondures</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hong Kong</masterLabel>
+            <translation><!-- Hong Kong --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hungary</masterLabel>
+            <translation>Hongria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iceland</masterLabel>
+            <translation>Islàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>India</masterLabel>
+            <translation>Índia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Indonesia</masterLabel>
+            <translation>Indonèsia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iran (Islamic Republic of)</masterLabel>
+            <translation>Iran (República Islàmica de l&apos;Iran)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iraq</masterLabel>
+            <translation><!-- Iraq --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ireland</masterLabel>
+            <translation>Irlanda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Isle of Man</masterLabel>
+            <translation>Illa de Man</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Israel</masterLabel>
+            <translation><!-- Israel --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Italy</masterLabel>
+            <translation>Itàlia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jamaica</masterLabel>
+            <translation><!-- Jamaica --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Japan</masterLabel>
+            <translation>Japó</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jersey</masterLabel>
+            <translation><!-- Jersey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Johnston Island</masterLabel>
+            <translation>Illa Johnston</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jordan</masterLabel>
+            <translation>Jordània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kazakhstan</masterLabel>
+            <translation><!-- Kazakhstan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kenya</masterLabel>
+            <translation><!-- Kenya --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kiribati</masterLabel>
+            <translation><!-- Kiribati --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Korea (the Democratic People&apos;s Republic of)</masterLabel>
+            <translation>Corea (República Democràtica Popular de Corea)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Korea (the Republic of)</masterLabel>
+            <translation>Corea (la República de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kuwait</masterLabel>
+            <translation><!-- Kuwait --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kyrgyzstan</masterLabel>
+            <translation>Kirguizistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lao People&apos;s Democratic Republic (the)</masterLabel>
+            <translation>República Democràtica Popular de Laos (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Latvia</masterLabel>
+            <translation>Letònia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lebanon</masterLabel>
+            <translation>Líban</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lesotho</masterLabel>
+            <translation><!-- Lesotho --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Liberia</masterLabel>
+            <translation>Libèria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Libya</masterLabel>
+            <translation>Líbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Liechtenstein</masterLabel>
+            <translation><!-- Liechtenstein --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lithuania</masterLabel>
+            <translation>Lituània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Luxembourg</masterLabel>
+            <translation>Luxemburg</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Macao</masterLabel>
+            <translation>Macau</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Macedonia (the former Yugoslav Republic of)</masterLabel>
+            <translation>Macedònia (Antiga República Iugoslava de Macedònia)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Madagascar</masterLabel>
+            <translation><!-- Madagascar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malawi</masterLabel>
+            <translation><!-- Malawi --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malaysia</masterLabel>
+            <translation>Malàisia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mali</masterLabel>
+            <translation><!-- Mali --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malta</masterLabel>
+            <translation><!-- Malta --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Marshall Islands (the)</masterLabel>
+            <translation>Illes Marshall (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Martinique</masterLabel>
+            <translation>Martinica</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mauritania</masterLabel>
+            <translation>Mauritània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mauritius</masterLabel>
+            <translation>Maurici</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mayotte</masterLabel>
+            <translation><!-- Mayotte --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mexico</masterLabel>
+            <translation>Mèxic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Micronesia (Federated States of)</masterLabel>
+            <translation>Micronèsia (Estats Federats de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Midway Islands</masterLabel>
+            <translation>Illa Midway</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Moldova (the Republic of)</masterLabel>
+            <translation>Moldàvia (la República de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Monaco</masterLabel>
+            <translation>Mònaco</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mongolia</masterLabel>
+            <translation>Mongòlia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Montenegro</masterLabel>
+            <translation><!-- Montenegro --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Montserrat</masterLabel>
+            <translation><!-- Montserrat --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Morocco</masterLabel>
+            <translation>Marroc</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mozambique</masterLabel>
+            <translation>Moçambic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Myanmar</masterLabel>
+            <translation><!-- Myanmar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Namibia</masterLabel>
+            <translation>Namíbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nauru</masterLabel>
+            <translation><!-- Nauru --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nepal</masterLabel>
+            <translation><!-- Nepal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Netherlands (the)</masterLabel>
+            <translation>Països Baixos (Els)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Netherlands Antilles</masterLabel>
+            <translation>Antilles Neerlandeses</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Neutral Zone</masterLabel>
+            <translation>Zona Neutral</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Caledonia</masterLabel>
+            <translation>Nova Caledònia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Hebrides</masterLabel>
+            <translation>Illes Hèbrides</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Zealand</masterLabel>
+            <translation>Nova Zelanda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nicaragua</masterLabel>
+            <translation><!-- Nicaragua --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Niger (the)</masterLabel>
+            <translation>Níger (El)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nigeria</masterLabel>
+            <translation>Nigèria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Niue</masterLabel>
+            <translation><!-- Niue --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Norfolk Island</masterLabel>
+            <translation>Illa Norfolk</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Northern Mariana Islands (the)</masterLabel>
+            <translation>Illes Mariannes Septentrionals (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Norway</masterLabel>
+            <translation>Noruega</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Oman</masterLabel>
+            <translation><!-- Oman --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pacific Islands (Trust Territory)</masterLabel>
+            <translation>Illes del Pacífic (Territori en Fideïcomís de les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pakistan</masterLabel>
+            <translation><!-- Pakistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Palau</masterLabel>
+            <translation><!-- Palau --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Palestine, State of</masterLabel>
+            <translation>Palestina, Estat de</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Panama</masterLabel>
+            <translation>Panamà</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Panama Canal Zone</masterLabel>
+            <translation>Zona del Canal de Panamà</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Papua New Guinea</masterLabel>
+            <translation>Papua Nova Guinea</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Paraguay</masterLabel>
+            <translation>Paraguai</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Peru</masterLabel>
+            <translation>Perú</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Philippines (the)</masterLabel>
+            <translation>Filipines (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pitcairn</masterLabel>
+            <translation><!-- Pitcairn --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Poland</masterLabel>
+            <translation>Polònia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Portugal</masterLabel>
+            <translation><!-- Portugal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Puerto Rico</masterLabel>
+            <translation><!-- Puerto Rico --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Qatar</masterLabel>
+            <translation><!-- Qatar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Romania</masterLabel>
+            <translation><!-- Romania --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Russian Federation (the)</masterLabel>
+            <translation>Federació Russa (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Rwanda</masterLabel>
+            <translation>Ruanda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Réunion</masterLabel>
+            <translation>Reunió</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Barthélemy</masterLabel>
+            <translation><!-- Saint Barthélemy --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Helena, Ascension and Tristan da Cunha</masterLabel>
+            <translation>Santa Helena, Ascensió i Tristan da Cunha</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Kitts and Nevis</masterLabel>
+            <translation>Saint Christopher i Nevis</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Lucia</masterLabel>
+            <translation><!-- Saint Lucia --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Martin (French part)</masterLabel>
+            <translation>Saint Martin (part francesa)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Pierre and Miquelon</masterLabel>
+            <translation>Saint-Pierre i Miquelon</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Vincent and the Grenadines</masterLabel>
+            <translation>Saint Vincent i les Grenadines</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Samoa</masterLabel>
+            <translation><!-- Samoa --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>San Marino</masterLabel>
+            <translation><!-- San Marino --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sao Tome and Principe</masterLabel>
+            <translation>São Tomé i Príncipe</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saudi Arabia</masterLabel>
+            <translation>Aràbia Saudita</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Senegal</masterLabel>
+            <translation><!-- Senegal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Serbia</masterLabel>
+            <translation>Sèrbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Serbia and Montenegro</masterLabel>
+            <translation>Sèrbia i Montenegro</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Seychelles</masterLabel>
+            <translation><!-- Seychelles --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sierra Leone</masterLabel>
+            <translation><!-- Sierra Leone --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sikkim</masterLabel>
+            <translation><!-- Sikkim --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Singapore</masterLabel>
+            <translation>Singapur</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sint Maarten (Dutch part)</masterLabel>
+            <translation>Sint Maarten (part neerlandesa)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Slovakia</masterLabel>
+            <translation>Eslovàquia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Slovenia</masterLabel>
+            <translation>Eslovènia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Solomon Islands</masterLabel>
+            <translation>Illes Salomó</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Somalia</masterLabel>
+            <translation>Somàlia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Africa</masterLabel>
+            <translation>Sud-àfrica</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Georgia and the South Sandwich Islands</masterLabel>
+            <translation>Illes Geòrgia del Sud i Sandwich del Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Sudan</masterLabel>
+            <translation>Sudan del Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Southern Rodesia</masterLabel>
+            <translation>Rhodèsia del Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Spain</masterLabel>
+            <translation>Espanya</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sri Lanka</masterLabel>
+            <translation><!-- Sri Lanka --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sudan (the)</masterLabel>
+            <translation>Sudan (el)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Surinam</masterLabel>
+            <translation><!-- Surinam --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Svalbard and Jan Mayen</masterLabel>
+            <translation>Svalbard i Jan Mayen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Swaziland</masterLabel>
+            <translation>Swazilàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sweden</masterLabel>
+            <translation>Suècia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Switzerland</masterLabel>
+            <translation>Suïssa</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Syrian Arab Republic</masterLabel>
+            <translation>República Àrab Siriana</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Taiwan (Province of China)</masterLabel>
+            <translation>Taiwan (Província de Xina)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tajikistan</masterLabel>
+            <translation>Tadjikistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tanzania, United Republic of</masterLabel>
+            <translation>Tanzània, República Unida de</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Thailand</masterLabel>
+            <translation>Tailàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Timor-Leste</masterLabel>
+            <translation>Timor Oriental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Togo</masterLabel>
+            <translation><!-- Togo --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tokelau</masterLabel>
+            <translation><!-- Tokelau --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tonga</masterLabel>
+            <translation><!-- Tonga --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Trinidad and Tobago</masterLabel>
+            <translation>Trinitat i Tobago</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tunisia</masterLabel>
+            <translation>Tunísia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turkey</masterLabel>
+            <translation>Turquia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turkmenistan</masterLabel>
+            <translation><!-- Turkmenistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turks and Caicos Islands (the)</masterLabel>
+            <translation>Illes Turks i Caicos (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tuvalu</masterLabel>
+            <translation><!-- Tuvalu --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>USSR</masterLabel>
+            <translation>URSS</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uganda</masterLabel>
+            <translation><!-- Uganda --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ukraine</masterLabel>
+            <translation>Ucraïna</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United Arab Emirates (the)</masterLabel>
+            <translation>Emirats Àrabs Units (els)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United Kingdom of Great Britain and Northern Ireland (the)</masterLabel>
+            <translation>Regne Unit de la Gran Bretanya i Irlanda del Nord (el)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United States Minor Outlying Islands (the)</masterLabel>
+            <translation>Illes Perifèriques Menors dels EUA (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United States of America (the)</masterLabel>
+            <translation>Estats Units d&apos;Amèrica (els)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Unites States Miscellaneous Pacific Islands</masterLabel>
+            <translation>Diverses Illes del Pacífic dels EUA</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Upper Volta</masterLabel>
+            <translation><!-- Upper Volta --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uruguay</masterLabel>
+            <translation>Uruguai</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uzbekistan</masterLabel>
+            <translation><!-- Uzbekistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Vanuatu</masterLabel>
+            <translation><!-- Vanuatu --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Venezuela (Bolivarian Republic of)</masterLabel>
+            <translation>Veneçuela (República Bolivariana de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Viet Nam</masterLabel>
+            <translation>Vietnam</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Viet-Nam, Democratic Republic of</masterLabel>
+            <translation>República Socialista de Vietnam</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Virgin Islands (British)</masterLabel>
+            <translation>Illes Verges (Britàniques)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Virgin Islands (U.S.)</masterLabel>
+            <translation>Illes Verges (Nord-americanes)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wake Island</masterLabel>
+            <translation>Illa Wake</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wallis and Futuna</masterLabel>
+            <translation>Wallis i Futuna</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Western Sahara</masterLabel>
+            <translation>Sàhara Occidental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yemen</masterLabel>
+            <translation>Iemen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yemen, Democratic</masterLabel>
+            <translation>República del Iemen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yugoslavia</masterLabel>
+            <translation>Iugoslàvia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zaire</masterLabel>
+            <translation><!-- Zaire --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zambia</masterLabel>
+            <translation>Zàmbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zimbabwe</masterLabel>
+            <translation><!-- Zimbabwe --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Åland Islands</masterLabel>
+            <translation>Illes Åland</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>País d&apos;origen</label>
+        <name>Country_of_Origin__c</name>
+        <picklistValues>
+            <masterLabel>Afghanistan</masterLabel>
+            <translation>Afganistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Albania</masterLabel>
+            <translation>Albània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Algeria</masterLabel>
+            <translation>Algèria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>American Samoa</masterLabel>
+            <translation>Samoa Nord-americana</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Andorra</masterLabel>
+            <translation><!-- Andorra --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Angola</masterLabel>
+            <translation><!-- Angola --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Anguilla</masterLabel>
+            <translation><!-- Anguilla --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Antarctica</masterLabel>
+            <translation>Antàrtida</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Antigua and Barbuda</masterLabel>
+            <translation>Antigua i Barbuda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Argentina</masterLabel>
+            <translation><!-- Argentina --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Armenia</masterLabel>
+            <translation>Armènia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Aruba</masterLabel>
+            <translation><!-- Aruba --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Australia</masterLabel>
+            <translation>Austràlia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Austria</masterLabel>
+            <translation>Àustria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Azerbaijan</masterLabel>
+            <translation>Azerbaidjan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bahamas (the)</masterLabel>
+            <translation>Bahames (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bahrain</masterLabel>
+            <translation><!-- Bahrain --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bangladesh</masterLabel>
+            <translation>Bangla Desh</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Barbados</masterLabel>
+            <translation><!-- Barbados --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belarus</masterLabel>
+            <translation>Bielorússia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belgium</masterLabel>
+            <translation>Bèlgica</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belize</masterLabel>
+            <translation><!-- Belize --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Benin</masterLabel>
+            <translation>Benín</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bermuda</masterLabel>
+            <translation>Bermudes (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bhutan</masterLabel>
+            <translation><!-- Bhutan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bolivia (Plurinational State of)</masterLabel>
+            <translation>Bolívia (Estat Plurinacional de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bonaire, Sint Eustatius and Saba</masterLabel>
+            <translation>Bonaire, Sint Eustatius i Saba</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bosnia and Herzegovina</masterLabel>
+            <translation>Bòsnia i Hercegovina</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Botswana</masterLabel>
+            <translation><!-- Botswana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bouvet Island</masterLabel>
+            <translation>Illa de Bouvet</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Brazil</masterLabel>
+            <translation>Brasil</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>British Antarctic Territory</masterLabel>
+            <translation>Territori Antàrtic Britànic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>British Indian Ocean Territory (the)</masterLabel>
+            <translation>Territori Britànic de l&apos;Oceà Índic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Brunei Darussalam</masterLabel>
+            <translation><!-- Brunei Darussalam --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bulgaria</masterLabel>
+            <translation>Bulgària</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burkina Faso</masterLabel>
+            <translation><!-- Burkina Faso --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burma</masterLabel>
+            <translation>Birmània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burundi</masterLabel>
+            <translation><!-- Burundi --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Byelorussian SSR</masterLabel>
+            <translation>RSS de Bielorússia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cabo Verde</masterLabel>
+            <translation>Cap Verd</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cambodia</masterLabel>
+            <translation>Cambodja</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cameroon</masterLabel>
+            <translation>Camerun</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Canada</masterLabel>
+            <translation><!-- Canada --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Canton and Enderbury Islands</masterLabel>
+            <translation>Illes de Canton i Enderbury</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cayman Islands (the)</masterLabel>
+            <translation>Illes Caiman (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Central African Republic (the)</masterLabel>
+            <translation>República Centreafricana (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Chad</masterLabel>
+            <translation>Txad</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Chile</masterLabel>
+            <translation>Xile</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>China</masterLabel>
+            <translation>Xina</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Christmas Island</masterLabel>
+            <translation>Illa Christmas</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cocos (Keeling) Islands (the)</masterLabel>
+            <translation>Illes Cocos (Keeling) (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Colombia</masterLabel>
+            <translation>Colòmbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Comoros (the)</masterLabel>
+            <translation>Comores (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Congo (the Democratic Republic of the)</masterLabel>
+            <translation>Congo (República Democràtica del)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Congo (the)</masterLabel>
+            <translation>Congo (el)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cook Islands (the)</masterLabel>
+            <translation>Illes Cook (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Costa Rica</masterLabel>
+            <translation><!-- Costa Rica --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Croatia</masterLabel>
+            <translation>Croàcia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cuba</masterLabel>
+            <translation><!-- Cuba --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Curaçao</masterLabel>
+            <translation><!-- Curaçao --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cyprus</masterLabel>
+            <translation>Xipre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Czech Republic (the)</masterLabel>
+            <translation>República Txeca (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Czechoslovakia</masterLabel>
+            <translation>Txecoslovàquia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Côte d&apos;Ivoire</masterLabel>
+            <translation>Costa d&apos;Ivori</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dahomey</masterLabel>
+            <translation><!-- Dahomey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Denmark</masterLabel>
+            <translation>Dinamarca</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Djibouti</masterLabel>
+            <translation><!-- Djibouti --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dominica</masterLabel>
+            <translation><!-- Dominica --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dominican Republic (the)</masterLabel>
+            <translation>República Dominicana (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dronning Maud Land</masterLabel>
+            <translation>Terra de la Reina Maud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>East Timor</masterLabel>
+            <translation>Timor Oriental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ecuador</masterLabel>
+            <translation>Equador</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Egypt</masterLabel>
+            <translation>Egipte</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>El Salvador</masterLabel>
+            <translation><!-- El Salvador --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Equatorial Guinea</masterLabel>
+            <translation>Guinea Equatorial</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Eritrea</masterLabel>
+            <translation><!-- Eritrea --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Estonia</masterLabel>
+            <translation>Estònia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ethiopia</masterLabel>
+            <translation>Etiòpia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Falkland Islands (the) [Malvinas]</masterLabel>
+            <translation>Illes Malvines (les) [Falkland]</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Faroe Islands (the)</masterLabel>
+            <translation>Illes Fèroe (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Fiji</masterLabel>
+            <translation><!-- Fiji --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Finland</masterLabel>
+            <translation>Finlàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>France</masterLabel>
+            <translation>França</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>France, Metropolitan</masterLabel>
+            <translation>França, Metropolitana</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Afars and Issas</masterLabel>
+            <translation>Territori Francès dels Àfars i dels Isses</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Guiana</masterLabel>
+            <translation>Guaiana Francesa</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Polynesia</masterLabel>
+            <translation>Polinèsia Francesa</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Southern Territories (the)</masterLabel>
+            <translation>Terres Australs Franceses (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Southern and Antarctic Territories</masterLabel>
+            <translation>Terres Australs i Antàrtiques Franceses (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gabon</masterLabel>
+            <translation><!-- Gabon --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gambia (the)</masterLabel>
+            <translation>Gàmbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Georgia</masterLabel>
+            <translation>Geòrgia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>German Democratic Republic</masterLabel>
+            <translation>República Democràtica Alemanya</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Germany</masterLabel>
+            <translation>Alemanya</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ghana</masterLabel>
+            <translation><!-- Ghana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gibraltar</masterLabel>
+            <translation><!-- Gibraltar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gilbert and Ellice Islands</masterLabel>
+            <translation>Illes Gilbert i Ellice</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Greece</masterLabel>
+            <translation>Grècia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Greenland</masterLabel>
+            <translation>Groenlàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grenada</masterLabel>
+            <translation><!-- Grenada --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guadeloupe</masterLabel>
+            <translation>Guadalupe</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guam</masterLabel>
+            <translation><!-- Guam --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guatemala</masterLabel>
+            <translation><!-- Guatemala --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guernsey</masterLabel>
+            <translation><!-- Guernsey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guinea</masterLabel>
+            <translation><!-- Guinea --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guinea-Bissau</masterLabel>
+            <translation>Guinea Bissau</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guyana</masterLabel>
+            <translation><!-- Guyana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Haiti</masterLabel>
+            <translation>Haití</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Heard Island and McDonal Islands</masterLabel>
+            <translation>Illes Heard i McDonald</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Holy See (the)</masterLabel>
+            <translation>Santa Seu (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Honduras</masterLabel>
+            <translation>Hondures</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hong Kong</masterLabel>
+            <translation><!-- Hong Kong --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hungary</masterLabel>
+            <translation>Hongria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iceland</masterLabel>
+            <translation>Islàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>India</masterLabel>
+            <translation>Índia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Indonesia</masterLabel>
+            <translation>Indonèsia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iran (Islamic Republic of)</masterLabel>
+            <translation>Iran (República Islàmica de l&apos;Iran)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iraq</masterLabel>
+            <translation><!-- Iraq --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ireland</masterLabel>
+            <translation>Irlanda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Isle of Man</masterLabel>
+            <translation>Illa de Man</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Israel</masterLabel>
+            <translation><!-- Israel --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Italy</masterLabel>
+            <translation>Itàlia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jamaica</masterLabel>
+            <translation><!-- Jamaica --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Japan</masterLabel>
+            <translation>Japó</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jersey</masterLabel>
+            <translation><!-- Jersey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Johnston Island</masterLabel>
+            <translation>Illa Johnston</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jordan</masterLabel>
+            <translation>Jordània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kazakhstan</masterLabel>
+            <translation><!-- Kazakhstan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kenya</masterLabel>
+            <translation><!-- Kenya --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kiribati</masterLabel>
+            <translation><!-- Kiribati --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Korea (the Democratic People&apos;s Republic of)</masterLabel>
+            <translation>Corea (República Democràtica Popular de Corea)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Korea (the Republic of)</masterLabel>
+            <translation>Corea (la República de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kuwait</masterLabel>
+            <translation><!-- Kuwait --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kyrgyzstan</masterLabel>
+            <translation>Kirguizistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lao People&apos;s Democratic Republic (the)</masterLabel>
+            <translation>República Democràtica Popular de Laos (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Latvia</masterLabel>
+            <translation>Letònia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lebanon</masterLabel>
+            <translation>Líban</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lesotho</masterLabel>
+            <translation><!-- Lesotho --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Liberia</masterLabel>
+            <translation>Libèria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Libya</masterLabel>
+            <translation>Líbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Liechtenstein</masterLabel>
+            <translation><!-- Liechtenstein --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lithuania</masterLabel>
+            <translation>Lituània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Luxembourg</masterLabel>
+            <translation>Luxemburg</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Macao</masterLabel>
+            <translation>Macau</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Macedonia (the former Yugoslav Republic of)</masterLabel>
+            <translation>Macedònia (Antiga República Iugoslava de Macedònia)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Madagascar</masterLabel>
+            <translation><!-- Madagascar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malawi</masterLabel>
+            <translation><!-- Malawi --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malaysia</masterLabel>
+            <translation>Malàisia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mali</masterLabel>
+            <translation><!-- Mali --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malta</masterLabel>
+            <translation><!-- Malta --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Marshall Islands (the)</masterLabel>
+            <translation>Illes Marshall (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Martinique</masterLabel>
+            <translation>Martinica</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mauritania</masterLabel>
+            <translation>Mauritània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mauritius</masterLabel>
+            <translation>Maurici</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mayotte</masterLabel>
+            <translation><!-- Mayotte --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mexico</masterLabel>
+            <translation>Mèxic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Micronesia (Federated States of)</masterLabel>
+            <translation>Micronèsia (Estats Federats de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Midway Islands</masterLabel>
+            <translation>Illa Midway</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Moldova (the Republic of)</masterLabel>
+            <translation>Moldàvia (la República de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Monaco</masterLabel>
+            <translation>Mònaco</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mongolia</masterLabel>
+            <translation>Mongòlia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Montenegro</masterLabel>
+            <translation><!-- Montenegro --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Montserrat</masterLabel>
+            <translation><!-- Montserrat --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Morocco</masterLabel>
+            <translation>Marroc</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mozambique</masterLabel>
+            <translation>Moçambic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Myanmar</masterLabel>
+            <translation><!-- Myanmar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Namibia</masterLabel>
+            <translation>Namíbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nauru</masterLabel>
+            <translation><!-- Nauru --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nepal</masterLabel>
+            <translation><!-- Nepal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Netherlands (the)</masterLabel>
+            <translation>Països Baixos (Els)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Netherlands Antilles</masterLabel>
+            <translation>Antilles Neerlandeses</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Neutral Zone</masterLabel>
+            <translation>Zona Neutral</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Caledonia</masterLabel>
+            <translation>Nova Caledònia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Hebrides</masterLabel>
+            <translation>Illes Hèbrides</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Zealand</masterLabel>
+            <translation>Nova Zelanda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nicaragua</masterLabel>
+            <translation><!-- Nicaragua --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Niger (the)</masterLabel>
+            <translation>Níger (El)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nigeria</masterLabel>
+            <translation>Nigèria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Niue</masterLabel>
+            <translation><!-- Niue --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Norfolk Island</masterLabel>
+            <translation>Illa Norfolk</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Northern Mariana Islands (the)</masterLabel>
+            <translation>Illes Mariannes Septentrionals (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Norway</masterLabel>
+            <translation>Noruega</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Oman</masterLabel>
+            <translation><!-- Oman --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pacific Islands (Trust Territory)</masterLabel>
+            <translation>Illes del Pacífic (Territori en Fideïcomís de les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pakistan</masterLabel>
+            <translation><!-- Pakistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Palau</masterLabel>
+            <translation><!-- Palau --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Palestine, State of</masterLabel>
+            <translation>Palestina, Estat de</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Panama</masterLabel>
+            <translation>Panamà</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Panama Canal Zone</masterLabel>
+            <translation>Zona del Canal de Panamà</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Papua New Guinea</masterLabel>
+            <translation>Papua Nova Guinea</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Paraguay</masterLabel>
+            <translation>Paraguai</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Peru</masterLabel>
+            <translation>Perú</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Philippines (the)</masterLabel>
+            <translation>Filipines (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pitcairn</masterLabel>
+            <translation><!-- Pitcairn --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Poland</masterLabel>
+            <translation>Polònia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Portugal</masterLabel>
+            <translation><!-- Portugal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Puerto Rico</masterLabel>
+            <translation><!-- Puerto Rico --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Qatar</masterLabel>
+            <translation><!-- Qatar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Romania</masterLabel>
+            <translation><!-- Romania --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Russian Federation (the)</masterLabel>
+            <translation>Federació Russa (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Rwanda</masterLabel>
+            <translation>Ruanda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Réunion</masterLabel>
+            <translation>Reunió</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Barthélemy</masterLabel>
+            <translation><!-- Saint Barthélemy --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Helena, Ascension and Tristan da Cunha</masterLabel>
+            <translation>Santa Helena, Ascensió i Tristan da Cunha</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Kitts and Nevis</masterLabel>
+            <translation>Saint Christopher i Nevis</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Lucia</masterLabel>
+            <translation><!-- Saint Lucia --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Martin (French part)</masterLabel>
+            <translation>Saint Martin (part francesa)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Pierre and Miquelon</masterLabel>
+            <translation>Saint-Pierre i Miquelon</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Vincent and the Grenadines</masterLabel>
+            <translation>Saint Vincent i les Grenadines</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Samoa</masterLabel>
+            <translation><!-- Samoa --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>San Marino</masterLabel>
+            <translation><!-- San Marino --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sao Tome and Principe</masterLabel>
+            <translation>São Tomé i Príncipe</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saudi Arabia</masterLabel>
+            <translation>Aràbia Saudita</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Senegal</masterLabel>
+            <translation><!-- Senegal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Serbia</masterLabel>
+            <translation>Sèrbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Serbia and Montenegro</masterLabel>
+            <translation>Sèrbia i Montenegro</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Seychelles</masterLabel>
+            <translation><!-- Seychelles --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sierra Leone</masterLabel>
+            <translation><!-- Sierra Leone --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sikkim</masterLabel>
+            <translation><!-- Sikkim --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Singapore</masterLabel>
+            <translation>Singapur</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sint Maarten (Dutch part)</masterLabel>
+            <translation>Sint Maarten (part neerlandesa)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Slovakia</masterLabel>
+            <translation>Eslovàquia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Slovenia</masterLabel>
+            <translation>Eslovènia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Solomon Islands</masterLabel>
+            <translation>Illes Salomó</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Somalia</masterLabel>
+            <translation>Somàlia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Africa</masterLabel>
+            <translation>Sud-àfrica</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Georgia and the South Sandwich Islands</masterLabel>
+            <translation>Illes Geòrgia del Sud i Sandwich del Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Sudan</masterLabel>
+            <translation>Sudan del Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Southern Rodesia</masterLabel>
+            <translation>Rhodèsia del Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Spain</masterLabel>
+            <translation>Espanya</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sri Lanka</masterLabel>
+            <translation><!-- Sri Lanka --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sudan (the)</masterLabel>
+            <translation>Sudan (el)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Surinam</masterLabel>
+            <translation><!-- Surinam --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Svalbard and Jan Mayen</masterLabel>
+            <translation>Svalbard i Jan Mayen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Swaziland</masterLabel>
+            <translation>Swazilàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sweden</masterLabel>
+            <translation>Suècia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Switzerland</masterLabel>
+            <translation>Suïssa</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Syrian Arab Republic</masterLabel>
+            <translation>República Àrab Siriana</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Taiwan (Province of China)</masterLabel>
+            <translation>Taiwan (Província de Xina)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tajikistan</masterLabel>
+            <translation>Tadjikistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tanzania, United Republic of</masterLabel>
+            <translation>Tanzània, República Unida de</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Thailand</masterLabel>
+            <translation>Tailàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Timor-Leste</masterLabel>
+            <translation>Timor Oriental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Togo</masterLabel>
+            <translation><!-- Togo --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tokelau</masterLabel>
+            <translation><!-- Tokelau --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tonga</masterLabel>
+            <translation><!-- Tonga --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Trinidad and Tobago</masterLabel>
+            <translation>Trinitat i Tobago</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tunisia</masterLabel>
+            <translation>Tunísia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turkey</masterLabel>
+            <translation>Turquia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turkmenistan</masterLabel>
+            <translation><!-- Turkmenistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turks and Caicos Islands (the)</masterLabel>
+            <translation>Illes Turks i Caicos (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tuvalu</masterLabel>
+            <translation><!-- Tuvalu --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>USSR</masterLabel>
+            <translation>URSS</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uganda</masterLabel>
+            <translation><!-- Uganda --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ukraine</masterLabel>
+            <translation>Ucraïna</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United Arab Emirates (the)</masterLabel>
+            <translation>Emirats Àrabs Units (els)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United Kingdom of Great Britain and Northern Ireland (the)</masterLabel>
+            <translation>Regne Unit de la Gran Bretanya i Irlanda del Nord (el)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United States Minor Outlying Islands (the)</masterLabel>
+            <translation>Illes Perifèriques Menors dels EUA (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United States of America (the)</masterLabel>
+            <translation>Estats Units d&apos;Amèrica (els)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Unites States Miscellaneous Pacific Islands</masterLabel>
+            <translation>Diverses Illes del Pacífic dels EUA</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Upper Volta</masterLabel>
+            <translation><!-- Upper Volta --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uruguay</masterLabel>
+            <translation>Uruguai</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uzbekistan</masterLabel>
+            <translation><!-- Uzbekistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Vanuatu</masterLabel>
+            <translation><!-- Vanuatu --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Venezuela (Bolivarian Republic of)</masterLabel>
+            <translation>Veneçuela (República Bolivariana de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Viet Nam</masterLabel>
+            <translation>Vietnam</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Viet-Nam, Democratic Republic of</masterLabel>
+            <translation>República Socialista de Vietnam</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Virgin Islands (British)</masterLabel>
+            <translation>Illes Verges (Britàniques)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Virgin Islands (U.S.)</masterLabel>
+            <translation>Illes Verges (Nord-americanes)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wake Island</masterLabel>
+            <translation>Illa Wake</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wallis and Futuna</masterLabel>
+            <translation>Wallis i Futuna</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Western Sahara</masterLabel>
+            <translation>Sàhara Occidental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yemen</masterLabel>
+            <translation>Iemen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yemen, Democratic</masterLabel>
+            <translation>República del Iemen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yugoslavia</masterLabel>
+            <translation>Iugoslàvia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zaire</masterLabel>
+            <translation><!-- Zaire --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zambia</masterLabel>
+            <translation>Zàmbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zimbabwe</masterLabel>
+            <translation><!-- Zimbabwe --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Åland Islands</masterLabel>
+            <translation>Illes Åland</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>L&apos;adreça actual que consta als camps de correu del contacte.</help>
+        <label>Adreça actual</label>
+        <name>Current_Address__c</name>
+        <relationshipLabel>Contactes (adreça actual)</relationshipLabel>
+    </fields>
+    <fields>
+        <help>Quan estigui seleccionada, aquesta opció marca el contacte com a difunt, i els exclou del nomenament de la llar, de correus electrònics i de trucades telefòniques.</help>
+        <label>Difunt</label>
+        <name>Deceased__c</name>
+    </fields>
+    <fields>
+        <help>Quan estigui seleccionada, aquesta opció exclou el contacte dels correus electrònics i de les trucades telefòniques.</help>
+        <label>No contactar</label>
+        <name>Do_Not_Contact__c</name>
+    </fields>
+    <fields>
+        <help>Si aquest contacte té una ciutadania múltiple, es pot registrar aquí.</help>
+        <label>Ciutadania dual</label>
+        <name>Dual_Citizenship__c</name>
+        <picklistValues>
+            <masterLabel>Afghanistan</masterLabel>
+            <translation>Afganistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Albania</masterLabel>
+            <translation>Albània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Algeria</masterLabel>
+            <translation>Algèria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>American Samoa</masterLabel>
+            <translation>Samoa Nord-americana</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Andorra</masterLabel>
+            <translation><!-- Andorra --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Angola</masterLabel>
+            <translation><!-- Angola --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Anguilla</masterLabel>
+            <translation><!-- Anguilla --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Antarctica</masterLabel>
+            <translation>Antàrtida</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Antigua and Barbuda</masterLabel>
+            <translation>Antigua i Barbuda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Argentina</masterLabel>
+            <translation><!-- Argentina --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Armenia</masterLabel>
+            <translation>Armènia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Aruba</masterLabel>
+            <translation><!-- Aruba --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Australia</masterLabel>
+            <translation>Austràlia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Austria</masterLabel>
+            <translation>Àustria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Azerbaijan</masterLabel>
+            <translation>Azerbaidjan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bahamas (the)</masterLabel>
+            <translation>Bahames (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bahrain</masterLabel>
+            <translation><!-- Bahrain --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bangladesh</masterLabel>
+            <translation>Bangla Desh</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Barbados</masterLabel>
+            <translation><!-- Barbados --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belarus</masterLabel>
+            <translation>Bielorússia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belgium</masterLabel>
+            <translation>Bèlgica</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belize</masterLabel>
+            <translation><!-- Belize --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Benin</masterLabel>
+            <translation>Benín</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bermuda</masterLabel>
+            <translation>Bermudes (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bhutan</masterLabel>
+            <translation><!-- Bhutan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bolivia (Plurinational State of)</masterLabel>
+            <translation>Bolívia (Estat Plurinacional de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bonaire, Sint Eustatius and Saba</masterLabel>
+            <translation>Bonaire, Sint Eustatius i Saba</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bosnia and Herzegovina</masterLabel>
+            <translation>Bòsnia i Hercegovina</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Botswana</masterLabel>
+            <translation><!-- Botswana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bouvet Island</masterLabel>
+            <translation>Illa de Bouvet</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Brazil</masterLabel>
+            <translation>Brasil</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>British Antarctic Territory</masterLabel>
+            <translation>Territori Antàrtic Britànic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>British Indian Ocean Territory (the)</masterLabel>
+            <translation>Territori Britànic de l&apos;Oceà Índic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Brunei Darussalam</masterLabel>
+            <translation><!-- Brunei Darussalam --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bulgaria</masterLabel>
+            <translation>Bulgària</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burkina Faso</masterLabel>
+            <translation><!-- Burkina Faso --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burma</masterLabel>
+            <translation>Birmània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burundi</masterLabel>
+            <translation><!-- Burundi --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Byelorussian SSR</masterLabel>
+            <translation>RSS de Bielorússia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cabo Verde</masterLabel>
+            <translation>Cap Verd</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cambodia</masterLabel>
+            <translation>Cambodja</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cameroon</masterLabel>
+            <translation>Camerun</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Canada</masterLabel>
+            <translation>Canadà</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Canton and Enderbury Islands</masterLabel>
+            <translation>Illes de Canton i Enderbury</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cayman Islands (the)</masterLabel>
+            <translation>Illes Caiman (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Central African Republic (the)</masterLabel>
+            <translation>República Centreafricana (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Chad</masterLabel>
+            <translation>Txad</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Chile</masterLabel>
+            <translation>Xile</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>China</masterLabel>
+            <translation>Xina</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Christmas Island</masterLabel>
+            <translation>Illa Christmas</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cocos (Keeling) Islands (the)</masterLabel>
+            <translation>Illes Cocos (Keeling) (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Colombia</masterLabel>
+            <translation>Colòmbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Comoros (the)</masterLabel>
+            <translation>Comores (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Congo (the Democratic Republic of the)</masterLabel>
+            <translation>Congo (República Democràtica del)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Congo (the)</masterLabel>
+            <translation>Congo (el)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cook Islands (the)</masterLabel>
+            <translation>Illes Cook (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Costa Rica</masterLabel>
+            <translation><!-- Costa Rica --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Croatia</masterLabel>
+            <translation>Croàcia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cuba</masterLabel>
+            <translation><!-- Cuba --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Curaçao</masterLabel>
+            <translation><!-- Curaçao --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cyprus</masterLabel>
+            <translation>Xipre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Czech Republic (the)</masterLabel>
+            <translation>República Txeca (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Czechoslovakia</masterLabel>
+            <translation>Txecoslovàquia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Côte d&apos;Ivoire</masterLabel>
+            <translation>Costa d&apos;Ivori</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dahomey</masterLabel>
+            <translation><!-- Dahomey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Denmark</masterLabel>
+            <translation>Dinamarca</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Djibouti</masterLabel>
+            <translation><!-- Djibouti --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dominica</masterLabel>
+            <translation><!-- Dominica --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dominican Republic (the)</masterLabel>
+            <translation>República Dominicana (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dronning Maud Land</masterLabel>
+            <translation>Terra de la Reina Maud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>East Timor</masterLabel>
+            <translation>Timor Oriental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ecuador</masterLabel>
+            <translation>Equador</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Egypt</masterLabel>
+            <translation>Egipte</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>El Salvador</masterLabel>
+            <translation><!-- El Salvador --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Equatorial Guinea</masterLabel>
+            <translation>Guinea Equatorial</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Eritrea</masterLabel>
+            <translation><!-- Eritrea --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Estonia</masterLabel>
+            <translation>Estònia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ethiopia</masterLabel>
+            <translation>Etiòpia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Falkland Islands (the) [Malvinas]</masterLabel>
+            <translation>Illes Malvines (les) [Falkland]</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Faroe Islands (the)</masterLabel>
+            <translation>Illes Fèroe (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Fiji</masterLabel>
+            <translation><!-- Fiji --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Finland</masterLabel>
+            <translation>Finlàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>France</masterLabel>
+            <translation>França</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>France, Metropolitan</masterLabel>
+            <translation>França, Metropolitana</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Afars and Issas</masterLabel>
+            <translation>Territori Francès dels Àfars i dels Isses</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Guiana</masterLabel>
+            <translation>Guaiana Francesa</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Polynesia</masterLabel>
+            <translation>Polinèsia Francesa</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Southern Territories (the)</masterLabel>
+            <translation>Terres Australs Franceses (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Southern and Antarctic Territories</masterLabel>
+            <translation>Terres Australs i Antàrtiques Franceses (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gabon</masterLabel>
+            <translation><!-- Gabon --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gambia (the)</masterLabel>
+            <translation>Gàmbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Georgia</masterLabel>
+            <translation>Geòrgia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>German Democratic Republic</masterLabel>
+            <translation>República Democràtica Alemanya</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Germany</masterLabel>
+            <translation>Alemanya</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ghana</masterLabel>
+            <translation><!-- Ghana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gibraltar</masterLabel>
+            <translation><!-- Gibraltar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gilbert and Ellice Islands</masterLabel>
+            <translation>Illes Gilbert i Ellice</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Greece</masterLabel>
+            <translation>Grècia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Greenland</masterLabel>
+            <translation>Groenlàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grenada</masterLabel>
+            <translation><!-- Grenada --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guadeloupe</masterLabel>
+            <translation>Guadalupe</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guam</masterLabel>
+            <translation><!-- Guam --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guatemala</masterLabel>
+            <translation><!-- Guatemala --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guernsey</masterLabel>
+            <translation><!-- Guernsey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guinea</masterLabel>
+            <translation><!-- Guinea --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guinea-Bissau</masterLabel>
+            <translation>Guinea Bissau</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guyana</masterLabel>
+            <translation><!-- Guyana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Haiti</masterLabel>
+            <translation>Haití</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Heard Island and McDonal Islands</masterLabel>
+            <translation>Illes Heard i McDonald</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Holy See (the)</masterLabel>
+            <translation>Santa Seu (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Honduras</masterLabel>
+            <translation>Hondures</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hong Kong</masterLabel>
+            <translation><!-- Hong Kong --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hungary</masterLabel>
+            <translation>Hongria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iceland</masterLabel>
+            <translation>Islàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>India</masterLabel>
+            <translation>Índia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Indonesia</masterLabel>
+            <translation>Indonèsia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iran (Islamic Republic of)</masterLabel>
+            <translation>Iran (República Islàmica de l&apos;Iran)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iraq</masterLabel>
+            <translation><!-- Iraq --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ireland</masterLabel>
+            <translation>Irlanda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Isle of Man</masterLabel>
+            <translation>Illa de Man</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Israel</masterLabel>
+            <translation><!-- Israel --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Italy</masterLabel>
+            <translation>Itàlia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jamaica</masterLabel>
+            <translation><!-- Jamaica --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Japan</masterLabel>
+            <translation>Japó</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jersey</masterLabel>
+            <translation><!-- Jersey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Johnston Island</masterLabel>
+            <translation>Illa Johnston</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jordan</masterLabel>
+            <translation>Jordània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kazakhstan</masterLabel>
+            <translation><!-- Kazakhstan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kenya</masterLabel>
+            <translation><!-- Kenya --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kiribati</masterLabel>
+            <translation><!-- Kiribati --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Korea (the Democratic People&apos;s Republic of)</masterLabel>
+            <translation>Corea (República Democràtica Popular de Corea)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Korea (the Republic of)</masterLabel>
+            <translation>Corea (la República de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kuwait</masterLabel>
+            <translation><!-- Kuwait --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kyrgyzstan</masterLabel>
+            <translation>Kirguizistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lao People&apos;s Democratic Republic (the)</masterLabel>
+            <translation>República Democràtica Popular de Laos (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Latvia</masterLabel>
+            <translation>Letònia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lebanon</masterLabel>
+            <translation>Líban</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lesotho</masterLabel>
+            <translation><!-- Lesotho --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Liberia</masterLabel>
+            <translation>Libèria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Libya</masterLabel>
+            <translation>Líbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Liechtenstein</masterLabel>
+            <translation><!-- Liechtenstein --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lithuania</masterLabel>
+            <translation>Lituània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Luxembourg</masterLabel>
+            <translation>Luxemburg</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Macao</masterLabel>
+            <translation>Macau</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Macedonia (the former Yugoslav Republic of)</masterLabel>
+            <translation>Macedònia (Antiga República Iugoslava de Macedònia)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Madagascar</masterLabel>
+            <translation><!-- Madagascar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malawi</masterLabel>
+            <translation><!-- Malawi --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malaysia</masterLabel>
+            <translation>Malàisia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mali</masterLabel>
+            <translation><!-- Mali --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malta</masterLabel>
+            <translation><!-- Malta --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Marshall Islands (the)</masterLabel>
+            <translation>Illes Marshall (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Martinique</masterLabel>
+            <translation>Martinica</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mauritania</masterLabel>
+            <translation>Mauritània</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mauritius</masterLabel>
+            <translation>Maurici</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mayotte</masterLabel>
+            <translation><!-- Mayotte --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mexico</masterLabel>
+            <translation>Mèxic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Micronesia (Federated States of)</masterLabel>
+            <translation>Micronèsia (Estats Federats de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Midway Islands</masterLabel>
+            <translation>Illa Midway</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Moldova (the Republic of)</masterLabel>
+            <translation>Moldàvia (la República de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Monaco</masterLabel>
+            <translation>Mònaco</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mongolia</masterLabel>
+            <translation>Mongòlia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Montenegro</masterLabel>
+            <translation><!-- Montenegro --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Montserrat</masterLabel>
+            <translation><!-- Montserrat --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Morocco</masterLabel>
+            <translation>Marroc</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mozambique</masterLabel>
+            <translation>Moçambic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Myanmar</masterLabel>
+            <translation><!-- Myanmar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Namibia</masterLabel>
+            <translation>Namíbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nauru</masterLabel>
+            <translation><!-- Nauru --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nepal</masterLabel>
+            <translation><!-- Nepal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Netherlands (the)</masterLabel>
+            <translation>Països Baixos (Els)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Netherlands Antilles</masterLabel>
+            <translation>Antilles Neerlandeses</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Neutral Zone</masterLabel>
+            <translation>Zona Neutral</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Caledonia</masterLabel>
+            <translation>Nova Caledònia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Hebrides</masterLabel>
+            <translation>Illes Hèbrides</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Zealand</masterLabel>
+            <translation>Nova Zelanda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nicaragua</masterLabel>
+            <translation><!-- Nicaragua --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Niger (the)</masterLabel>
+            <translation>Níger (El)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nigeria</masterLabel>
+            <translation>Nigèria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Niue</masterLabel>
+            <translation><!-- Niue --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Norfolk Island</masterLabel>
+            <translation>Illa Norfolk</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Northern Mariana Islands (the)</masterLabel>
+            <translation>Illes Mariannes Septentrionals (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Norway</masterLabel>
+            <translation>Noruega</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Oman</masterLabel>
+            <translation><!-- Oman --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pacific Islands (Trust Territory)</masterLabel>
+            <translation>Illes del Pacífic (Territori en Fideïcomís de les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pakistan</masterLabel>
+            <translation><!-- Pakistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Palau</masterLabel>
+            <translation><!-- Palau --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Palestine, State of</masterLabel>
+            <translation>Palestina, Estat de</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Panama</masterLabel>
+            <translation>Panamà</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Panama Canal Zone</masterLabel>
+            <translation>Zona del Canal de Panamà</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Papua New Guinea</masterLabel>
+            <translation>Papua Nova Guinea</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Paraguay</masterLabel>
+            <translation>Paraguai</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Peru</masterLabel>
+            <translation>Perú</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Philippines (the)</masterLabel>
+            <translation>Filipines (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pitcairn</masterLabel>
+            <translation><!-- Pitcairn --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Poland</masterLabel>
+            <translation>Polònia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Portugal</masterLabel>
+            <translation><!-- Portugal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Puerto Rico</masterLabel>
+            <translation><!-- Puerto Rico --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Qatar</masterLabel>
+            <translation><!-- Qatar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Romania</masterLabel>
+            <translation><!-- Romania --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Russian Federation (the)</masterLabel>
+            <translation>Federació Russa (la)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Rwanda</masterLabel>
+            <translation>Ruanda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Réunion</masterLabel>
+            <translation>Reunió</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Barthélemy</masterLabel>
+            <translation><!-- Saint Barthélemy --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Helena, Ascension and Tristan da Cunha</masterLabel>
+            <translation>Santa Helena, Ascensió i Tristan da Cunha</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Kitts and Nevis</masterLabel>
+            <translation>Saint Christopher i Nevis</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Lucia</masterLabel>
+            <translation><!-- Saint Lucia --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Martin (French part)</masterLabel>
+            <translation>Saint Martin (part francesa)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Pierre and Miquelon</masterLabel>
+            <translation>Saint-Pierre i Miquelon</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Vincent and the Grenadines</masterLabel>
+            <translation>Saint Vincent i les Grenadines</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Samoa</masterLabel>
+            <translation><!-- Samoa --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>San Marino</masterLabel>
+            <translation><!-- San Marino --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sao Tome and Principe</masterLabel>
+            <translation>São Tomé i Príncipe</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saudi Arabia</masterLabel>
+            <translation>Aràbia Saudita</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Senegal</masterLabel>
+            <translation><!-- Senegal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Serbia</masterLabel>
+            <translation>Sèrbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Serbia and Montenegro</masterLabel>
+            <translation>Sèrbia i Montenegro</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Seychelles</masterLabel>
+            <translation><!-- Seychelles --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sierra Leone</masterLabel>
+            <translation><!-- Sierra Leone --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sikkim</masterLabel>
+            <translation><!-- Sikkim --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Singapore</masterLabel>
+            <translation>Singapur</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sint Maarten (Dutch part)</masterLabel>
+            <translation>Sint Maarten (part neerlandesa)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Slovakia</masterLabel>
+            <translation>Eslovàquia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Slovenia</masterLabel>
+            <translation>Eslovènia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Solomon Islands</masterLabel>
+            <translation>Illes Salomó</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Somalia</masterLabel>
+            <translation>Somàlia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Africa</masterLabel>
+            <translation>Sud-àfrica</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Georgia and the South Sandwich Islands</masterLabel>
+            <translation>Illes Geòrgia del Sud i Sandwich del Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Sudan</masterLabel>
+            <translation>Sudan del Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Southern Rodesia</masterLabel>
+            <translation>Rhodèsia del Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Spain</masterLabel>
+            <translation>Espanya</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sri Lanka</masterLabel>
+            <translation><!-- Sri Lanka --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sudan (the)</masterLabel>
+            <translation>Sudan (el)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Surinam</masterLabel>
+            <translation><!-- Surinam --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Svalbard and Jan Mayen</masterLabel>
+            <translation>Svalbard i Jan Mayen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Swaziland</masterLabel>
+            <translation>Swazilàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sweden</masterLabel>
+            <translation>Suècia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Switzerland</masterLabel>
+            <translation>Suïssa</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Syrian Arab Republic</masterLabel>
+            <translation>República Àrab Siriana</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Taiwan (Province of China)</masterLabel>
+            <translation>Taiwan (Província de Xina)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tajikistan</masterLabel>
+            <translation>Tadjikistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tanzania, United Republic of</masterLabel>
+            <translation>Tanzània, República Unida de</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Thailand</masterLabel>
+            <translation>Tailàndia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Timor-Leste</masterLabel>
+            <translation>Timor Oriental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Togo</masterLabel>
+            <translation><!-- Togo --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tokelau</masterLabel>
+            <translation><!-- Tokelau --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tonga</masterLabel>
+            <translation><!-- Tonga --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Trinidad and Tobago</masterLabel>
+            <translation>Trinitat i Tobago</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tunisia</masterLabel>
+            <translation>Tunísia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turkey</masterLabel>
+            <translation>Turquia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turkmenistan</masterLabel>
+            <translation><!-- Turkmenistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turks and Caicos Islands (the)</masterLabel>
+            <translation>Illes Turks i Caicos (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tuvalu</masterLabel>
+            <translation><!-- Tuvalu --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>USSR</masterLabel>
+            <translation>URSS</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uganda</masterLabel>
+            <translation><!-- Uganda --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ukraine</masterLabel>
+            <translation>Ucraïna</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United Arab Emirates (the)</masterLabel>
+            <translation>Emirats Àrabs Units (els)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United Kingdom of Great Britain and Northern Ireland (the)</masterLabel>
+            <translation>Regne Unit de la Gran Bretanya i Irlanda del Nord (el)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United States Minor Outlying Islands (the)</masterLabel>
+            <translation>Illes Perifèriques Menors dels EUA (les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United States of America (the)</masterLabel>
+            <translation>Estats Units d&apos;Amèrica (els)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Unites States Miscellaneous Pacific Islands</masterLabel>
+            <translation>Diverses Illes del Pacífic dels EUA</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Upper Volta</masterLabel>
+            <translation><!-- Upper Volta --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uruguay</masterLabel>
+            <translation>Uruguai</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uzbekistan</masterLabel>
+            <translation><!-- Uzbekistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Vanuatu</masterLabel>
+            <translation><!-- Vanuatu --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Venezuela (Bolivarian Republic of)</masterLabel>
+            <translation>Veneçuela (República Bolivariana de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Viet Nam</masterLabel>
+            <translation>Vietnam</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Viet-Nam, Democratic Republic of</masterLabel>
+            <translation>República Socialista de Vietnam</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Virgin Islands (British)</masterLabel>
+            <translation>Illes Verges (Britàniques)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Virgin Islands (U.S.)</masterLabel>
+            <translation>Illes Verges (Nord-americanes)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wake Island</masterLabel>
+            <translation>Illa Wake</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wallis and Futuna</masterLabel>
+            <translation>Wallis i Futuna</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Western Sahara</masterLabel>
+            <translation>Sàhara Occidental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yemen</masterLabel>
+            <translation>Iemen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yemen, Democratic</masterLabel>
+            <translation>República del Iemen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yugoslavia</masterLabel>
+            <translation>Iugoslàvia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zaire</masterLabel>
+            <translation><!-- Zaire --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zambia</masterLabel>
+            <translation>Zàmbia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zimbabwe</masterLabel>
+            <translation><!-- Zimbabwe --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Åland Islands</masterLabel>
+            <translation>Illes Åland</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>Ètnia</label>
+        <name>Ethnicity__c</name>
+        <picklistValues>
+            <masterLabel>Hispanic or Latino</masterLabel>
+            <translation><!-- Hispanic or Latino --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Not Hispanic or Latino</masterLabel>
+            <translation><!-- Not Hispanic or Latino --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Si marques aquesta casella s&apos;exclou aquest contacte de la Salutació formal de la llar.</help>
+        <label>Exclou de salutació formal de la llar</label>
+        <name>Exclude_from_Household_Formal_Greeting__c</name>
+    </fields>
+    <fields>
+        <help>Si marques aquesta casella s&apos;exclou aquest contacte de la Salutació informal de la llar.</help>
+        <label>Exclou de salutació informal de la llar</label>
+        <name>Exclude_from_Household_Informal_Greeting__c</name>
+    </fields>
+    <fields>
+        <help>Si marques aquesta casella s&apos;exclou aquest contacte del Nom de la llar.</help>
+        <label>Exclou del nom de la llar</label>
+        <name>Exclude_from_Household_Name__c</name>
+    </fields>
+    <fields>
+        <label><!-- FERPA --></label>
+        <name>FERPA__c</name>
+    </fields>
+    <fields>
+        <label>Sol·licitant d&apos;ajuda financera</label>
+        <name>Financial_Aid_Applicant__c</name>
+    </fields>
+    <fields>
+        <label>Sexe</label>
+        <name>Gender__c</name>
+        <picklistValues>
+            <masterLabel>Female</masterLabel>
+            <translation>Dona</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Male</masterLabel>
+            <translation>Home</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>Detall HIPAA</label>
+        <name>HIPAA_Detail__c</name>
+    </fields>
+    <fields>
+        <label><!-- HIPAA --></label>
+        <name>HIPAA__c</name>
+    </fields>
+    <fields>
+        <label>Antecedents militars</label>
+        <name>Military_Background__c</name>
+    </fields>
+    <fields>
+        <label>Servei militar</label>
+        <name>Military_Service__c</name>
+    </fields>
+    <fields>
+        <help>Determina a quins noms de les famílies no s&apos;inclou aquest contacte com a part.</help>
+        <label>Exclusions de nomenaments</label>
+        <name>Naming_Exclusions__c</name>
+        <picklistValues>
+            <masterLabel>Household__c.Formal_Greeting__c</masterLabel>
+            <translation><!-- Household__c.Formal_Greeting__c --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Household__c.Informal_Greeting__c</masterLabel>
+            <translation><!-- Household__c.Informal_Greeting__c --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Household__c.Name</masterLabel>
+            <translation><!-- Household__c.Name --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Quin número de telèfon s&apos;hauria d&apos;utilitzar per a la majoria de comunicacions que incloguin aquest contacte?</help>
+        <label>Telèfon preferit</label>
+        <name>PreferredPhone__c</name>
+        <picklistValues>
+            <masterLabel>Home</masterLabel>
+            <translation>Llar</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mobile</masterLabel>
+            <translation>Mòbil</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Other</masterLabel>
+            <translation>Altres</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation>Feina</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Quin correu electrònic s&apos;hauria d&apos;utilitzar per a la majoria de comunicacions que incloguin aquest contacte?</help>
+        <label>Correu preferit</label>
+        <name>Preferred_Email__c</name>
+        <picklistValues>
+            <masterLabel>Alternate</masterLabel>
+            <translation>Alternatiu</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>University</masterLabel>
+            <translation>Universitat</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation>Feina</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Quin tipus d&apos;adreça és l&apos;adreça de correu?</help>
+        <label>Tipus d&apos;adreça primari</label>
+        <name>Primary_Address_Type__c</name>
+        <picklistValues>
+            <masterLabel>Home</masterLabel>
+            <translation>Llar</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Other</masterLabel>
+            <translation>Altres</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation>Feina</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>Llar primària</label>
+        <name>Primary_Household__c</name>
+        <relationshipLabel>Contactes (llar primària)</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Organització empresarial primària</label>
+        <name>Primary_Organization__c</name>
+        <relationshipLabel>Contactes (Organització primària)</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Raça</label>
+        <name>Race__c</name>
+        <picklistValues>
+            <masterLabel>American Indian or Alaska Native</masterLabel>
+            <translation>Indi americà o nadiu d&apos;Alaska</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Asian</masterLabel>
+            <translation>Asiàtic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Black or African American</masterLabel>
+            <translation>Negre o afroamericà</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hispanic or Latino</masterLabel>
+            <translation>Hispà o llatí</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Native Hawaiian or Other Pacific Islander</masterLabel>
+            <translation>Nadiu hawaià o illenc d&apos;una altra illa del pacífic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>White</masterLabel>
+            <translation>Blanc</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>Religió</label>
+        <name>Religion__c</name>
+        <picklistValues>
+            <masterLabel>Atheist</masterLabel>
+            <translation>Ateu</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Buddhist</masterLabel>
+            <translation>Budista</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Christian</masterLabel>
+            <translation>Cristià</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hindu</masterLabel>
+            <translation>Hindú</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jewish</masterLabel>
+            <translation>Jueu</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Muslim</masterLabel>
+            <translation>Musulmà</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Other</masterLabel>
+            <translation>Altres</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Quin tipus d&apos;adreça és l&apos;altra adreça?</help>
+        <label>Tipus d&apos;adreça secundària</label>
+        <name>Secondary_Address_Type__c</name>
+        <picklistValues>
+            <masterLabel>Home</masterLabel>
+            <translation>Llar</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Other</masterLabel>
+            <translation>Altres</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation>Feina</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>Número de la Seguretat Social</label>
+        <name>Social_Security_Number__c</name>
+    </fields>
+    <fields>
+        <help>Adreça de correu electrònic de la Universitat Oficial.</help>
+        <label>Correu electrònic universitari</label>
+        <name>UniversityEmail__c</name>
+    </fields>
+    <fields>
+        <help>Vegeu el camp de correu electrònic preferit.</help>
+        <label>Correu electrònic de la feina</label>
+        <name>WorkEmail__c</name>
+    </fields>
+    <fields>
+        <help>Vegeu el camp &quot;Telèfon preferit&quot;.</help>
+        <label>Telèfon de la feina</label>
+        <name>WorkPhone__c</name>
+    </fields>
+    <fields>
+        <help>Fórmula: si el tipus d&apos;adreça principal és Feina, l&apos;adreça de correu postal. Si el tipus d&apos;adreça secundària és Feina, l&apos;altra adreça.</help>
+        <label>Direcció de la feina</label>
+        <name>Work_Address__c</name>
+    </fields>
+    <fields>
+        <help>Si es marca, la cerca d&apos;adreça actual del contacte anul·la l&apos;adreça predeterminada de la llar o l&apos;adreça temporal.</help>
+        <label>No actualitzis automàticament</label>
+        <name>is_Address_Override__c</name>
+    </fields>
+    <layouts>
+        <layout>HEDA Contact Layout</layout>
+        <sections>
+            <label><!-- Additional Information --></label>
+            <section>Additional Information</section>
+        </sections>
+        <sections>
+            <label>Preferències de comunicació</label>
+            <section>Communication Preferences</section>
+        </sections>
+        <sections>
+            <label>Dades de contacte</label>
+            <section>Contact Details</section>
+        </sections>
+        <sections>
+            <label>Afiliacions primàries</label>
+            <section>Primary Affiliations</section>
+        </sections>
+    </layouts>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Contact-ca.objectTranslation
+++ b/src/objectTranslations/Contact-ca.objectTranslation
@@ -1,5 +1,927 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Contacte</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Contactes</value>
+    </caseValues>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Adreça</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>address_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Assistent</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>assistant_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Telèfon d&apos;Assistent</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>asst_phone_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Adreça de facturació</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>billing_address_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Data de naixement</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>birthdate_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Ciutat</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>city_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Estat de neteja</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>cleanstatus_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Accés de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_access</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nivell d&apos;accés de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_access_level</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Compte de contacte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>contact_account</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Divisa de contacte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>contact_currency</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Descripció de contacte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>contact_description</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Divisió de contacte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>contact_division</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Modificació de contacte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>contact_edit</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Correu electrònic de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_email</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Fax de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_fax</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Camp de contacte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Campos de contactes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_field</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Historial de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_history</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Informe d&apos;historial de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_history_report</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Id. de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_id</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Informació de contacte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>contact_information</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Mòbil de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_mobile</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nom de contacte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Noms de contactes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_name</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nota de contacte</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>contact_note</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nombre de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_number</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Propietari de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_owner</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Àlies de propietari de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_owner_alias</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Telèfon de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_phone</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Registre de contacte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Registres de contactes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_record</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Tipus de registre de contacte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Tipus de registres de contactes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_record_type</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Contacte de supervisor</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_reports_to</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Funció de contacte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Funcions de contactes</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>contact_role</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Id. de Funció de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_role_id</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Informe de funció de contacte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Informes de funcions de contactes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_role_report</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Id. de Etapa de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_stage_id</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Estat de contacte</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_status</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Tipus de contacte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Tipus de contactes</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>contact_type</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Vista de contacte</value>
+        </caseValues>
+        <caseValues>
+            <plural>true</plural>
+            <value>Vistas de contactes</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>contact_view</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>País</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>country_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Clau de Data.com</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>datadotcom_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Departament</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>department_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Descripció</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>description_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>No cridar</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>do_not_call_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Correu electrònic</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>email_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Anul·lació de subscripció de correu electrònic</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>email_opt_out_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Anul·lació de subscripció de fax</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>fax_opt_out_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nom de pila</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>first_name_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nom de pila (Local)</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>first_name_local_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Part global</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>global_party_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Telèfon domèstic</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>home_phone_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nom informal</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>informal_name_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nom informal (Local)</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>informal_name_local_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Cognom</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>last_name_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Cognom (Local)</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>last_name_local_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Precisió de geocodi postal</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>mailing_accuracy_geocode_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Adreça postal</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>mailing_address_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Ciutat postal</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>mailing_city_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Codi de país postal</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>mailing_country_code_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>País postal</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>mailing_country_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Latitud postal</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>mailing_latitude_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Longitud postal</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>mailing_longitude_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Codi d&apos;estat/província postal</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>mailing_state_code_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Estat/Província postal</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>mailing_state_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Carrer postal</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>mailing_street_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Codi postal</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>mailing_zip_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Segon nom</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>middle_name_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Segon nom (Local)</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>middle_name_local_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Mòbil</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>mobile_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nom</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>name_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Sufix</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>name_suffix_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Una altra precisió de geocodi</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>other_accuracy_geocode_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Una altra adreça</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>other_address_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Una altra ciutat</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>other_city_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Un altre codi de país</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>other_country_code_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Un altre país</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>other_country_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Una altra latitud</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>other_latitude_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Una altra longitud</value>
+        </caseValues>
+        <gender>Feminine</gender>
+        <name>other_longitude_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Un altre telèfon</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>other_phone_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Un altre codi d&apos;estat/província</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>other_state_code_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Un altre estat/província</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>other_state_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Un altre carrer</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>other_street_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Un altre codi postal</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>other_zip_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Telèfon</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>phone_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Supervisor</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>reports_to_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nom de pila de supervisor</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>reports_to_first_name_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nom de pila de supervisor (Local)</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>reports_to_first_name_local_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nom informal de supervisor</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>reports_to_informal_name_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nom informal de supervisor (Local)</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>reports_to_informal_name_local_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Cognom de supervisor</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>reports_to_last_name_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Cognom de supervisor (Local)</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>reports_to_last_name_local_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Segon nom de supervisor</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>reports_to_middle_name_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Segon nom de supervisor (Local)</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>reports_to_middle_name_local_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Nom de supervisor</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>reports_to_name_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Sufix de supervisor</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>reports_to_suffix_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Salutació</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>salutation_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Estat</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>state_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Càrrec (Job position) / Títol</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>title_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
+    <fields>
+        <caseValues>
+            <plural>false</plural>
+            <value>Codi postal</value>
+        </caseValues>
+        <gender>Masculine</gender>
+        <name>zip_contact</name>
+        <startsWith>Consonant</startsWith>
+    </fields>
     <fields>
         <help>El correu electrònic alternatiu és un quart correu electrònic opcional: no és un correu electrònic personal, preferit ni de treball.</help>
         <label>Correu electrònic alternatiu</label>
@@ -3633,6 +4555,7 @@
         <label>No actualitzis automàticament</label>
         <name>is_Address_Override__c</name>
     </fields>
+    <gender>Masculine</gender>
     <layouts>
         <layout>HEDA Contact Layout</layout>
         <sections>
@@ -3652,4 +4575,5 @@
             <section>Primary Affiliations</section>
         </sections>
     </layouts>
+    <startsWith>Consonant</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Course_Enrollment__c-ca.objectTranslation
+++ b/src/objectTranslations/Course_Enrollment__c-ca.objectTranslation
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Course Connection --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Course Connection --></value>
+    </caseValues>
+    <fields>
+        <help>El programa acadèmic en què està inscrit l&apos;estudiant.</help>
+        <label>Programa acadèmic del contacte</label>
+        <name>Account__c</name>
+        <relationshipLabel>Connexions del curs</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Afiliació</label>
+        <name>Affiliation__c</name>
+        <relationshipLabel>Connexió del curs</relationshipLabel>
+    </fields>
+    <fields>
+        <help>L&apos;alumne que cursa el curs.</help>
+        <label>Contacte</label>
+        <name>Contact__c</name>
+        <relationshipLabel>Connexions del curs</relationshipLabel>
+    </fields>
+    <fields>
+        <help>L&apos;oferta de curs a la qual està inscrit l&apos;estudiant. És un curs ofert en un termini específic.</help>
+        <label>ID d&apos;oferta del curs</label>
+        <name>Course_Offering__c</name>
+        <relationshipLabel>Connexió del curs</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Crèdits als quals s&apos;ha assistit</label>
+        <name>Credits_Attempted__c</name>
+    </fields>
+    <fields>
+        <label>Crèdits obtinguts</label>
+        <name>Credits_Earned__c</name>
+    </fields>
+    <fields>
+        <label>Nota</label>
+        <name>Grade__c</name>
+    </fields>
+    <fields>
+        <help>Representa una connexió de curs principal.</help>
+        <label>Primari</label>
+        <name>Primary__c</name>
+    </fields>
+    <fields>
+        <help>El programa en què està inscrit l&apos;estudiant. Enllaça un estudiant amb un programa acadèmic.</help>
+        <label>ID d&apos;inscripció del programa</label>
+        <name>Program_Enrollment__c</name>
+        <relationshipLabel>Connexions del curs</relationshipLabel>
+    </fields>
+    <fields>
+        <help>Representa l&apos;estat de connexió del curs.</help>
+        <label>Estat</label>
+        <name>Status__c</name>
+        <picklistValues>
+            <masterLabel>Current</masterLabel>
+            <translation>Actual</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Former</masterLabel>
+            <translation>Antic</translation>
+        </picklistValues>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <layouts>
+        <layout>HEDA Course Enrollment Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Course Connection ID --></nameFieldLabel>
+    <recordTypes>
+        <label><!-- Default --></label>
+        <name>Default</name>
+    </recordTypes>
+    <recordTypes>
+        <label>Facultat</label>
+        <name>Faculty</name>
+    </recordTypes>
+    <recordTypes>
+        <label>Estudiant</label>
+        <name>Student</name>
+    </recordTypes>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Course_Enrollment__c-ca.objectTranslation
+++ b/src/objectTranslations/Course_Enrollment__c-ca.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Course Connection --></value>
+        <value>Connexió del curs</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Course Connection --></value>
+        <value>Connexions del curs</value>
     </caseValues>
     <fields>
         <help>El programa acadèmic en què està inscrit l&apos;estudiant.</help>
@@ -67,7 +67,7 @@
             <translation>Antic</translation>
         </picklistValues>
     </fields>
-    <gender><!-- Feminine --></gender>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Course Enrollment Layout</layout>
         <sections>
@@ -75,7 +75,7 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <nameFieldLabel><!-- Course Connection ID --></nameFieldLabel>
+    <nameFieldLabel>ID de connexió del curs</nameFieldLabel>
     <recordTypes>
         <label><!-- Default --></label>
         <name>Default</name>
@@ -88,5 +88,5 @@
         <label>Estudiant</label>
         <name>Student</name>
     </recordTypes>
-    <startsWith><!-- Consonant --></startsWith>
+    <startsWith>Consonant</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Course_Enrollment__c-es.objectTranslation
+++ b/src/objectTranslations/Course_Enrollment__c-es.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Course Connection --></value>
+        <value><!-- Connexió del curs --></value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Course Connection --></value>
+        <value><!-- Connexió del curs --></value>
     </caseValues>
     <fields>
         <help>El programa académico en el que el estudiante está inscrito.</help>

--- a/src/objectTranslations/Course_Offering__c-ca.objectTranslation
+++ b/src/objectTranslations/Course_Offering__c-ca.objectTranslation
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Course Offering --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Course Offering --></value>
+    </caseValues>
+    <fields>
+        <label>Capacitat</label>
+        <name>Capacity__c</name>
+    </fields>
+    <fields>
+        <label>Curs</label>
+        <name>Course__c</name>
+        <relationshipLabel>Ofertes de cursos</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Data de finalització</label>
+        <name>End_Date__c</name>
+    </fields>
+    <fields>
+        <label>Facultat primària</label>
+        <name>Faculty__c</name>
+        <relationshipLabel>Ofertes de cursos</relationshipLabel>
+    </fields>
+    <fields>
+        <label>ID de secció</label>
+        <name>Section_ID__c</name>
+    </fields>
+    <fields>
+        <label>Data d&apos;inici</label>
+        <name>Start_Date__c</name>
+    </fields>
+    <fields>
+        <label>Termini</label>
+        <name>Term__c</name>
+        <relationshipLabel>Ofertes de cursos</relationshipLabel>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <layouts>
+        <layout>HEDA Course Offering Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Course Offering ID --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Course_Offering__c-ca.objectTranslation
+++ b/src/objectTranslations/Course_Offering__c-ca.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Course Offering --></value>
+        <value>Oferta de curs</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Course Offering --></value>
+        <value>Ofertes de cursos</value>
     </caseValues>
     <fields>
         <label>Capacitat</label>
@@ -39,7 +39,7 @@
         <name>Term__c</name>
         <relationshipLabel>Ofertes de cursos</relationshipLabel>
     </fields>
-    <gender><!-- Feminine --></gender>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Course Offering Layout</layout>
         <sections>
@@ -47,6 +47,6 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <nameFieldLabel><!-- Course Offering ID --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <nameFieldLabel>ID d&apos;oferta del curs</nameFieldLabel>
+    <startsWith>Vowel</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Course__c-ca.objectTranslation
+++ b/src/objectTranslations/Course__c-ca.objectTranslation
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Course --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Course --></value>
+    </caseValues>
+    <fields>
+        <label>Departament</label>
+        <name>Account__c</name>
+        <relationshipLabel>Cursos</relationshipLabel>
+    </fields>
+    <fields>
+        <label>ID de curs</label>
+        <name>Course_ID__c</name>
+    </fields>
+    <fields>
+        <label>Hores del crèdit</label>
+        <name>Credit_Hours__c</name>
+    </fields>
+    <fields>
+        <label>Descripció</label>
+        <name>Description__c</name>
+    </fields>
+    <fields>
+        <label>Descripció ampliada</label>
+        <name>Extended_Description__c</name>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <layouts>
+        <layout>HEDA Course Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Course Name --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Course__c-ca.objectTranslation
+++ b/src/objectTranslations/Course__c-ca.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Course --></value>
+        <value>Curs</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Course --></value>
+        <value>Cursos</value>
     </caseValues>
     <fields>
         <label>Departament</label>
@@ -29,7 +29,7 @@
         <label>Descripció ampliada</label>
         <name>Extended_Description__c</name>
     </fields>
-    <gender><!-- Feminine --></gender>
+    <gender>Masculine</gender>
     <layouts>
         <layout>HEDA Course Layout</layout>
         <sections>
@@ -37,6 +37,6 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <nameFieldLabel><!-- Course Name --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <nameFieldLabel>Nom del curs</nameFieldLabel>
+    <startsWith>Consonant</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Error__c-ca.objectTranslation
+++ b/src/objectTranslations/Error__c-ca.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Error --></value>
+        <value>Error</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Error --></value>
+        <value>Errors</value>
     </caseValues>
     <fields>
         <help>Context en què es generava l&apos;error, si es coneix.</help>
@@ -53,7 +53,7 @@
         <label>Seguiment de pila</label>
         <name>Stack_Trace__c</name>
     </fields>
-    <gender><!-- Feminine --></gender>
-    <nameFieldLabel><!-- Error Number --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <gender>Masculine</gender>
+    <nameFieldLabel>Nombre d&apos;error</nameFieldLabel>
+    <startsWith>Vowel</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Error__c-ca.objectTranslation
+++ b/src/objectTranslations/Error__c-ca.objectTranslation
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Error --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Error --></value>
+    </caseValues>
+    <fields>
+        <help>Context en què es generava l&apos;error, si es coneix.</help>
+        <label>Tipus de context</label>
+        <name>Context_Type__c</name>
+    </fields>
+    <fields>
+        <help>Data i hora en què s&apos;ha produït l&apos;error</help>
+        <label>Data i hora</label>
+        <name>Datetime__c</name>
+    </fields>
+    <fields>
+        <help>Indica si s&apos;ha enviat una notificació per correu electrònic sobre aquest error.</help>
+        <label>Correu electrònic enviat</label>
+        <name>Email_Sent__c</name>
+    </fields>
+    <fields>
+        <help>Tipus d&apos;error que s&apos;ha produït</help>
+        <label>Tipus d&apos;error</label>
+        <name>Error_Type__c</name>
+    </fields>
+    <fields>
+        <help>Text complet del missatge d&apos;error</help>
+        <label>Missatge complet</label>
+        <name>Full_Message__c</name>
+    </fields>
+    <fields>
+        <help>Tipus d&apos;objecte en què s&apos;ha produït l&apos;error, si es coneix.</help>
+        <label>Tipus d&apos;objecte</label>
+        <name>Object_Type__c</name>
+    </fields>
+    <fields>
+        <help>Indica si l&apos;error s&apos;ha publicat a Chatter.</help>
+        <label>Publicat a Chatter</label>
+        <name>Posted_in_Chatter__c</name>
+    </fields>
+    <fields>
+        <help>Un enllaç del registre que va provocar l&apos;error, si està disponible.</help>
+        <label>URL del registre</label>
+        <name>Record_URL__c</name>
+    </fields>
+    <fields>
+        <help>Seguiment de pila per a l&apos;error llançat, si està disponible en temps d&apos;execució.</help>
+        <label>Seguiment de pila</label>
+        <name>Stack_Trace__c</name>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <nameFieldLabel><!-- Error Number --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Hierarchy_Settings__c-ca.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-ca.objectTranslation
@@ -24,6 +24,16 @@
         <name>Accounts_to_Delete__c</name>
     </fields>
     <fields>
+        <help><!-- This is the setting for admin account naming format --></help>
+        <label><!-- Admin Account Naming Format --></label>
+        <name>Admin_Account_Naming_Format__c</name>
+    </fields>
+    <fields>
+        <help><!-- To store other naming setting for admin account --></help>
+        <label><!-- Admin Other Name Setting --></label>
+        <name>Admin_Other_Name_Setting__c</name>
+    </fields>
+    <fields>
         <help>Estat al qual s&apos;ha de canviar una Afiliació quan es suprimeix la inscripció de programa relacionada, si l&apos;opció seleccionada és canviar el seu estat en lloc de suprimir-lo.</help>
         <label>Estat afil. supressió inscripció prog.</label>
         <name>Affl_ProgEnroll_Del_Status__c</name>
@@ -41,6 +51,11 @@
     <fields>
         <label>Darrera comprovació errors asíncrons</label>
         <name>Async_Error_Check_Last_Run__c</name>
+    </fields>
+    <fields>
+        <help><!-- If checked, the system will provide automatic naming for Household Names, Informal and Formal Greetings. --></help>
+        <label><!-- Automatic Household Naming --></label>
+        <name>Automatic_Household_Naming__c</name>
     </fields>
     <fields>
         <help>Suport gestió d&apos;adreces per a contactes.</help>
@@ -81,9 +96,19 @@
         <name>Faculty_RecType__c</name>
     </fields>
     <fields>
+        <help><!-- This is the setting for household account naming format --></help>
+        <label><!-- Household Account Naming Format --></label>
+        <name>Household_Account_Naming_Format__c</name>
+    </fields>
+    <fields>
         <help>Tipus de registre del compte que admet el comportament de les adreces de la llar.</help>
         <label>Tipus registre de compte adreces de llar</label>
         <name>Household_Addresses_RecType__c</name>
+    </fields>
+    <fields>
+        <help><!-- To store other name setting for household account --></help>
+        <label><!-- Household Other Name Setting --></label>
+        <name>Household_Other_Name_Setting__c</name>
     </fields>
     <fields>
         <help>Determina el mètode utilitzat per generar la relació recíproca. Configuració de la llista que utilitza la configuració personalitzada per sexe, o la inversió de valor, que inverteix el tipus, si escau (&quot;Principal-Derivat&quot; a &quot;Derivat-Principal&quot;)</help>

--- a/src/objectTranslations/Hierarchy_Settings__c-ca.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-ca.objectTranslation
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Hierarchy Settings --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Hierarchy Settings --></value>
+    </caseValues>
+    <fields>
+        <help>Configuració del model de compte. Hauria de ser &quot;Unipersonal&quot; o &quot;Individual&quot;. Reemplaça el camp personalitzat Contact.SystemAccountProcessor__c</help>
+        <label>Processador de compte</label>
+        <name>Account_Processor__c</name>
+    </fields>
+    <fields>
+        <help>Els tipus de registres d&apos;aquells comptes que haurien de tenir diverses adreces habilitades.</help>
+        <label>Comptes d&apos;adreces múltiples</label>
+        <name>Accounts_Addresses_Enabled__c</name>
+    </fields>
+    <fields>
+        <help>Els tipus de registres d&apos;aquells comptes que s&apos;han d&apos;eliminar si s&apos;han eliminat tots els contactes derivats.</help>
+        <label>Comptes per esborrar</label>
+        <name>Accounts_to_Delete__c</name>
+    </fields>
+    <fields>
+        <help>Estat al qual s&apos;ha de canviar una Afiliació quan es suprimeix la inscripció de programa relacionada, si l&apos;opció seleccionada és canviar el seu estat en lloc de suprimir-lo.</help>
+        <label>Estat afil. supressió inscripció prog.</label>
+        <name>Affl_ProgEnroll_Del_Status__c</name>
+    </fields>
+    <fields>
+        <help>Determina si una afiliació s&apos;eliminarà automàticament quan se suprimeixi la inscripció relacionada del programa. En cas contrari, l&apos;estat es canviarà a antic.</help>
+        <label>Supressió inscripció programa afiliació</label>
+        <name>Affl_ProgEnroll_Del__c</name>
+    </fields>
+    <fields>
+        <help>Les relacions autocreades es dedueixen automàticament per evitar que es creïn registres duplicats entre dos contactes. Marqueu la casella per desactivar aquest comportament i permetre que es creïn diverses relacions del mateix tipus entre dos Contactes.</help>
+        <label>Permet relacions duplicades autocreades</label>
+        <name>Allow_AutoCreated_Duplicates__c</name>
+    </fields>
+    <fields>
+        <label>Darrera comprovació errors asíncrons</label>
+        <name>Async_Error_Check_Last_Run__c</name>
+    </fields>
+    <fields>
+        <help>Suport gestió d&apos;adreces per a contactes.</help>
+        <label>Suport gestió d&apos;adreces per a contactes.</label>
+        <name>Contacts_Addresses_Enabled__c</name>
+    </fields>
+    <fields>
+        <help>Si es marca, el marc de maneig d&apos;errors de HEDA està desactivat.</help>
+        <label>Desactiva el maneig d&apos;errors</label>
+        <name>Disable_Error_Handling__c</name>
+    </fields>
+    <fields>
+        <help>Seleccioneu aquesta casella per desactivar l&apos;aplicació del camp de correu electrònic preferit per a contactes.</help>
+        <label>Desact. aplicació correu elect. preferit</label>
+        <name>Disable_Preferred_Email_Enforcement__c</name>
+    </fields>
+    <fields>
+        <label>Activa les connexions del curs</label>
+        <name>Enable_Course_Connections__c</name>
+    </fields>
+    <fields>
+        <help>Activeu aquesta opció per activar les declaracions de depuració en el codi del paquet gestionat.</help>
+        <label>Activa la depuració</label>
+        <name>Enable_Debug__c</name>
+    </fields>
+    <fields>
+        <help>Marqueu això si voleu que el sistema publiqui notificacions per a determinats tipus d&apos;errors.</help>
+        <label>Notificacions d&apos;errors</label>
+        <name>Error_Notifications_On__c</name>
+    </fields>
+    <fields>
+        <help>Seleccioneu el tipus d&apos;usuari per enviar notificacions.</help>
+        <label>Destinataris notificacions d&apos;errors</label>
+        <name>Error_Notifications_To__c</name>
+    </fields>
+    <fields>
+        <label>Tipus de registre de la facultat</label>
+        <name>Faculty_RecType__c</name>
+    </fields>
+    <fields>
+        <help>Tipus de registre del compte que admet el comportament de les adreces de la llar.</help>
+        <label>Tipus registre de compte adreces de llar</label>
+        <name>Household_Addresses_RecType__c</name>
+    </fields>
+    <fields>
+        <help>Determina el mètode utilitzat per generar la relació recíproca. Configuració de la llista que utilitza la configuració personalitzada per sexe, o la inversió de valor, que inverteix el tipus, si escau (&quot;Principal-Derivat&quot; a &quot;Derivat-Principal&quot;)</help>
+        <label>Mètode recíproc</label>
+        <name>Reciprocal_Method__c</name>
+    </fields>
+    <fields>
+        <help>El fet d&apos;omplir aquest valor permetrà que el camp s&apos;ompli a l&apos;hora de crear relacions noves del Visor de relacions (vegeu la descripció per obtenir més informació).</help>
+        <label>Identificador de camp de nom de relació</label>
+        <name>Relationship_Name_Field_Id__c</name>
+    </fields>
+    <fields>
+        <help>El fet d&apos;omplir aquest valor permetrà que el camp s&apos;ompli a l&apos;hora de crear relacions noves del Visor de relacions (vegeu la descripció per obtenir més informació).</help>
+        <label>Id. de camp de l&apos;id. de nom de relació</label>
+        <name>Relationship_Name_Id_Field_Id__c</name>
+    </fields>
+    <fields>
+        <help>Si està marcada, els canvis en un camp d&apos;adreça de contacte o de compte actualitzen l&apos;adreça existent, en lloc de crear una nova adreça.</help>
+        <label>Canvi simple adreça com a actualització</label>
+        <name>Simple_Address_Change_Treated_as_Update__c</name>
+    </fields>
+    <fields>
+        <help>Marqueu això si voleu que s&apos;emmagatzemin els errors a la base de dades.</help>
+        <label>Errors d&apos;emmagatzematge</label>
+        <name>Store_Errors_On__c</name>
+    </fields>
+    <fields>
+        <label>Tipus de registre d&apos;estudiant</label>
+        <name>Student_RecType__c</name>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Program_Enrollment__c-ca.objectTranslation
+++ b/src/objectTranslations/Program_Enrollment__c-ca.objectTranslation
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Program Enrollment --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Program Enrollment --></value>
+    </caseValues>
+    <fields>
+        <help>El programa al qual està inscrit l&apos;estudiant.</help>
+        <label>Programa</label>
+        <name>Account__c</name>
+        <relationshipLabel>Inscripcions del programa</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Data d&apos;admissió</label>
+        <name>Admission_Date__c</name>
+    </fields>
+    <fields>
+        <help>La relació de compte i contacte amb la qual està relacionada aquesta informació acadèmica.</help>
+        <label>Afiliació</label>
+        <name>Affiliation__c</name>
+        <relationshipLabel>Inscripcions del programa</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Data de presentació de la sol·licitud</label>
+        <name>Application_Submitted_Date__c</name>
+    </fields>
+    <fields>
+        <label>Classe de peu</label>
+        <name>Class_Standing__c</name>
+        <picklistValues>
+            <masterLabel>Freshman</masterLabel>
+            <translation>Estudiant de primer any</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Junior</masterLabel>
+            <translation>Estudiant de penúltim any</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Senior</masterLabel>
+            <translation>Estudiant d&apos;últim any</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sophomore</masterLabel>
+            <translation>Estudiant de segon any</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>El contacte principal.</help>
+        <label>Contacte</label>
+        <name>Contact__c</name>
+        <relationshipLabel>Inscripcions del programa</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Crèdits als quals s&apos;ha assistit</label>
+        <name>Credits_Attempted__c</name>
+    </fields>
+    <fields>
+        <label>Crèdits obtinguts</label>
+        <name>Credits_Earned__c</name>
+    </fields>
+    <fields>
+        <label>Elegible per inscriure&apos;s</label>
+        <name>Eligible_to_Enroll__c</name>
+    </fields>
+    <fields>
+        <label>Data de finalització</label>
+        <name>End_Date__c</name>
+    </fields>
+    <fields>
+        <label>Estat d&apos;inscripció</label>
+        <name>Enrollment_Status__c</name>
+        <picklistValues>
+            <masterLabel>Full-time</masterLabel>
+            <translation>A temps complet</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Half-time</masterLabel>
+            <translation>A mitja jornada</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Less than half-time</masterLabel>
+            <translation>Menys de mitja jornada</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label><!-- GPA --></label>
+        <name>GPA__c</name>
+    </fields>
+    <fields>
+        <label>Any de classe</label>
+        <name>Graduation_Year__c</name>
+    </fields>
+    <fields>
+        <label>Data d&apos;inici</label>
+        <name>Start_Date__c</name>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <layouts>
+        <layout>HEDA Program Enrollment Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Program Enrollment ID --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Program_Enrollment__c-ca.objectTranslation
+++ b/src/objectTranslations/Program_Enrollment__c-ca.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Program Enrollment --></value>
+        <value>Inscripció al programa</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Program Enrollment --></value>
+        <value>Inscripcions al programa</value>
     </caseValues>
     <fields>
         <help>El programa al qual està inscrit l&apos;estudiant.</help>
@@ -98,7 +98,7 @@
         <label>Data d&apos;inici</label>
         <name>Start_Date__c</name>
     </fields>
-    <gender><!-- Feminine --></gender>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Program Enrollment Layout</layout>
         <sections>
@@ -106,6 +106,6 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <nameFieldLabel><!-- Program Enrollment ID --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <nameFieldLabel>ID d&apos;inscripció del programa</nameFieldLabel>
+    <startsWith>Vowel</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Relationship_Auto_Create__c-ca.objectTranslation
+++ b/src/objectTranslations/Relationship_Auto_Create__c-ca.objectTranslation
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Relationship Auto-Create --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Relationship Auto-Create --></value>
+    </caseValues>
+    <fields>
+        <help>Els tipus de campanya elegibles per a aquest membre de la campanya es creen automàticament. (Estarà en blanc per crear automàticament el contacte)</help>
+        <label>Tipus de campanya</label>
+        <name>Campaign_Types__c</name>
+    </fields>
+    <fields>
+        <help>La inserció o actualització de camp que activa la creació d&apos;aquesta relació</help>
+        <label>Camp</label>
+        <name>Field__c</name>
+    </fields>
+    <fields>
+        <help>L&apos;objecte al qual està associada aquesta relació automàtica</help>
+        <label>Objecte</label>
+        <name>Object__c</name>
+    </fields>
+    <fields>
+        <help>El tipus de relació que es crearà entre l&apos;objecte base i l&apos;objecte de cerca. L&apos;objecte de cerca rebrà la relació recíproca, si n&apos;hi ha disponible.</help>
+        <label>Tipus de relació</label>
+        <name>Relationship_Type__c</name>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Relationship_Lookup__c-ca.objectTranslation
+++ b/src/objectTranslations/Relationship_Lookup__c-ca.objectTranslation
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Relationship Lookup --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Relationship Lookup --></value>
+    </caseValues>
+    <fields>
+        <help>Indica si aquesta cerca recíproca està activa.</help>
+        <label>Actiu</label>
+        <name>Active__c</name>
+    </fields>
+    <fields>
+        <help>El valor utilitzat si el camp de sexe del contacte coincideix amb els valors de l&apos;etiqueta personalitzada femenina o la salutació del contacte indica el sexe.</help>
+        <label>Dona</label>
+        <name>Female__c</name>
+    </fields>
+    <fields>
+        <help>El valor utilitzat si el camp de sexe del contacte coincideix amb els valors de l&apos;etiqueta personalitzada masculina o la salutació del contacte indica el sexe.</help>
+        <label>Home</label>
+        <name>Male__c</name>
+    </fields>
+    <fields>
+        <help>El valor utilitzat si el camp de sexe del contacte no coincideix amb les etiquetes personalitzades masculines o femenines, i si de la salutació del contacte no s&apos;infereix el sexe.</help>
+        <label><!-- Neutral --></label>
+        <name>Neutral__c</name>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Relationship__c-ca.objectTranslation
+++ b/src/objectTranslations/Relationship__c-ca.objectTranslation
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Relationship --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Relationship --></value>
+    </caseValues>
+    <fields>
+        <help>El contacte relacionat és ______ d&apos;aquest contacte.</help>
+        <label>Contacte</label>
+        <name>Contact__c</name>
+        <relationshipLabel>Relacions</relationshipLabel>
+    </fields>
+    <fields>
+        <help>Informació addicional sobre aquesta relació</help>
+        <label>Descripció</label>
+        <name>Description__c</name>
+    </fields>
+    <fields>
+        <help>És un contacte d&apos;emergència?</help>
+        <label>Contacte d&apos;emergència</label>
+        <name>Emergency_Contact__c</name>
+    </fields>
+    <fields>
+        <help>Camp de sistema que uneix els dos costats de la relació junts. Aquest camp no s&apos;ha de modificar directament. La relació recíproca tindrà el tipus contrari, si està disponible, d&apos;aquesta relació.</help>
+        <label>Relació recíproca</label>
+        <name>ReciprocalRelationship__c</name>
+        <relationshipLabel>Relacions</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Contacte relacionat</label>
+        <name>RelatedContact__c</name>
+        <relationshipLabel>Llista de relacions ocultades</relationshipLabel>
+    </fields>
+    <fields>
+        <help>Fórmula de text que construeix una frase que explica la relació entre els dos contactes.</help>
+        <label>Explicació de la relació</label>
+        <name>Relationship_Explanation__c</name>
+    </fields>
+    <fields>
+        <help>Camp del sistema que indica si aquesta relació es va crear automàticament com a recíproca a altres relacions.</help>
+        <label><!-- _SYSTEM: SystemCreated --></label>
+        <name>SYSTEM_SystemCreated__c</name>
+    </fields>
+    <fields>
+        <help>Estat de la relació.</help>
+        <label>Estat</label>
+        <name>Status__c</name>
+        <picklistValues>
+            <masterLabel>Current</masterLabel>
+            <translation>Actual</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Former</masterLabel>
+            <translation>Antic</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Camp que descriu com el contacte relacionat està connectat al contacte.</help>
+        <label>Tipus</label>
+        <name>Type__c</name>
+        <picklistValues>
+            <masterLabel>Aunt</masterLabel>
+            <translation>Tia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Child</masterLabel>
+            <translation>Nen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cousin</masterLabel>
+            <translation>Cosí/na</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Coworker</masterLabel>
+            <translation>Company de feina</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Daughter</masterLabel>
+            <translation>Filla</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Employee</masterLabel>
+            <translation>Empleat</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Employer</masterLabel>
+            <translation>Empresari</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Family</masterLabel>
+            <translation>Família</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Father</masterLabel>
+            <translation>Pare</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Friend</masterLabel>
+            <translation>Amic</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grandchild</masterLabel>
+            <translation>Net/a</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Granddaughter</masterLabel>
+            <translation>Neta</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grandfather</masterLabel>
+            <translation>Avi</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grandmother</masterLabel>
+            <translation>Àvia</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grandparent</masterLabel>
+            <translation>Avi</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grandson</masterLabel>
+            <translation>Net</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Husband</masterLabel>
+            <translation>Marit</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mother</masterLabel>
+            <translation>Mare</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Parent</masterLabel>
+            <translation>Pare</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Partner</masterLabel>
+            <translation>Company</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Son</masterLabel>
+            <translation>Fill</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uncle</masterLabel>
+            <translation>Oncle</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wife</masterLabel>
+            <translation>Dona</translation>
+        </picklistValues>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <layouts>
+        <layout>HEDA Relationship Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+        <sections>
+            <label>Informació de la relació</label>
+            <section>Relationship Information</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Relationship Key --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+    <validationRules>
+        <errorMessage>En lloc de canviar els contactes en una relació existent, elimineu aquesta relació i creeu-ne un d&apos;entre els nous contactes</errorMessage>
+        <name>Related_Contact_Do_Not_Change</name>
+    </validationRules>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Relationship__c-ca.objectTranslation
+++ b/src/objectTranslations/Relationship__c-ca.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Relationship --></value>
+        <value>Relació</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Relationship --></value>
+        <value>Relacions</value>
     </caseValues>
     <fields>
         <help>El contacte relacionat és ______ d&apos;aquest contacte.</help>
@@ -155,7 +155,7 @@
             <translation>Dona</translation>
         </picklistValues>
     </fields>
-    <gender><!-- Feminine --></gender>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Relationship Layout</layout>
         <sections>
@@ -167,8 +167,8 @@
             <section>Relationship Information</section>
         </sections>
     </layouts>
-    <nameFieldLabel><!-- Relationship Key --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <nameFieldLabel>Clau de relació</nameFieldLabel>
+    <startsWith>Consonant</startsWith>
     <validationRules>
         <errorMessage>En lloc de canviar els contactes en una relació existent, elimineu aquesta relació i creeu-ne un d&apos;entre els nous contactes</errorMessage>
         <name>Related_Contact_Do_Not_Change</name>

--- a/src/objectTranslations/Term__c-ca.objectTranslation
+++ b/src/objectTranslations/Term__c-ca.objectTranslation
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Term --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Term --></value>
+    </caseValues>
+    <fields>
+        <label>Compte</label>
+        <name>Account__c</name>
+        <relationshipLabel>Condicions</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Data de finalització</label>
+        <name>End_Date__c</name>
+    </fields>
+    <fields>
+        <label>Data d&apos;inici</label>
+        <name>Start_Date__c</name>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <layouts>
+        <layout>HEDA Term Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Term Name --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Term__c-ca.objectTranslation
+++ b/src/objectTranslations/Term__c-ca.objectTranslation
@@ -2,16 +2,16 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Term --></value>
+        <value>Termini</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Term --></value>
+        <value>Terminis</value>
     </caseValues>
     <fields>
         <label>Compte</label>
         <name>Account__c</name>
-        <relationshipLabel>Condicions</relationshipLabel>
+        <relationshipLabel>Terminis</relationshipLabel>
     </fields>
     <fields>
         <label>Data de finalització</label>
@@ -21,7 +21,7 @@
         <label>Data d&apos;inici</label>
         <name>Start_Date__c</name>
     </fields>
-    <gender><!-- Feminine --></gender>
+    <gender>Masculine</gender>
     <layouts>
         <layout>HEDA Term Layout</layout>
         <sections>
@@ -29,6 +29,6 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <nameFieldLabel><!-- Term Name --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <nameFieldLabel>Nom del termini</nameFieldLabel>
+    <startsWith>Consonant</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Trigger_Handler__c-ca.objectTranslation
+++ b/src/objectTranslations/Trigger_Handler__c-ca.objectTranslation
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Trigger Handler --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Trigger Handler --></value>
+    </caseValues>
+    <fields>
+        <help>Indica que aquest mòdul està actiu</help>
+        <label>Actiu</label>
+        <name>Active__c</name>
+    </fields>
+    <fields>
+        <help>Indica que aquest mòdul s&apos;ha d&apos;executar de forma asíncrona en aquesta transacció</help>
+        <label>Asíncron</label>
+        <name>Asynchronous__c</name>
+    </fields>
+    <fields>
+        <help>Nom de la classe a executar</help>
+        <label>Classe</label>
+        <name>Class__c</name>
+    </fields>
+    <fields>
+        <help>Nom del camp utilitzat per filtrar.</help>
+        <label>Camp de filtre</label>
+        <name>Filter_Field__c</name>
+    </fields>
+    <fields>
+        <help>Valor del camp utilitzat per al filtratge.</help>
+        <label>Valor del filtre</label>
+        <name>Filter_Value__c</name>
+    </fields>
+    <fields>
+        <help>L&apos;ordre en què s&apos;ha d&apos;executar aquest mòdul, ajuda a mantenir les dependències en els mòduls i les dades.</help>
+        <label>Ordre de càrrega</label>
+        <name>Load_Order__c</name>
+    </fields>
+    <fields>
+        <help>Nom de l&apos;objecte a on s&apos;ha d&apos;executar aquest controlador</help>
+        <label>Objecte</label>
+        <name>Object__c</name>
+    </fields>
+    <fields>
+        <label>Propietat per l&apos;espai de noms</label>
+        <name>Owned_by_Namespace__c</name>
+    </fields>
+    <fields>
+        <help>Acció d&apos;activació en què aquest mòdul s&apos;hauria de disparar</help>
+        <label>Acció d&apos;activació</label>
+        <name>Trigger_Action__c</name>
+        <picklistValues>
+            <masterLabel>AfterDelete</masterLabel>
+            <translation>Després de suprimir</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>AfterInsert</masterLabel>
+            <translation>Després d&apos;inserir</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>AfterUndelete</masterLabel>
+            <translation>Després de recuperar</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>AfterUpdate</masterLabel>
+            <translation>Després d&apos;actualitzar</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>BeforeDelete</masterLabel>
+            <translation>Abans de suprimir</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>BeforeInsert</masterLabel>
+            <translation>Abans d&apos;inserir</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>BeforeUpdate</masterLabel>
+            <translation>Abans d&apos;actualitzar</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Comproveu si voleu administrar el registre per si mateix. Tingueu en compte que les actualitzacions del paquet no actualitzaran el registre.</help>
+        <label>Usuari gestionat</label>
+        <name>User_Managed__c</name>
+    </fields>
+    <fields>
+        <help><!-- Semicolon separated list of Salesforce usernames that this trigger will NOT run for. Leave blank to run for all users. --></help>
+        <label><!-- Usernames to Exclude --></label>
+        <name>Usernames_to_Exclude__c</name>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <layouts>
+        <layout>HEDA Trigger Handler Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Trigger Handler Name --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Trigger_Handler__c-ca.objectTranslation
+++ b/src/objectTranslations/Trigger_Handler__c-ca.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Trigger Handler --></value>
+        <value>Gestor de disparador</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Trigger Handler --></value>
+        <value>Gestors de disparadors</value>
     </caseValues>
     <fields>
         <help>Indica que aquest mòdul està actiu</help>
@@ -90,7 +90,7 @@
         <label><!-- Usernames to Exclude --></label>
         <name>Usernames_to_Exclude__c</name>
     </fields>
-    <gender><!-- Feminine --></gender>
+    <gender>Masculine</gender>
     <layouts>
         <layout>HEDA Trigger Handler Layout</layout>
         <sections>
@@ -98,6 +98,6 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <nameFieldLabel><!-- Trigger Handler Name --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <nameFieldLabel>Nom del gestor de disparador</nameFieldLabel>
+    <startsWith>Consonant</startsWith>
 </CustomObjectTranslation>

--- a/src/package.xml
+++ b/src/package.xml
@@ -647,6 +647,7 @@
         <name>ListView</name>
     </types>
     <types>
+        <members>ca</members>
         <members>es</members>
         <members>fr</members>
         <name>Translations</name>

--- a/src/package.xml
+++ b/src/package.xml
@@ -516,34 +516,50 @@
         <name>CustomObject</name>
     </types>
     <types>
+        <members>Account-ca</members>
         <members>Account-es</members>
+        <members>Address__c-ca</members>
         <members>Address__c-en_US</members>
         <members>Address__c-es</members>
+        <members>Affiliation__c-ca</members>
         <members>Affiliation__c-en_US</members>
         <members>Affiliation__c-es</members>
+        <members>Affl_Mappings__c-ca</members>
         <members>Affl_Mappings__c-en_US</members>
         <members>Affl_Mappings__c-es</members>
+        <members>Contact-ca</members>
         <members>Contact-es</members>
+        <members>Course_Enrollment__c-ca</members>
         <members>Course_Enrollment__c-en_US</members>
         <members>Course_Enrollment__c-es</members>
+        <members>Course_Offering__c-ca</members>
         <members>Course_Offering__c-en_US</members>
         <members>Course_Offering__c-es</members>
+        <members>Course__c-ca</members>
         <members>Course__c-en_US</members>
         <members>Course__c-es</members>
+        <members>Error__c-ca</members>
         <members>Error__c-en_US</members>
         <members>Error__c-es</members>
+        <members>Hierarchy_Settings__c-ca</members>
         <members>Hierarchy_Settings__c-en_US</members>
         <members>Hierarchy_Settings__c-es</members>
+        <members>Program_Enrollment__c-ca</members>
         <members>Program_Enrollment__c-en_US</members>
         <members>Program_Enrollment__c-es</members>
+        <members>Relationship_Auto_Create__c-ca</members>
         <members>Relationship_Auto_Create__c-en_US</members>
         <members>Relationship_Auto_Create__c-es</members>
+        <members>Relationship_Lookup__c-ca</members>
         <members>Relationship_Lookup__c-en_US</members>
         <members>Relationship_Lookup__c-es</members>
+        <members>Relationship__c-ca</members>
         <members>Relationship__c-en_US</members>
         <members>Relationship__c-es</members>
+        <members>Term__c-ca</members>
         <members>Term__c-en_US</members>
         <members>Term__c-es</members>
+        <members>Trigger_Handler__c-ca</members>
         <members>Trigger_Handler__c-en_US</members>
         <members>Trigger_Handler__c-es</members>
         <name>CustomObjectTranslation</name>

--- a/src/translations/ca.translation
+++ b/src/translations/ca.translation
@@ -77,6 +77,10 @@
         <name>RelationshipsLookupDescription</name>
     </customLabels>
     <customLabels>
+        <label><!-- acctNamingOther --></label>
+        <name>acctNamingOther</name>
+    </customLabels>
+    <customLabels>
         <label>Els registres d&apos;adreces només s&apos;han de crear com a derivats de compte o de contacte.</label>
         <name>addrHhAdmAccountOnly</name>
     </customLabels>
@@ -105,8 +109,28 @@
         <name>addrValidParentObjects</name>
     </customLabels>
     <customLabels>
+        <label><!-- adminAccNameFormat --></label>
+        <name>adminAccNameFormat</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- adminAccNameFormatHelpText --></label>
+        <name>adminAccNameFormatHelpText</name>
+    </customLabels>
+    <customLabels>
         <label>El tipus de registre del compte {0} no existeix. Demaneu al vostre administrador que verifiqui els tipus de registre en les assignacions d&apos;afiliació.</label>
         <name>afflNullPointerError</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- automaticHHNaming --></label>
+        <name>automaticHHNaming</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- automaticHHNamingHelpText --></label>
+        <name>automaticHHNamingHelpText</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- defaultNamingConnector --></label>
+        <name>defaultNamingConnector</name>
     </customLabels>
     <customLabels>
         <label><!-- Error message for TDTM filtering functionality. --></label>
@@ -127,6 +151,50 @@
     <customLabels>
         <label><!-- Error message for TDTM filtering functionality. --></label>
         <name>fieldWithHEDANamespace</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- firstNameLastNameAdminACC --></label>
+        <name>firstNameLastNameAdminACC</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- firstNameLastNameFamily --></label>
+        <name>firstNameLastNameFamily</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- firstNameLastNameHH --></label>
+        <name>firstNameLastNameHH</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- hhAccNameFormat --></label>
+        <name>hhAccNameFormat</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- hhAccNameFormatHelpText --></label>
+        <name>hhAccNameFormatHelpText</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- lastNameAdminAcc --></label>
+        <name>lastNameAdminAcc</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- lastNameFamily --></label>
+        <name>lastNameFamily</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- lastNameFirstNameAdminAcc --></label>
+        <name>lastNameFirstNameAdminAcc</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- lastNameFirstNameFamily --></label>
+        <name>lastNameFirstNameFamily</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- lastNameFirstNameHH --></label>
+        <name>lastNameFirstNameHH</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- lastNameHH --></label>
+        <name>lastNameHH</name>
     </customLabels>
     <customLabels>
         <label>El tipus de registre del compte definit no existeix:</label>

--- a/src/translations/ca.translation
+++ b/src/translations/ca.translation
@@ -1,0 +1,623 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Translations xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customApplications>
+        <label><!-- HEDA --></label>
+        <name>HEDA</name>
+    </customApplications>
+    <customLabels>
+        <label>Les afiliacions primàries assignades apareixen en una secció especial d&apos;afiliacions primàries al registre de contactes. El valor establert com a principal per a un tipus de registre del compte apareix als camps corresponents del registre de contacte, tal com es defineix a continuació. Per obtenir més informació, consulteu el</label>
+        <name>AfflMappingsDescription</name>
+    </customLabels>
+    <customLabels>
+        <label>Quan se suprimeixi la inscripció del programa, elimineu l&apos;afiliació relacionada.</label>
+        <name>AfflProgEnrollDeleted</name>
+    </customLabels>
+    <customLabels>
+        <label>No es pot trobar la configuració de la relació d&apos;autocreació vàlida. Verifiqueu la configuració a Configuració de HEDA | Relacions | Autocreació per a camps vàlids i torneu-ho a provar.</label>
+        <name>AutoCreateFieldError</name>
+    </customLabels>
+    <customLabels>
+        <label>Establiu el camp del filtre, o bé el camp del filtre i el valor del filtre.</label>
+        <name>BothFieldAndValue</name>
+    </customLabels>
+    <customLabels>
+        <label>No es pot esborrar el registre perquè hi ha registres derivats. Elimineu primer els derivats.</label>
+        <name>CannotDelete</name>
+    </customLabels>
+    <customLabels>
+        <label>Compte</label>
+        <name>DefaultAccountName</name>
+    </customLabels>
+    <customLabels>
+        <label>Compte administratiu</label>
+        <name>DefaultAdminName</name>
+    </customLabels>
+    <customLabels>
+        <label>Llar</label>
+        <name>DefaultHouseholdName</name>
+    </customLabels>
+    <customLabels>
+        <label>Dona</label>
+        <name>Female</name>
+    </customLabels>
+    <customLabels>
+        <label>El valor del camp de filtre no és vàlid definit per a </label>
+        <name>InvalidFilter</name>
+    </customLabels>
+    <customLabels>
+        <label>Home</label>
+        <name>Male</name>
+    </customLabels>
+    <customLabels>
+        <label>No podem trobar el correu electrònic especificat a Correu electrònic preferit. Assegureu-vos que esteu introduint l&apos;etiqueta del camp d&apos;un camp de correu electrònic personalitzat existent.</label>
+        <name>PreferredEmailMatchMustExist</name>
+    </customLabels>
+    <customLabels>
+        <label>El correu electrònic seleccionat per a l&apos;adreça electrònica preferida no es pot deixar en blanc.</label>
+        <name>PreferredEmailMatchNotNull</name>
+    </customLabels>
+    <customLabels>
+        <label>Indiqueu el correu electrònic preferit.</label>
+        <name>PreferredEmailRequiredError</name>
+    </customLabels>
+    <customLabels>
+        <label>és</label>
+        <name>Relationship_Explanation_Connector</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Relationship Split --></label>
+        <name>Relationship_Split</name>
+    </customLabels>
+    <customLabels>
+        <label>Les relacions automàtiques permeten identificar els vostres propis camps de cerca personalitzats als objectes de contacte o de campanya que activen la creació d&apos;un nou tipus de relació que vulgueu. Per exemple, una consulta de &quot;Referència&quot; des del membre de la campanya amb qui contactar podria crear una relació de &quot;Referenciant&quot; i un &quot;Referit&quot; entre els dos contactes. (Tingueu en compte que aquesta funció no està disponible per a clients potencials o objectes membre de la campanya que fan referències.)</label>
+        <name>RelationshipsAutoDescription</name>
+    </customLabels>
+    <customLabels>
+        <label>Aquesta configuració us permet configurar relacions recíproques o la relació &quot;coincident&quot; entre dos contactes. Per exemple, si un pare està relacionat amb el seu fill, el fill també s&apos;hauria de relacionar amb el pare. Podeu especificar el valor Tipus de nom i, a continuació, especificar en quin valor recíproc s&apos;ha de basar en el sexe del contacte de connexió. Podeu definir un recíproc masculí, un recíproc femení i un recíproc neutre que s&apos;utilitzarà si el sexe no es pot determinar.</label>
+        <name>RelationshipsLookupDescription</name>
+    </customLabels>
+    <customLabels>
+        <label>Els registres d&apos;adreces només s&apos;han de crear com a derivats de compte o de contacte.</label>
+        <name>addrHhAdmAccountOnly</name>
+    </customLabels>
+    <customLabels>
+        <label>La capacitat d&apos;afegir diverses adreces està desactivada per a aquest tipus de registre del compte. Per habilitar-lo, aneu a Configuració de HEDA, feu clic a Comptes i contactes i seleccioneu la casella corresponent al costat dels tipus de compte amb les adreces múltiples activades.</label>
+        <name>addrNotEnabledAccount</name>
+    </customLabels>
+    <customLabels>
+        <label>La capacitat d&apos;afegir diverses adreces està desactivada per als contactes. Per activar-lo, aneu a Configuració de HEDA, feu clic a Comptes i contactes i, a continuació, seleccioneu la casella de selecció Contacte amb adreces múltiples activades.</label>
+        <name>addrNotEnabledContact</name>
+    </customLabels>
+    <customLabels>
+        <label>Els intervals de dates per a les adreces estacionals no es poden superposar.</label>
+        <name>addrSeasonalOverlap</name>
+    </customLabels>
+    <customLabels>
+        <label>Una adreça ha de tenir tots els camps d&apos;inici i finalització del dia i el mes establerts o cap d&apos;ells.</label>
+        <name>addrSeasonalPartial</name>
+    </customLabels>
+    <customLabels>
+        <label>Una adreça ha de tenir tant el conjunt d&apos;inici com a final d&apos;any o cap d&apos;ells.</label>
+        <name>addrSeasonalPartialYear</name>
+    </customLabels>
+    <customLabels>
+        <label>Els registres d&apos;adreces només s&apos;han de crear com a derivats de compte o de contacte.</label>
+        <name>addrValidParentObjects</name>
+    </customLabels>
+    <customLabels>
+        <label>El tipus de registre del compte {0} no existeix. Demaneu al vostre administrador que verifiqui els tipus de registre en les assignacions d&apos;afiliació.</label>
+        <name>afflNullPointerError</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Error message for TDTM filtering functionality. --></label>
+        <name>duplicateFieldInFilter</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Error message for TDTM filtering functionality. --></label>
+        <name>duplicateWithHEDAField</name>
+    </customLabels>
+    <customLabels>
+        <label>No s&apos;estableix un camp obligatori. Aquest camp podria ser d&apos;aquest registre o d&apos;un registre relacionat.</label>
+        <name>exceptionRequiredField</name>
+    </customLabels>
+    <customLabels>
+        <label>Una regla de validació impedeix que es processi el registre. Això podria ser a causa d&apos;aquest registre o d&apos;un registre relacionat que s&apos;actualitzava. MISSATGE DE VALIDACIÓ:</label>
+        <name>exceptionValidationRule</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Error message for TDTM filtering functionality. --></label>
+        <name>fieldWithHEDANamespace</name>
+    </customLabels>
+    <customLabels>
+        <label>El tipus de registre del compte definit no existeix:</label>
+        <name>noAccRecType</name>
+    </customLabels>
+    <customLabels>
+        <label>Sense assignacions d&apos;afiliació per mostrar. Intenteu crear-ne de noves utilitzant el formulari següent.</label>
+        <name>noAfflMappings</name>
+    </customLabels>
+    <customLabels>
+        <label>Sense configuracions de creació automàtica per mostrar. Intenteu crear-ne de noves utilitzant el formulari següent.</label>
+        <name>noAutoCreateSettings</name>
+    </customLabels>
+    <customLabels>
+        <label>Sense configuracions de reciprocitat per mostrar. Intenteu crear-ne de noves utilitzant el formulari següent.</label>
+        <name>noRecSettings</name>
+    </customLabels>
+    <customLabels>
+        <label>Correu electrònic (estàndard)</label>
+        <name>preferredBatchDefaultEmail</name>
+    </customLabels>
+    <customLabels>
+        <label>Model de compte predeterminat:</label>
+        <name>stgAccModelTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Tipus de registre del compte que admeten les adreces de la llar.</label>
+        <name>stgAccountRecordTypeSupportsHHAddress</name>
+    </customLabels>
+    <customLabels>
+        <label>Tipus de comptes amb diverses adreces habilitades:</label>
+        <name>stgAccountTypesMultiAddressesEnabled</name>
+    </customLabels>
+    <customLabels>
+        <label>Tipus de compte sense contactes per esborrar:</label>
+        <name>stgAccoutTypesWithoutContactsDelete</name>
+    </customLabels>
+    <customLabels>
+        <label>Afegiu &quot;Hispà o llatí&quot; com a valor de llista de selecció al camp Ètnia si és necessari.</label>
+        <name>stgAddHispanicOrLatinoPicklistValue</name>
+    </customLabels>
+    <customLabels>
+        <label>Afegiu &quot;No hispà ni llatí&quot; com a valor de llista de selecció al camp Ètnia si és necessari.</label>
+        <name>stgAddNotHispanicOrLatinoPicklistValue</name>
+    </customLabels>
+    <customLabels>
+        <label>Després d&apos;executar el reenviament:</label>
+        <name>stgAfterRunBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Introduïu el nom del grup de Chatter per cercar</label>
+        <name>stgAutoCompleteEnterChatterGroupName</name>
+    </customLabels>
+    <customLabels>
+        <label>Introduïu el nom de l&apos;usuari per cercar</label>
+        <name>stgAutoCompleteEnterUserName</name>
+    </customLabels>
+    <customLabels>
+        <label>Seleccioneu el grup de Chatter</label>
+        <name>stgAutoCompleteSelectChatterGroup</name>
+    </customLabels>
+    <customLabels>
+        <label>Seleccioneu l&apos;usuari</label>
+        <name>stgAutoCompleteSelectUser</name>
+    </customLabels>
+    <customLabels>
+        <label>Inscripció automàtica</label>
+        <name>stgAutoEnrollment</name>
+    </customLabels>
+    <customLabels>
+        <label>Funció d&apos;inscripció automàtica</label>
+        <name>stgAutoEnrollmentRole</name>
+    </customLabels>
+    <customLabels>
+        <label>Estat d&apos;inscripció automàtica</label>
+        <name>stgAutoEnrollmentStatus</name>
+    </customLabels>
+    <customLabels>
+        <label>El reenviament s&apos;ha posat en cua correctament. S&apos;enviarà un correu electrònic en finalitzar el lot.</label>
+        <name>stgBackfillQueuedEmailSent</name>
+    </customLabels>
+    <customLabels>
+        <label>Abans d&apos;executar el reenviament:</label>
+        <name>stgBeforeRunBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Afegeix una assignació</label>
+        <name>stgBtnAddMapping</name>
+    </customLabels>
+    <customLabels>
+        <label>Afegeix una configuració</label>
+        <name>stgBtnAddSetting</name>
+    </customLabels>
+    <customLabels>
+        <label>Cancel·la</label>
+        <name>stgBtnCancel</name>
+    </customLabels>
+    <customLabels>
+        <label>Edita</label>
+        <name>stgBtnEdit</name>
+    </customLabels>
+    <customLabels>
+        <label>Executa el reenviament</label>
+        <name>stgBtnRunBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Executa la còpia</label>
+        <name>stgBtnRunCopy</name>
+    </customLabels>
+    <customLabels>
+        <label>Desa</label>
+        <name>stgBtnSave</name>
+    </customLabels>
+    <customLabels>
+        <label>La neteja s&apos;ha posat en cua correctament. S&apos;enviarà un correu electrònic en finalitzar el lot.</label>
+        <name>stgCleanupQueuedEmailSent</name>
+    </customLabels>
+    <customLabels>
+        <label>Tipus de registre del compte</label>
+        <name>stgColAccountRecordType</name>
+    </customLabels>
+    <customLabels>
+        <label>Actiu</label>
+        <name>stgColActive</name>
+    </customLabels>
+    <customLabels>
+        <label>Tipus de campanya</label>
+        <name>stgColCampTypes</name>
+    </customLabels>
+    <customLabels>
+        <label>Camp d&apos;afiliació primària de contacte</label>
+        <name>stgColContactPrimaryAfflField</name>
+    </customLabels>
+    <customLabels>
+        <label>Dona</label>
+        <name>stgColFemale</name>
+    </customLabels>
+    <customLabels>
+        <label>Camp</label>
+        <name>stgColField</name>
+    </customLabels>
+    <customLabels>
+        <label>Home</label>
+        <name>stgColMale</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- stgColNeutral --></label>
+        <name>stgColNeutral</name>
+    </customLabels>
+    <customLabels>
+        <label>Objecte</label>
+        <name>stgColObject</name>
+    </customLabels>
+    <customLabels>
+        <label>Tipus de relació</label>
+        <name>stgColRelType</name>
+    </customLabels>
+    <customLabels>
+        <label>Funció</label>
+        <name>stgColRole</name>
+    </customLabels>
+    <customLabels>
+        <label>Estat</label>
+        <name>stgColStatus</name>
+    </customLabels>
+    <customLabels>
+        <label>Entenc i estic preparat per executar el reenviament</label>
+        <name>stgConfirmReadyRunBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Contacte amb múltiples adreces activades:</label>
+        <name>stgContactMultiAddressesEnabled</name>
+    </customLabels>
+    <customLabels>
+        <label>El treball Apex per lots ha processat {0} lots amb {1} errors.</label>
+        <name>stgCourseDescriptionCopyEmailBody</name>
+    </customLabels>
+    <customLabels>
+        <label>Descripció del curs Còpia Treball Complet amb un estatus de:</label>
+        <name>stgCourseDescriptionCopyEmailSubject</name>
+    </customLabels>
+    <customLabels>
+        <label>Tipus predeterminat de registre de la facultat:</label>
+        <name>stgDefaultFacultyTypeTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Tipus predeterminat de registre d&apos;estudiant actiu:</label>
+        <name>stgDefaultStudentTypeTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>No, només s&apos;ha de canviar l&apos;estat a:</label>
+        <name>stgDeleteRelatedAfflNo</name>
+    </customLabels>
+    <customLabels>
+        <label>Sí:</label>
+        <name>stgDeleteRelatedAfflYes</name>
+    </customLabels>
+    <customLabels>
+        <label>Desactiva el maneig d&apos;errors:</label>
+        <name>stgDisableErrorHandlingTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Desactiva l&apos;aplicació de correu electrònic preferit:</label>
+        <name>stgDisablePreferredEmailEnforcement</name>
+    </customLabels>
+    <customLabels>
+        <label>Activa les connexions del curs:</label>
+        <name>stgEnableCourseConnectionsTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Notificacions d&apos;errors a:</label>
+        <name>stgErrorNotiTo</name>
+    </customLabels>
+    <customLabels>
+        <label>Destinataris de les notificacions d&apos;errors:</label>
+        <name>stgErrorNotifRecipientsTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Origen ètnic i racial per als contactes</label>
+        <name>stgEthnicityRaceBackfillContacts</name>
+    </customLabels>
+    <customLabels>
+        <label>Configuració del model de compte. &quot;Administratiu&quot; és el model recomanat.</label>
+        <name>stgHelpAccountModel</name>
+    </customLabels>
+    <customLabels>
+        <label>Registre els tipus dels comptes que s&apos;eliminaran automàticament si s&apos;han eliminat tots els contactes dels seus derivats.</label>
+        <name>stgHelpAccoutsDeletedIfChildContactsDeleted</name>
+    </customLabels>
+    <customLabels>
+        <label>Els tipus de registre del compte que admeten la gestió d&apos;adreces múltiples.</label>
+        <name>stgHelpAddressAccRecType</name>
+    </customLabels>
+    <customLabels>
+        <label>Seleccioneu aquesta opció per activar la gestió d&apos;adreces múltiples per a contactes.</label>
+        <name>stgHelpContactAddrs</name>
+    </customLabels>
+    <customLabels>
+        <label>No requereix que els contactes tinguin un correu electrònic preferit.</label>
+        <name>stgHelpContactPreferredEmail</name>
+    </customLabels>
+    <customLabels>
+        <label>El procés s&apos;ha posat en cua correctament. S&apos;enviarà un correu electrònic en finalitzar el treball.</label>
+        <name>stgHelpCopyQueuedEmailSent</name>
+    </customLabels>
+    <customLabels>
+        <label>El reenviament de connexions del curs s&apos;ha d&apos;utilitzar només quan s&apos;activen les connexions del curs per primera vegada i només a les organitzacions on hi ha hagut ofertes per a cursos i connexions per a cursos (inscripcions) abans d&apos;activar la funció. El reenviament converteix tots els contactes que es van incloure com a professors en una connexió de curs (inscripció) o oferta de cursos en el tipus de registre predeterminat del professorat. El reenviament converteix els contactes de les connexions restants del curs (inscripcions) en el tipus predeterminat de registre d&apos;estudiant actiu.</label>
+        <name>stgHelpCourseConnBackfillDescription</name>
+    </customLabels>
+    <customLabels>
+        <label>A HEDA 1.30, el camp de Descripció ampliada s&apos;ha afegit per donar cabuda a descripcions de cursos més llargues.</label>
+        <name>stgHelpCoursesDataMigration</name>
+    </customLabels>
+    <customLabels>
+        <label>Aquesta utilitat copia els valors del camp Descripció del curs al camp de Descripció ampliada. Aquest procés pot trigar una mica, però podeu tancar aquesta pàgina amb seguretat i el procés continuarà en segon pla.</label>
+        <name>stgHelpCoursesDataMigrationCopiesValues</name>
+    </customLabels>
+    <customLabels>
+        <label>Si un curs ja té un valor per a la Descripció ampliada, no la sobreescriurem.</label>
+        <name>stgHelpCoursesDataMigrationDontOverwrite</name>
+    </customLabels>
+    <customLabels>
+        <label>Un cop finalitzat el procés, recordeu actualitzar els dissenys de pàgines i altres àrees de l&apos;aplicació que fan referència als camps de la descripció.</label>
+        <name>stgHelpCoursesDataMigrationUpdatePageLayouts</name>
+    </customLabels>
+    <customLabels>
+        <label>El tipus de gravació predeterminat quan es creen connexions de curs per a un membre de la facultat.</label>
+        <name>stgHelpDefaultFacultyType</name>
+    </customLabels>
+    <customLabels>
+        <label>El tipus de gravació predeterminat quan es creen connexions de curs per a estudiants actius.</label>
+        <name>stgHelpDefaultStudentType</name>
+    </customLabels>
+    <customLabels>
+        <label>Heu d&apos;habilitar les connexions del curs abans d&apos;executar el reenviament de connexions del curs.</label>
+        <name>stgHelpEnableCourseConnBeforeBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Heu d&apos;habilitar les connexions del curs abans d&apos;editar els tipus de registre.</label>
+        <name>stgHelpEnableCourseConnBeforeRecordTypes</name>
+    </customLabels>
+    <customLabels>
+        <label>Les connexions del curs connecten un contacte amb una oferta de cursos. Si activeu aquesta casella de selecció, podeu triar crear la connexió per a un estudiant o professor (els dos tipus de registre predeterminats). Després de seleccionar aquesta casella de verificació, heu d&apos;establir el Tipus predeterminat de registre d&apos;estudiant actiu i el tipus predeterminat de registre de facultat. Si activeu aquesta funció per primera vegada, us recomanem que executeu el reenviament a la vostra organització.</label>
+        <name>stgHelpEnableCourseConnections</name>
+    </customLabels>
+    <customLabels>
+        <label>Per als contactes existents que no han especificat un correu electrònic preferit, la neteja assegura que una de les adreces de correu electrònic estàndard o personalitzada del contacte s&apos;estableixi com a correu electrònic preferit.</label>
+        <name>stgHelpEnsureExistContactPreferEmail</name>
+    </customLabels>
+    <customLabels>
+        <label>Si es marca, el marc de maneig d&apos;errors de HEDA està desactivat.</label>
+        <name>stgHelpErrorDisable</name>
+    </customLabels>
+    <customLabels>
+        <label>Marqueu això si voleu que el sistema publiqui notificacions per a determinats tipus d&apos;errors.</label>
+        <name>stgHelpErrorNotifyOn</name>
+    </customLabels>
+    <customLabels>
+        <label>Podeu enviar notificacions per correu electrònic a tots els administradors del sistema, a un sol usuari o a un grup de Chatter. Els valors vàlids són &quot;Tots els administradors del sistema&quot;, la identificació d&apos;un usuari a la vostra organització, o la identificació d&apos;un grup de Chatter. Només podeu introduir un valor.</label>
+        <name>stgHelpErrorNotifyTo</name>
+    </customLabels>
+    <customLabels>
+        <label>Utilitzeu el reenviament d&apos;ètnia i raça només si la vostra organització utilitzava el camp d&apos;Ètnia abans que HEDA afegís el camp de la raça i elimineu els valors del camp Ètnia a partir de la versió HEDA 1.28. Si el valor del camp d&apos;origen de contacte no és igual a &quot;No hispà ni llatí&quot; o &quot;hispà o llatí&quot;, el reenviament copia el valor al camp Raça. Els dos valors estàndard de la llista de selecció i els valors personalitzats que hàgiu afegit podran ser copiats.</label>
+        <name>stgHelpEthnicityRaceBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Activa la gestió d&apos;adreces de comptes administratius i de les llars quan es selecciona.</label>
+        <name>stgHelpHouseAdmAccountAddressMgmt</name>
+    </customLabels>
+    <customLabels>
+        <label>El tipus de registre del compte que millor representa les llars. HEDA utilitza el tipus de registre del compte de la llar de forma predeterminada, però podeu utilitzar un altre tipus de registre si ho desitgeu.</label>
+        <name>stgHelpHouseholdRecType</name>
+    </customLabels>
+    <customLabels>
+        <label>Si la vostra organització ha afegit prèviament valors de llista de selecció personalitzats al camp Ètnia que voleu que estigui disponible al camp Raça, copieu els valors de llista de selecció personalitzats al camp Raça.</label>
+        <name>stgHelpIfCustomValuesEthnicityCopyRace</name>
+    </customLabels>
+    <customLabels>
+        <label>Activa la gestió d&apos;adreces dels comptes d&apos;organització quan es selecciona.</label>
+        <name>stgHelpOrgAccountAddressMgmt</name>
+    </customLabels>
+    <customLabels>
+        <label>Les relacions creades automàticament es dedueixen automàticament per evitar que es creïn registres de relacions duplicats entre dos contactes. Marqueu aquesta casella per desactivar aquest comportament i permetre que es creïn diverses relacions del mateix tipus entre dos Contactes.</label>
+        <name>stgHelpRelAutoCreatedDup</name>
+    </customLabels>
+    <customLabels>
+        <label>Determina el mètode utilitzat per generar la relació recíproca. Configuració de la llista que utilitza la configuració personalitzada per sexe (vegeu la pestanya Relacions recíproques), o la inversió de valor, que inverteix el tipus, si escau (&quot;Principal-Derivat&quot; a &quot;Derivat-Principal&quot;)</label>
+        <name>stgHelpRelReciprocalMethod</name>
+    </customLabels>
+    <customLabels>
+        <label>Elimineu tots els valors de la llista de selecció del camp Ètnia, excepte &quot;Hispà o llatí&quot; i &quot;No hispà ni llatí&quot;. Recomanem que substituïu cada valor eliminat amb un dels valors vàlids restants, en comptes d&apos;eliminar-los directament dels registres existents. A partir de la versió HEDA 1.28, els únics valors ètnics vàlids són &quot;No hispà ni llatí&quot; i &quot;hispà o llatí&quot;.</label>
+        <name>stgHelpRemoveAllPicklistValuesEthnicityExceptHispanicOrLatino</name>
+    </customLabels>
+    <customLabels>
+        <label>Tracta els canvis en els camps d&apos;adreça de contacte o un únic compte com a actualitzacions de l&apos;adreça existent (és a dir, no es crea cap nou objecte d&apos;adreça). També provoca que l&apos;espai en blanc i els canvis de cas siguin tractats com a actualitzacions.</label>
+        <name>stgHelpSimpleAddrChangeIsUpdate</name>
+    </customLabels>
+    <customLabels>
+        <label>Marqueu això si voleu que s&apos;emmagatzemin els errors a la base de dades.</label>
+        <name>stgHelpStoreErrorsOn</name>
+    </customLabels>
+    <customLabels>
+        <label>Si teniu dependències que es basaven en els valors anteriors del camp Ètnia, com ara els informes, actualitzeu-los.</label>
+        <name>stgHelpUpdateReportIfDependenciesEthnicity</name>
+    </customLabels>
+    <customLabels>
+        <label>Nova assignació d&apos;afiliació</label>
+        <name>stgNewAfflMapping</name>
+    </customLabels>
+    <customLabels>
+        <label>Tots els administradors de sistemes</label>
+        <name>stgOptAllSysAdmins</name>
+    </customLabels>
+    <customLabels>
+        <label>Grup de Chatter</label>
+        <name>stgOptChatterGroup</name>
+    </customLabels>
+    <customLabels>
+        <label>Selecciona...</label>
+        <name>stgOptSelect</name>
+    </customLabels>
+    <customLabels>
+        <label>Usuari</label>
+        <name>stgOptUser</name>
+    </customLabels>
+    <customLabels>
+        <label>El treball Apex per lots ha processat {0} registres amb {1} errors.</label>
+        <name>stgPreferredEmailBatchEmailBody</name>
+    </customLabels>
+    <customLabels>
+        <label>Treball de correu electrònic preferit completat amb un estat de:</label>
+        <name>stgPreferredEmailBatchEmailSubject</name>
+    </customLabels>
+    <customLabels>
+        <label>Neteja de dades de correu electrònic preferit:</label>
+        <name>stgPreferredEmailDataCleanup</name>
+    </customLabels>
+    <customLabels>
+        <label>Executeu aquest procés de neteja de dades després d&apos;haver activat el requisit de correu electrònic preferit per primera vegada o després d&apos;un període de no compliment del requisit.</label>
+        <name>stgRunCleanUpEnableFirstTime</name>
+    </customLabels>
+    <customLabels>
+        <label>Seleccioneu el tipus de destinatari</label>
+        <name>stgSelectReciType</name>
+    </customLabels>
+    <customLabels>
+        <label>Envia notificacions d&apos;errors:</label>
+        <name>stgSendErrorsTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Canvi simple d&apos;adreça tractat com a actualització:</label>
+        <name>stgSimpleAddressChangeUpdate</name>
+    </customLabels>
+    <customLabels>
+        <label>Errors d&apos;emmagatzematge:</label>
+        <name>stgStoreErrorsTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Comptes i contactes</label>
+        <name>stgTabAccCont</name>
+    </customLabels>
+    <customLabels>
+        <label>Afiliacions</label>
+        <name>stgTabAffl</name>
+    </customLabels>
+    <customLabels>
+        <label>Assignacions d&apos;afiliació</label>
+        <name>stgTabAfflMappings</name>
+    </customLabels>
+    <customLabels>
+        <label>Creació automàtica</label>
+        <name>stgTabAutocreation</name>
+    </customLabels>
+    <customLabels>
+        <label>Reenviament</label>
+        <name>stgTabBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Cursos</label>
+        <name>stgTabCourse</name>
+    </customLabels>
+    <customLabels>
+        <label>Connexions del curs</label>
+        <name>stgTabCourseConn</name>
+    </customLabels>
+    <customLabels>
+        <label>Nom</label>
+        <name>stgTabName</name>
+    </customLabels>
+    <customLabels>
+        <label>Camp d&apos;afiliació primària</label>
+        <name>stgTabPrimaryAfflField</name>
+    </customLabels>
+    <customLabels>
+        <label>Configuració recíproca</label>
+        <name>stgTabReciprocalSettings</name>
+    </customLabels>
+    <customLabels>
+        <label>Relacions</label>
+        <name>stgTabRel</name>
+    </customLabels>
+    <customLabels>
+        <label>Configuració</label>
+        <name>stgTabSettings</name>
+    </customLabels>
+    <customLabels>
+        <label>Sistema</label>
+        <name>stgTabSystem</name>
+    </customLabels>
+    <customLabels>
+        <label>Permetre relacions duplicades creades automàticament:</label>
+        <name>stgTitleAllowAutocreatedDuplicateRel</name>
+    </customLabels>
+    <customLabels>
+        <label>Configuració a tota l&apos;aplicació</label>
+        <name>stgTitleAppwideSettings</name>
+    </customLabels>
+    <customLabels>
+        <label>Reenviament de connexió del curs:</label>
+        <name>stgTitleCourseConnectionBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Cursos: Migració de dades de descripció</label>
+        <name>stgTitleCoursesDescriptionDataMigration</name>
+    </customLabels>
+    <customLabels>
+        <label>Configuració</label>
+        <name>stgTitleHEDAConfig</name>
+    </customLabels>
+    <customLabels>
+        <label>Configuració de HEDA</label>
+        <name>stgTitleHEDASettings</name>
+    </customLabels>
+    <customLabels>
+        <label>Nova configuració de creació automàtica</label>
+        <name>stgTitleNewAutocreateSetting</name>
+    </customLabels>
+    <customLabels>
+        <label>Nova configuració recíproca</label>
+        <name>stgTitleNewReciSetting</name>
+    </customLabels>
+    <customLabels>
+        <label>Mètode recíproc:</label>
+        <name>stgTitleReciMethod</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- stgToastError --></label>
+        <name>stgToastError</name>
+    </customLabels>
+    <customTabs>
+        <label>Configuració de HEDA</label>
+        <name>HEDA_Settings</name>
+    </customTabs>
+</Translations>


### PR DESCRIPTION
# Critical Changes

# Changes
- We're excited to announce that we've added support for Catalan as a platform-only language. Support of platform-only languages is more limited than fully supported languages and end-user languages. Also keep in mind that labels and custom labels that were not translated with this release will be translated in a future release.

- Before using any HEDA translations, first enable Translation Workbench from Setup, in Translation Settings (for details, see [Enable and Disable the Translation Workbench](https://help.salesforce.com/articleView?id=customize_wbench.htm&type=5)). Then, to enable Catalan for HEDA, from Setup, in Language Settings, select **Enable platform-only languages**, move Catalan to the Displayed Languages list, and click **Save**. You can then change the language for your org or have users change their personal language settings. 

# Issues Closed

# New Metadata
Account-ca.objectTranslation
Address__c-ca.objectTranslation
Affiliation__c-ca.objectTranslation
Affl_Mappings__c-ca.objectTranslation
Contact-ca.objectTranslation
Course_Enrollment__c-ca.objectTranslation
Course_Offering__c-ca.objectTranslation
Course__c-ca.objectTranslation
Error__c-ca.objectTranslation
Hierarchy_Settings__c-ca.objectTranslation
Program_Enrollment__c-ca.objectTranslation
Relationship_Auto_Create__c-ca.objectTranslation
Relationship_Lookup__c-ca.objectTranslation
Relationship__c-ca.objectTranslation
Term__c-ca.objectTranslation
Trigger_Handler__c-ca.objectTranslation
ca.translation

# Deleted Metadata

# Testing Notes

1. Go to Setup -> Language Settings, click "Enable platform-only languages", then move Catalan over to "Displayed Languages" and Save
2. Click your profile image, then "Settings"
3. Select Language & Time Zone in the left menu
4. Update language to "Catala"