### PR TITLE
Fixed currency/number not working in filters of trigger handlers

### DIFF
--- a/src/classes/TDTM_Filter.cls
+++ b/src/classes/TDTM_Filter.cls
@@ -414,12 +414,20 @@ public class TDTM_Filter {
             return Date.parse(val);
         } else if(fieldType == DisplayType.Reference) {
             return ID.valueOf(val);
+        } else if(fieldType == DisplayType.CURRENCY) {
+            return Decimal.valueOf(val);
+        } else if(fieldType == DisplayType.INTEGER) {
+            return Integer.valueOf(val);
+        } else if(fieldType == DisplayType.DOUBLE) {
+            return Double.valueOf(val);
+        } else if(fieldType == DisplayType.PERCENT) {
+            return Decimal.valueOf(val);
         } else { //We'll treat everything else as a string, including String, Email, Phone, and Picklist
             return val;
         }
         return null;
     }
-    
+
     /*******************************************************************************************************
     * @description Filters newList and oldList based on the defined filtering criteria. 
     * @param newListRelatedFields A list of records pointing to the same records that are present in newList, 

--- a/src/classes/TDTM_Filter_TEST.cls
+++ b/src/classes/TDTM_Filter_TEST.cls
@@ -638,4 +638,81 @@ public with sharing class TDTM_Filter_TEST {
         Relationship__c[] rels = [select Contact__c, RelatedContact__c from Relationship__c];
         System.assertEquals(2, rels.size());     
     }
+
+    /*********************************************************************************************************
+    * @description Update a contact to meet currency trigger handler filter. Make sure trigger does not run.
+    */
+    @isTest
+    public static void filterCurrencyField() {
+        List<TDTM_Global_API.TdtmToken> tokens = setup();
+        //Creating filter condition.
+        for(TDTM_Global_API.TdtmToken token : tokens) {
+            if(token.className == 'CON_DoNotContact_TDTM') {
+                token.filterField = 'Account.AnnualRevenue';
+                token.filterValue = '25';
+            }
+        }
+        TDTM_Global_API.setTdtmConfig(tokens);
+
+        Contact testContact = UTIL_UnitTestData_TEST.getContact();
+        insert testContact;
+
+        //Use account because contact has no corrency/number field
+        Account testAccount = [SELECT Id FROM Account LIMIT 1];
+        testAccount.AnnualRevenue = 25;
+        update testAccount;
+
+        Test.startTest();
+        testContact.Deceased__c = true;
+        update testContact;
+        Test.stopTest();
+
+
+        Contact assertContact = [SELECT Id,
+                                        Exclude_from_Household_Name__c,
+                                        Do_Not_Contact__c
+                                FROM Contact WHERE Id = :testContact.Id];
+        system.assertEquals(false, assertContact.Exclude_from_Household_Name__c);
+        system.assertEquals(false, testContact.Do_Not_Contact__c);
+
+    }
+
+    /*********************************************************************************************************
+    * @description Update a contact to meet number trigger handler filter. Make sure trigger does not run.
+    */
+    @isTest
+    public static void filterNumberField() {
+        List<TDTM_Global_API.TdtmToken> tokens = setup();
+        //Creating filter condition.
+        for(TDTM_Global_API.TdtmToken token : tokens) {
+            if(token.className == 'CON_DoNotContact_TDTM') {
+                token.filterField = 'Account.NumberOfEmployees';
+                token.filterValue = '25';
+            }
+        }
+        TDTM_Global_API.setTdtmConfig(tokens);
+
+        Contact testContact = UTIL_UnitTestData_TEST.getContact();
+        insert testContact;
+
+        //Use account because contact has no corrency/number field
+        Account testAccount = [SELECT Id FROM Account LIMIT 1];
+        testAccount.NumberOfEmployees = 25;
+        update testAccount;
+
+        Test.startTest();
+        testContact.Deceased__c = true;
+        update testContact;
+        Test.stopTest();
+
+
+        Contact assertContact = [SELECT Id,
+                Exclude_from_Household_Name__c,
+                Do_Not_Contact__c
+        FROM Contact WHERE Id = :testContact.Id];
+        system.assertEquals(false, assertContact.Exclude_from_Household_Name__c);
+        system.assertEquals(false, testContact.Do_Not_Contact__c);
+
+    }
+
 }


### PR DESCRIPTION
# Critical Changes

# Changes
- Added support for currency, integer, double, and percent fields in the trigger handler Filter Field.

# Issues Closed
Fixes #539
# New Metadata

# Deleted Metadata

# Testing Notes
1. Create custom field on Contact such as Household Income (Currency 18,0)
2. Set the Filter Field on a Contact-related Trigger Handler (such as CON_DoNotContact_TDTM) to Household_Income__c
3. Set the Filter Value to 50000
4. Create or update a Contact with 50000 in the Household Income field
5. Check Deceased and Save
6. Notice that the trigger runs even though there is a filter