### PR TITLE
Feature/lparrott/gdpr email log

### DIFF
--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -96,7 +96,7 @@ public without sharing class UTIL_CustomSettingsFacade {
 		hs.Household_Addresses_RecType__c = UTIL_Describe.getHhAccRecTypeID();
 		hs.Reciprocal_Method__c = 'List Setting';
         hs.Store_Errors_On__c = true;
-        hs.Error_Notifications_On__c = true;
+        hs.Error_Notifications_On__c = false;
         hs.Error_Notifications_To__c = ERR_Notifier.NotificationOptions.sysAdmins;
         hs.Disable_Error_Handling__c = false;
         hs.Enable_Debug__c = false;

--- a/src/classes/UTIL_CustomSettingsFacade_TEST.cls
+++ b/src/classes/UTIL_CustomSettingsFacade_TEST.cls
@@ -84,4 +84,11 @@ public with sharing class UTIL_CustomSettingsFacade_TEST {
 
         System.assertEquals(1, settings.size());
     }
+
+    @isTest
+    public static void getOrgSettings() {
+        Hierarchy_Settings__c hs = UTIL_CustomSettingsFacade.getOrgSettings();
+
+        System.assertEquals(false, hs.Error_Notifications_On__c);
+    }
 }


### PR DESCRIPTION
# Critical Changes

# Changes

- To help you comply with various data protection and privacy regulations, the Send Error Notifications setting in HEDA Settings is now disabled by default.

# Issues Closed

Fixes #567 

# New Metadata

# Deleted Metadata

# Testing Notes

Steps to reproduce #567 :

1. Install the HEDA package to a new org with this change included.
2. From the HEDA App, navigate to the HEDA Settings tab, then to the "System" sub tab of that page.
3. The “Send Error Notifications” should be unchecked.


