### PR TITLE
fix the prefer email issue

### DIFF
--- a/src/classes/CON_Email.cls
+++ b/src/classes/CON_Email.cls
@@ -178,8 +178,19 @@ public class CON_Email {
             this.valuedFields = new List<CON_EmailField>();
             Map<String, Schema.DescribeFieldResult> fieldMap = UTIL_Describe.getFieldsOfType('Contact', 'EMAIL');
             this.emailLabel = fieldMap.get('Email').getLabel();
+
+            Map<String, String> hedaEmailField = new Map<String, String>();
+            //build map for HEDA email field map (Label, API Name)
             for(String fieldName : fieldMap.keySet() ) {
-                if ( fieldName != emailLabel ) {
+                if(String.isNotBlank(UTIL_Namespace.getNamespace()) && fieldName.startsWithIgnoreCase(UTIL_Namespace.getNamespace())) {
+                    hedaEmailField.put(fieldMap.get(fieldName).getLabel(), fieldName);
+                }
+            }
+
+            for(String fieldName : fieldMap.keySet() ) {
+                //If the field is not a standard email field and it is not duplicate with HEDA email, then add it to the list
+                if ( fieldName != emailLabel && !(hedaEmailField.get(fieldMap.get(fieldName).getLabel()) != null &&
+                                fieldName != hedaEmailField.get(fieldMap.get(fieldName).getLabel()))) {
                     String emailField = (String)contact.get(fieldName);
 
                     allFields.add( new CON_EmailField( emailField, fieldMap.get(fieldName).getLabel(), fieldName ) );


### PR DESCRIPTION
# Critical Changes

# Changes
- If you have email fields that use the same label as a HEDA email field, we now choose the HEDA version of the field for a Contact's Preferred Email address. For example, if a user chooses Work Email as the preferred email address and your org has multiple fields on the Contact object labeled Work Email, we use the value from the HEDA Work Email field.
# Issues Closed
Fixes #543
# New Metadata

# Deleted Metadata

# Testing Notes
Steps to reproduce #543 :

1. Org needs HEDA and NPSP installed.
2. When user try to set the prefer email as Work Email on a Contact and click Save, system will display an error "The prefer email can not be empty".
3. If you enter the HEDA Work Email field and click Save, you will still see the error.
4. If you enter NPSP Work Email field then the error will disappear.

The issue here is that the system is confused with HEDA Work Email field and NPSP Work Email field. The correct behavior is that system should display/not display error based on HEDA Work Email but not NPSP Work Email since the logic is in HEDA package.