### PR TITLE
Feature/xinnanli/trigger handler list index error

### DIFF
--- a/src/classes/TDTM_Filter.cls
+++ b/src/classes/TDTM_Filter.cls
@@ -491,10 +491,11 @@ public class TDTM_Filter {
     * @param filteredList The resulting filtered list.
     * @return void 
     */
-    private void filterList(List<SObject> listToFilter, List<SObject> filteredList) {
+    private void filterList(List<SObject> listToFilter, List<SObject> newList, List<SObject> filteredList) {
         if(listToFilter != null && listToFilter.size() > 0) {
-            for(SObject o : listToFilter) {
-                    filteredList.add(o);
+            for(integer i=0; i<listToFilter.size();i++) {
+                if(newList[i].get(fieldName) != filterValue) {
+                    filteredList.add(listToFilter[i]);
                 }
             }
         } 

--- a/src/classes/TDTM_Filter.cls
+++ b/src/classes/TDTM_Filter.cls
@@ -419,21 +419,21 @@ public class TDTM_Filter {
         }
         return null;
     }
-    
+
     /*******************************************************************************************************
     * @description Filters newList and oldList based on the defined filtering criteria. 
     * @param newListRelatedFields A list of records pointing to the same records that are present in newList, 
     * but containing only the fields defined in the query condition. In the same order as newList.
-    * @param oldListRelatedFields A list of records pointing to the same records that are present in oldList, 
-    * but containing only the fields defined in the query condition. In the same order as newList.
     * @return void 
     */
-    private void filterByCondition(List<SObject> newListRelatedFields, List<SObject> oldListRelatedFields) {
+    private void filterByCondition(List<SObject> newListRelatedFields) {
         if(filterObjectChain.size() == 0) { //The field in in the same object the trigger fires on
+            //Only need newList to decide if a record meets trigger handler filter value
             filterList(newList, newList, filtered.newList);
             filterList(oldList, newList, filtered.oldList);
         } else { //The field is in a related object
             filterListByRelatedField(newListRelatedFields, newList, filtered.newList);
+            //Only need newListRelatedFields to decide if a record meets trigger handler filter value
             filterListByRelatedField(newListRelatedFields, oldList, filtered.oldList);
         }
     }

--- a/src/classes/TDTM_Filter.cls
+++ b/src/classes/TDTM_Filter.cls
@@ -430,11 +430,11 @@ public class TDTM_Filter {
     */
     private void filterByCondition(List<SObject> newListRelatedFields, List<SObject> oldListRelatedFields) {
         if(filterObjectChain.size() == 0) { //The field in in the same object the trigger fires on
-	    	filterList(newList, filtered.newList);
-			filterList(oldList, filtered.oldList);	
+            filterList(newList, newList, filtered.newList);
+            filterList(oldList, newList, filtered.oldList);
         } else { //The field is in a related object
             filterListByRelatedField(newListRelatedFields, newList, filtered.newList);
-            filterListByRelatedField(oldListRelatedFields, oldList, filtered.oldList);
+            filterListByRelatedField(newListRelatedFields, oldList, filtered.oldList);
         }
     }
     
@@ -494,7 +494,6 @@ public class TDTM_Filter {
     private void filterList(List<SObject> listToFilter, List<SObject> filteredList) {
         if(listToFilter != null && listToFilter.size() > 0) {
             for(SObject o : listToFilter) {
-                if(o.get(fieldName) != filterValue) {
                     filteredList.add(o);
                 }
             }

--- a/src/classes/TDTM_Filter.cls
+++ b/src/classes/TDTM_Filter.cls
@@ -129,7 +129,6 @@ public class TDTM_Filter {
     */
     private void filterByRelationship() {        
         List<SObject> newListRelatedFields = queryRelatedFields(newList);
-        List<SObject> oldListRelatedFields = queryRelatedFields(oldList);
         
         List<String> filterFullChain = (filterField.split('\\.', 0)); //separate cross object references, i.e. account.name   
         fieldName = filterFullChain[filterFullChain.size() - 1]; //get the field name itself
@@ -151,7 +150,7 @@ public class TDTM_Filter {
         if(field != null) { //the field name is valid for the object at the top of the chain!
             filterValue = getFilter(field);
             UTIL_Debug.debug('****Filter value: ' + filterValue);
-            filterByCondition(newListRelatedFields, oldListRelatedFields);
+            filterByCondition(newListRelatedFields);
         } else {
             addErrorToAll();
         }       
@@ -388,7 +387,7 @@ public class TDTM_Filter {
         if(field != null) { //the field name is valid!
             filterValue = getFilter(field);
             UTIL_Debug.debug('****Filter value: ' + filterValue);
-            filterByCondition(null, null);
+            filterByCondition(null);
         } else {
             addErrorToAll();
         }
@@ -488,6 +487,7 @@ public class TDTM_Filter {
     * @description Populates filteredList with the records from listToFilter that don't match the filtering
     * criteria.
     * @param listToFilter The list of records to filter.
+    * @param newList The list of new records to compare with filter value.
     * @param filteredList The resulting filtered list.
     * @return void 
     */


### PR DESCRIPTION
# Critical Changes

# Changes
- We fixed an error that occurred when changing the value of a field referenced by Filter Field and Filter Value. Previously, for example, if you had referenced the Contact Title field and the value "CEO" (in Filter Field and Filter Value respectively), an error prevented you from changing "CEO" in the Title field to a different value.
# Issues Closed
Fixes #538
# New Metadata

# Deleted Metadata

# Testing Notes
1. Update the Trigger Handler that manages the CON_DoNotContact_TDTM class with these two values: Filter Field = Citizenship__c
Filter Value = Aruba
2. Create a Contact and set the Citizenship field to Aruba and Save.
3. Try to change the Citizenship field to any other value. Error is thrown.