### PR TITLE
Fixed bug: primary contact changed if a new contact connected to this…

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -324,19 +324,22 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                                     FROM Account
                                     WHERE Id in :listAccountId];
         for (Account acc : listAccount) {
-            setPrimaryContactIds.add(acc.Primary_Contact__c);
+            if (acc.Primary_Contact__c != null)
+                setPrimaryContactIds.add(acc.Primary_Contact__c);
         }
 
         if (setPrimaryContactIds.size() > 0) {
-            for (Account acc : [SELECT id,
-                                    (SELECT id
-                                    FROM Contacts
-                                    WHERE id in :setPrimaryContactIds
-                                    LIMIT 1)
+            for (Account acc : [SELECT Primary_Contact__c,
+                                        (SELECT id
+                                        FROM Contacts
+                                        WHERE id in :setPrimaryContactIds
+                                        LIMIT 1)
                                 FROM Account
-                                WHERE id in : listAccountId]){
-                //An account need to be reset if it can not find a child contact who is primary contact
-                if (acc.Contacts.size() == 0) {
+                                WHERE id in : listAccountId]) {
+                //There are two cases account primary contact needs reset
+                //1. An account has no child contact but it used to have primary contact
+                //2. An account used to have no child contact but a contact was just assigned to it
+                if (acc.Contacts.size() == 0 || acc.Primary_Contact__c == null) {
                     setAccToResetIds.add(acc.Id);
                 }
             }
@@ -350,10 +353,15 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         }
 
         //for each account need to be reset
-        //query one child contact and use it as primary contact
         for (Account acc : listAccount) {
-            if (acc.Contacts.size() > 0) {
-                acc.Primary_Contact__c = acc.contacts[0].Id;
+            if (setAccToResetIds.contains(acc.Id)) {
+                if (acc.Contacts.size() > 0) {
+                    //if any child contact exists, use one as primary contact
+                    acc.Primary_Contact__c = acc.contacts[0].Id;
+                } else {
+                    //if no child contact exists, clear up primary contact
+                    acc.Primary_Contact__c = null;
+                }
                 listAccToUpdate.add(acc);
             }
         }

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -695,4 +695,86 @@ private class ACCT_IndividualAccounts_TEST {
         system.assertEquals('Household Account', assertAccount.RecordType.Name);
         system.assertEquals('Household', assertAccount.Name);
     }
+
+/*********************************************************************************************************
+* @description
+* Remove primary contact from household account
+* Make sure the primary contact of household account is cleared up
+*/
+    @isTest
+    public static void hhAccountNoChildContactResetPrimaryContact() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe.getHhAccRecTypeID()));
+
+        Contact con = UTIL_UnitTestData_TEST.getContact();
+        insert con;
+
+        Test.startTest();
+        con.AccountId = null;
+        update con;
+        Test.stopTest();
+
+        Account assertAccount = [Select Primary_Contact__c FROM Account LIMIT 1];
+        system.assertEquals(null, assertAccount.Primary_Contact__c);
+    }
+
+/*********************************************************************************************************
+* @description
+* Add a contact to a household account
+* Make sure the primary contact of household account is not changed
+*/
+    @isTest
+    public static void hhAccountNewChildContactNotResetPrimaryContact() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe.getHhAccRecTypeID()));
+
+        Contact con = UTIL_UnitTestData_TEST.getContact();
+        insert con;
+
+        Account acc = [SELECT Id FROM Account LIMIT 1];
+
+        Contact con2 = UTIL_UnitTestData_TEST.getContact();
+        insert con2;
+
+        Test.startTest();
+        con2.AccountId = acc.Id;
+        update con2;
+        Test.stopTest();
+
+        Account assertAccount = [Select Primary_Contact__c FROM Account WHERE Id = :acc.Id LIMIT 1];
+        system.assertEquals(con.Id, assertAccount.Primary_Contact__c);
+        system.assertNotEquals(con2.Id, assertAccount.Primary_Contact__c);
+
+    }
+
+/*********************************************************************************************************
+* @description
+* Switch contacts between two household accounts
+* Make sure primary contacts are updated correctly
+*/
+    @isTest
+    public static void hhAccountSwitchChildContactResetPrimaryContact() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe.getHhAccRecTypeID()));
+
+        Contact con = UTIL_UnitTestData_TEST.getContact();
+        insert con;
+
+        Account acc = [SELECT Id FROM Account LIMIT 1];
+
+        Contact con2 = UTIL_UnitTestData_TEST.getContact();
+        insert con2;
+
+        Account acc2 = [SELECT Id FROM Account where Id != :acc.Id LIMIT 1];
+
+        Test.startTest();
+        con2.AccountId = acc.Id;
+        update con2;
+        con.AccountId = acc2.Id;
+        update con;
+        Test.stopTest();
+
+        Account assertAccount = [Select Primary_Contact__c FROM Account WHERE Id = :acc.Id LIMIT 1];
+        Account assertAccount2 = [Select Primary_Contact__c FROM Account WHERE Id = :acc2.Id LIMIT 1];
+        system.assertEquals(con2.Id, assertAccount.Primary_Contact__c);
+        system.assertEquals(con.Id, assertAccount2.Primary_Contact__c);
+
+    }
 }


### PR DESCRIPTION

# Critical Changes

# Changes
- Primary Contact on a Household Account does not change when a user adds a new Contact to the Household. If you want to change Primary Contact, simply update the field to the Contact you want.

# Issues Closed
Fixes #562

# New Metadata

# Deleted Metadata

# Testing Notes
1. Create a contact. It will automatically be the primary contact for this household. 
2. (not sure this step is necessary) Un-associate the contact as the primary contact (make it blank) for that household. Then re-associate the contact as the primary contact. 
3. Go back to Contacts and create a brand new contact to be auto-assigned a new household account. This contact will be the primary contact for this household. 
4. Move the contact created in step 1/2 to the household created in step 3 . 