### PR TITLE
fix the primary contact on Account issue

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -128,10 +128,12 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                     }
 
                     // grab the Accounts that need to have the newly assigned Contact Id added to them if:
-                    //    1. If the contact is connected to an Account and the current primary contact of the account is empty
-                    if (c.AccountId != null && c.Account.Primary_Contact__c == null) {
+                    //    1. If the contact is connected to an Account
+                    if (c.AccountId != null) {
                         // contacts are connected to Accounts, make the connection in the other direction
-                        mapAccountIdContactId.put(c.AccountId, c.Id);
+                        if(c.Account.Primary_Contact__c == null) {
+                            mapAccountIdContactId.put(c.AccountId, c.Id);
+                        }
                         if (c.Account.RecordTypeId == UTIL_Describe.getHhAccRecTypeID()
                                 && UTIL_CustomSettingsFacade.getSettings().Automatic_Household_Naming__c != false)
                         {

--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -128,8 +128,8 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                     }
 
                     // grab the Accounts that need to have the newly assigned Contact Id added to them if:
-                    //    1. If the contact is connected to an Account
-                    if (c.AccountId != null) {
+                    //    1. If the contact is connected to an Account and the current primary contact of the account is empty
+                    if (c.AccountId != null && c.Account.Primary_Contact__c == null) {
                         // contacts are connected to Accounts, make the connection in the other direction
                         mapAccountIdContactId.put(c.AccountId, c.Id);
                         if (c.Account.RecordTypeId == UTIL_Describe.getHhAccRecTypeID()

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -651,7 +651,8 @@ private class ACCT_IndividualAccounts_TEST {
         update con2;
         Test.stopTest();
 
-        assertAccount = [SELECT Id, RecordType.Name, Name FROM Account];
+        //After remove the Account lookup for con2, system will create a new Account for con2. So, we need to query the Account of con in order to verify the Account Name.
+        assertAccount = [SELECT Id, RecordType.Name, Name FROM Account where Id =: assertAccount.Id];
         system.assertEquals('Household Account', assertAccount.RecordType.Name);
         system.assertEquals(con.FirstName + ' ' + con.LastName + ' Household', assertAccount.Name);
     }


### PR DESCRIPTION
# Critical Changes

# Changes
- If a new Contact is added to an Account that already has a Primary Contact, we no longer change the Primary Contact to the newly added Contact. The first Contact added to the Account remains the Primary Contact unless you explicitly change it to another Contact.
# Issues Closed
Fixes #544
# New Metadata

# Deleted Metadata

# Testing Notes
Steps to reproduce #544 : 

1. Change the Account Model to Household Account in HEDA Settings
2. Make sure the _SYSTEM: One2OneContact (Primary_Contact__c) field is on Account layout. 
3. Create an Contact. System should create a HH Account. And system will populate _SYSTEM: One2OneContact.
4. Add another Contact into the same Account that created in step 3. You will see the _SYSTEM: One2OneContact is updated to the new Contact just added.

The issue here is that the _SYSTEM: One2OneContact (Primary_Contact__c) should not be updated every time when a new Contact is added. It should be the first Contact on the Account. 
