### PR TITLE
Enable French for HEDA

### DIFF
--- a/src/objectTranslations/Account-fr.objectTranslation
+++ b/src/objectTranslations/Account-fr.objectTranslation
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <help>L’adresse actuellement renseignée dans les champs de facturation du compte.</help>
+        <label>Adresse actuelle</label>
+        <name>Current_Address__c</name>
+        <relationshipLabel>Comptes (adresse actuelle)</relationshipLabel>
+    </fields>
+    <fields>
+        <label><!-- _SYSTEM: One2OneContact --></label>
+        <name>Primary_Contact__c</name>
+        <relationshipLabel>Compte</relationshipLabel>
+    </fields>
+    <layouts>
+        <layout>HEDA Household Layout</layout>
+        <sections>
+            <label>Adresse</label>
+            <section>Address</section>
+        </sections>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+        <sections>
+            <label><!-- Description --></label>
+            <section>Description</section>
+        </sections>
+        <sections>
+            <label>Champs</label>
+            <section>Fields</section>
+        </sections>
+    </layouts>
+    <layouts>
+        <layout>HEDA Organization Layout</layout>
+        <sections>
+            <label>Adresse</label>
+            <section>Address</section>
+        </sections>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+        <sections>
+            <label><!-- Description --></label>
+            <section>Description</section>
+        </sections>
+        <sections>
+            <label>Champs</label>
+            <section>Fields</section>
+        </sections>
+    </layouts>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Address__c-fr.objectTranslation
+++ b/src/objectTranslations/Address__c-fr.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Address --></value>
+        <value>Adresse</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Address --></value>
+        <value>Adresses</value>
     </caseValues>
     <fields>
         <label>Type d’adresse</label>
@@ -466,7 +466,7 @@
         <label>Année de début de saison</label>
         <name>Seasonal_Start_Year__c</name>
     </fields>
-    <gender><!-- Masculine --></gender>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Address Layout</layout>
         <sections>
@@ -475,5 +475,5 @@
         </sections>
     </layouts>
     <nameFieldLabel><!-- Address ID --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <startsWith>Vowel</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Address__c-fr.objectTranslation
+++ b/src/objectTranslations/Address__c-fr.objectTranslation
@@ -1,0 +1,479 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Address --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Address --></value>
+    </caseValues>
+    <fields>
+        <label>Type d’adresse</label>
+        <name>Address_Type__c</name>
+        <picklistValues>
+            <masterLabel>Home</masterLabel>
+            <translation>Domicile</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Other</masterLabel>
+            <translation>Autre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Vacation Residence</masterLabel>
+            <translation>Résidence de vacances</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation>Professionnel</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Cette adresse est-elle l’adresse par défaut à utiliser pour le foyer et ses contacts ?</help>
+        <label>Adresse par défaut</label>
+        <name>Default_Address__c</name>
+    </fields>
+    <fields>
+        <label>Adresse postale</label>
+        <name>Formula_MailingAddress__c</name>
+    </fields>
+    <fields>
+        <label>Rue (courrier)</label>
+        <name>Formula_MailingStreetAddress__c</name>
+    </fields>
+    <fields>
+        <help>Latitude et longitude exprimées du lieu.</help>
+        <label>Géolocalisation</label>
+        <name>Geolocation__c</name>
+    </fields>
+    <fields>
+        <help>La date de fin la plus récente à laquelle cette adresse a été utilisée pour ce foyer.</help>
+        <label>Dernière date de fin</label>
+        <name>Latest_End_Date__c</name>
+    </fields>
+    <fields>
+        <help>La date de début la plus récente à laquelle cette adresse a été utilisée pour ce foyer.</help>
+        <label>Dernière date de début</label>
+        <name>Latest_Start_Date__c</name>
+    </fields>
+    <fields>
+        <label>Ville (courrier)</label>
+        <name>MailingCity__c</name>
+    </fields>
+    <fields>
+        <label>Pays (courrier)</label>
+        <name>MailingCountry__c</name>
+    </fields>
+    <fields>
+        <label>Code postal (courrier)</label>
+        <name>MailingPostalCode__c</name>
+    </fields>
+    <fields>
+        <label>Région/Province (courrier)</label>
+        <name>MailingState__c</name>
+    </fields>
+    <fields>
+        <label>Rue 2 (courrier)</label>
+        <name>MailingStreet2__c</name>
+    </fields>
+    <fields>
+        <label>Rue (courrier)</label>
+        <name>MailingStreet__c</name>
+    </fields>
+    <fields>
+        <help>Le compte auquel cette adresse correspond.</help>
+        <label>Compte parent</label>
+        <name>Parent_Account__c</name>
+        <relationshipLabel>Adresses</relationshipLabel>
+    </fields>
+    <fields>
+        <help>Le contact auquel cette adresse correspond.</help>
+        <label>Contact parent</label>
+        <name>Parent_Contact__c</name>
+        <relationshipLabel>Adresses</relationshipLabel>
+    </fields>
+    <fields>
+        <help>Le jour du mois à partir duquel cette adresse ne remplace plus l’adresse par défaut.</help>
+        <label>Jour de fin de saison</label>
+        <name>Seasonal_End_Day__c</name>
+        <picklistValues>
+            <masterLabel>1</masterLabel>
+            <translation><!-- 1 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>10</masterLabel>
+            <translation><!-- 10 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>11</masterLabel>
+            <translation><!-- 11 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>12</masterLabel>
+            <translation><!-- 12 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>13</masterLabel>
+            <translation><!-- 13 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>14</masterLabel>
+            <translation><!-- 14 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>15</masterLabel>
+            <translation><!-- 15 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>16</masterLabel>
+            <translation><!-- 16 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>17</masterLabel>
+            <translation><!-- 17 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>18</masterLabel>
+            <translation><!-- 18 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>19</masterLabel>
+            <translation><!-- 19 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>2</masterLabel>
+            <translation><!-- 2 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>20</masterLabel>
+            <translation><!-- 20 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>21</masterLabel>
+            <translation><!-- 21 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>22</masterLabel>
+            <translation><!-- 22 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>23</masterLabel>
+            <translation><!-- 23 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>24</masterLabel>
+            <translation><!-- 24 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>25</masterLabel>
+            <translation><!-- 25 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>26</masterLabel>
+            <translation><!-- 26 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>27</masterLabel>
+            <translation><!-- 27 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>28</masterLabel>
+            <translation><!-- 28 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>29</masterLabel>
+            <translation><!-- 29 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>3</masterLabel>
+            <translation><!-- 3 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>30</masterLabel>
+            <translation><!-- 30 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>31</masterLabel>
+            <translation><!-- 31 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>4</masterLabel>
+            <translation><!-- 4 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>5</masterLabel>
+            <translation><!-- 5 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>6</masterLabel>
+            <translation><!-- 6 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>7</masterLabel>
+            <translation><!-- 7 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>8</masterLabel>
+            <translation><!-- 8 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>9</masterLabel>
+            <translation><!-- 9 --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Le mois de l’année à partir duquel cette adresse ne remplace plus l’adresse par défaut.</help>
+        <label>Mois de fin de saison</label>
+        <name>Seasonal_End_Month__c</name>
+        <picklistValues>
+            <masterLabel>1</masterLabel>
+            <translation><!-- 1 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>10</masterLabel>
+            <translation><!-- 10 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>11</masterLabel>
+            <translation><!-- 11 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>12</masterLabel>
+            <translation><!-- 12 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>2</masterLabel>
+            <translation><!-- 2 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>3</masterLabel>
+            <translation><!-- 3 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>4</masterLabel>
+            <translation><!-- 4 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>5</masterLabel>
+            <translation><!-- 5 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>6</masterLabel>
+            <translation><!-- 6 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>7</masterLabel>
+            <translation><!-- 7 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>8</masterLabel>
+            <translation><!-- 8 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>9</masterLabel>
+            <translation><!-- 9 --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>L’année à partir de laquelle cette adresse ne remplace plus l’adresse par défaut.</help>
+        <label>Année de fin de saison</label>
+        <name>Seasonal_End_Year__c</name>
+    </fields>
+    <fields>
+        <help>Le jour du mois à partir duquel cette adresse remplace l’adresse par défaut.</help>
+        <label>Jour de début de saison</label>
+        <name>Seasonal_Start_Day__c</name>
+        <picklistValues>
+            <masterLabel>1</masterLabel>
+            <translation><!-- 1 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>10</masterLabel>
+            <translation><!-- 10 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>11</masterLabel>
+            <translation><!-- 11 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>12</masterLabel>
+            <translation><!-- 12 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>13</masterLabel>
+            <translation><!-- 13 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>14</masterLabel>
+            <translation><!-- 14 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>15</masterLabel>
+            <translation><!-- 15 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>16</masterLabel>
+            <translation><!-- 16 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>17</masterLabel>
+            <translation><!-- 17 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>18</masterLabel>
+            <translation><!-- 18 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>19</masterLabel>
+            <translation><!-- 19 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>2</masterLabel>
+            <translation><!-- 2 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>20</masterLabel>
+            <translation><!-- 20 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>21</masterLabel>
+            <translation><!-- 21 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>22</masterLabel>
+            <translation><!-- 22 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>23</masterLabel>
+            <translation><!-- 23 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>24</masterLabel>
+            <translation><!-- 24 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>25</masterLabel>
+            <translation><!-- 25 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>26</masterLabel>
+            <translation><!-- 26 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>27</masterLabel>
+            <translation><!-- 27 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>28</masterLabel>
+            <translation><!-- 28 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>29</masterLabel>
+            <translation><!-- 29 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>3</masterLabel>
+            <translation><!-- 3 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>30</masterLabel>
+            <translation><!-- 30 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>31</masterLabel>
+            <translation><!-- 31 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>4</masterLabel>
+            <translation><!-- 4 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>5</masterLabel>
+            <translation><!-- 5 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>6</masterLabel>
+            <translation><!-- 6 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>7</masterLabel>
+            <translation><!-- 7 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>8</masterLabel>
+            <translation><!-- 8 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>9</masterLabel>
+            <translation><!-- 9 --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Le mois de l’année à partir duquel cette adresse remplace l’adresse par défaut.</help>
+        <label>Mois de début de saison</label>
+        <name>Seasonal_Start_Month__c</name>
+        <picklistValues>
+            <masterLabel>1</masterLabel>
+            <translation><!-- 1 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>10</masterLabel>
+            <translation><!-- 10 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>11</masterLabel>
+            <translation><!-- 11 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>12</masterLabel>
+            <translation><!-- 12 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>2</masterLabel>
+            <translation><!-- 2 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>3</masterLabel>
+            <translation><!-- 3 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>4</masterLabel>
+            <translation><!-- 4 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>5</masterLabel>
+            <translation><!-- 5 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>6</masterLabel>
+            <translation><!-- 6 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>7</masterLabel>
+            <translation><!-- 7 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>8</masterLabel>
+            <translation><!-- 8 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>9</masterLabel>
+            <translation><!-- 9 --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>L’année à partir de laquelle cette adresse remplace l’adresse par défaut.</help>
+        <label>Année de début de saison</label>
+        <name>Seasonal_Start_Year__c</name>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <layouts>
+        <layout>HEDA Address Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Address ID --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Affiliation__c-fr.objectTranslation
+++ b/src/objectTranslations/Affiliation__c-fr.objectTranslation
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Affiliation --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Affiliation --></value>
+    </caseValues>
+    <fields>
+        <label>Organisation</label>
+        <name>Account__c</name>
+        <relationshipLabel>Contacts affiliés</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Type d&apos;affiliation</label>
+        <name>Affiliation_Type__c</name>
+    </fields>
+    <fields>
+        <label><!-- Contact --></label>
+        <name>Contact__c</name>
+        <relationshipLabel>Comptes affiliés</relationshipLabel>
+    </fields>
+    <fields>
+        <label><!-- Description --></label>
+        <name>Description__c</name>
+    </fields>
+    <fields>
+        <label>Date de fin</label>
+        <name>EndDate__c</name>
+    </fields>
+    <fields>
+        <help>Si cette case est cochée, l’organisation de l’affiliation est stockée dans l’enregistrement du contact.</help>
+        <label>Principal</label>
+        <name>Primary__c</name>
+    </fields>
+    <fields>
+        <label>Rôle</label>
+        <name>Role__c</name>
+        <picklistValues>
+            <masterLabel>Applicant</masterLabel>
+            <translation>Candidat</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Employee</masterLabel>
+            <translation>Employé</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Faculty</masterLabel>
+            <translation>Professeur</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Prospect</masterLabel>
+            <translation><!-- Prospect --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Student</masterLabel>
+            <translation>Étudiant</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>Date de début</label>
+        <name>StartDate__c</name>
+    </fields>
+    <fields>
+        <label>Statut</label>
+        <name>Status__c</name>
+        <picklistValues>
+            <masterLabel>Current</masterLabel>
+            <translation>Actuel</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Former</masterLabel>
+            <translation>Ancien</translation>
+        </picklistValues>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <layouts>
+        <layout>HEDA Affiliation Layout</layout>
+        <sections>
+            <label>Informations sur l&apos;affiliation</label>
+            <section>Affiliation Information</section>
+        </sections>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Affiliation Key --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Affiliation__c-fr.objectTranslation
+++ b/src/objectTranslations/Affiliation__c-fr.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Affiliation --></value>
+        <value>Affiliation</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Affiliation --></value>
+        <value>Affiliations</value>
     </caseValues>
     <fields>
         <label>Organisation</label>
@@ -75,7 +75,7 @@
             <translation>Ancien</translation>
         </picklistValues>
     </fields>
-    <gender><!-- Masculine --></gender>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Affiliation Layout</layout>
         <sections>
@@ -88,5 +88,5 @@
         </sections>
     </layouts>
     <nameFieldLabel><!-- Affiliation Key --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <startsWith>Vowel</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Affl_Mappings__c-fr.objectTranslation
+++ b/src/objectTranslations/Affl_Mappings__c-fr.objectTranslation
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Affl Mappings --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Affl Mappings --></value>
+    </caseValues>
+    <fields>
+        <help>L&apos;étiquette du type d&apos;enregistrement de compte.</help>
+        <label>Type d&apos;enregistrement de compte</label>
+        <name>Account_Record_Type__c</name>
+    </fields>
+    <fields>
+        <label>Rôle d&apos;inscription automatique</label>
+        <name>Auto_Program_Enrollment_Role__c</name>
+    </fields>
+    <fields>
+        <label>Statut d&apos;inscription automatique</label>
+        <name>Auto_Program_Enrollment_Status__c</name>
+    </fields>
+    <fields>
+        <help>Si cette case est cochée, un enregistrement Inscription au programme est automatiquement créé lorsque l&apos;utilisateur crée une affiliation avec un compte de ce type.</help>
+        <label>Inscription automatique</label>
+        <name>Auto_Program_Enrollment__c</name>
+    </fields>
+    <fields>
+        <help>L&apos;étiquette du champ de référence du contact qui pointe vers le compte principal du type d&apos;enregistrement spécifié.</help>
+        <label>Champ d&apos;affiliation principal</label>
+        <name>Primary_Affl_Field__c</name>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Contact-fr.objectTranslation
+++ b/src/objectTranslations/Contact-fr.objectTranslation
@@ -1,0 +1,3655 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <help>L’e-mail alternatif est un quatrième e-mail facultatif, en plus de l&apos;e-mail personnel, préféré ou professionnel.</help>
+        <label>E-mail alternatif</label>
+        <name>AlternateEmail__c</name>
+    </fields>
+    <fields>
+        <label>Citoyenneté</label>
+        <name>Citizenship__c</name>
+        <picklistValues>
+            <masterLabel>Afghanistan</masterLabel>
+            <translation><!-- Afghanistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Albania</masterLabel>
+            <translation>Albanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Algeria</masterLabel>
+            <translation>Algérie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>American Samoa</masterLabel>
+            <translation>Samoa américaines</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Andorra</masterLabel>
+            <translation>Andorre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Angola</masterLabel>
+            <translation><!-- Angola --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Anguilla</masterLabel>
+            <translation><!-- Anguilla --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Antarctica</masterLabel>
+            <translation>Antarctique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Antigua and Barbuda</masterLabel>
+            <translation>Antigua et Barbuda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Argentina</masterLabel>
+            <translation>Argentine</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Armenia</masterLabel>
+            <translation>Arménie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Aruba</masterLabel>
+            <translation><!-- Aruba --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Australia</masterLabel>
+            <translation>Australie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Austria</masterLabel>
+            <translation>Autriche</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Azerbaijan</masterLabel>
+            <translation>Azerbaïdjan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bahamas (the)</masterLabel>
+            <translation>Bahamas (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bahrain</masterLabel>
+            <translation>Bahreïn</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bangladesh</masterLabel>
+            <translation><!-- Bangladesh --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Barbados</masterLabel>
+            <translation>Barbade</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belarus</masterLabel>
+            <translation>Biélorussie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belgium</masterLabel>
+            <translation>Belgique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belize</masterLabel>
+            <translation><!-- Belize --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Benin</masterLabel>
+            <translation>Bénin</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bermuda</masterLabel>
+            <translation>Bermudes</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bhutan</masterLabel>
+            <translation>Bhoutan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bolivia (Plurinational State of)</masterLabel>
+            <translation>Bolivie (État plurinational de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bonaire, Sint Eustatius and Saba</masterLabel>
+            <translation>Bonaire, Saint-Eustache et Saba</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bosnia and Herzegovina</masterLabel>
+            <translation>Bosnie-Herzégovine</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Botswana</masterLabel>
+            <translation><!-- Botswana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bouvet Island</masterLabel>
+            <translation>Île Bouvet</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Brazil</masterLabel>
+            <translation>Brésil</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>British Antarctic Territory</masterLabel>
+            <translation>Territoire antarctique britannique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>British Indian Ocean Territory (the)</masterLabel>
+            <translation>Territoire britannique de l&apos;océan Indien (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Brunei Darussalam</masterLabel>
+            <translation>Brunéi Darussalam</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bulgaria</masterLabel>
+            <translation>Bulgarie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burkina Faso</masterLabel>
+            <translation><!-- Burkina Faso --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burma</masterLabel>
+            <translation>Birmanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burundi</masterLabel>
+            <translation><!-- Burundi --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Byelorussian SSR</masterLabel>
+            <translation>RSS de Biélorussie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cabo Verde</masterLabel>
+            <translation>Cap-Vert</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cambodia</masterLabel>
+            <translation>Cambodge</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cameroon</masterLabel>
+            <translation>Cameroun</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Canada</masterLabel>
+            <translation><!-- Canada --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Canton and Enderbury Islands</masterLabel>
+            <translation>Îles Canton et Enderbury</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cayman Islands (the)</masterLabel>
+            <translation>Îles Caïman (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Central African Republic (the)</masterLabel>
+            <translation>République centrafricaine (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Chad</masterLabel>
+            <translation>Tchad</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Chile</masterLabel>
+            <translation>Chili</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>China</masterLabel>
+            <translation>Chine</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Christmas Island</masterLabel>
+            <translation>Île Christmas</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cocos (Keeling) Islands (the)</masterLabel>
+            <translation>Îles Cocos (Keeling) (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Colombia</masterLabel>
+            <translation>Colombie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Comoros (the)</masterLabel>
+            <translation>Comores (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Congo (the Democratic Republic of the)</masterLabel>
+            <translation>Congo (La république démocratique du)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Congo (the)</masterLabel>
+            <translation>Congo (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cook Islands (the)</masterLabel>
+            <translation>Îles Cook (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Costa Rica</masterLabel>
+            <translation><!-- Costa Rica --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Croatia</masterLabel>
+            <translation>Croatie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cuba</masterLabel>
+            <translation><!-- Cuba --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Curaçao</masterLabel>
+            <translation><!-- Curaçao --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cyprus</masterLabel>
+            <translation>Chypre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Czech Republic (the)</masterLabel>
+            <translation>République tchèque (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Czechoslovakia</masterLabel>
+            <translation>Tchécoslovaquie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Côte d&apos;Ivoire</masterLabel>
+            <translation><!-- Côte d&apos;Ivoire --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dahomey</masterLabel>
+            <translation><!-- Dahomey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Denmark</masterLabel>
+            <translation>Danemark</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Djibouti</masterLabel>
+            <translation><!-- Djibouti --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dominica</masterLabel>
+            <translation>Dominique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dominican Republic (the)</masterLabel>
+            <translation>République dominicaine (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dronning Maud Land</masterLabel>
+            <translation>Terre de la Reine-Maud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>East Timor</masterLabel>
+            <translation>Timor oriental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ecuador</masterLabel>
+            <translation>Équateur</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Egypt</masterLabel>
+            <translation>Égypte</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>El Salvador</masterLabel>
+            <translation>Salvador</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Equatorial Guinea</masterLabel>
+            <translation>Guinée équatoriale</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Eritrea</masterLabel>
+            <translation>Érythrée</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Estonia</masterLabel>
+            <translation>Estonie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ethiopia</masterLabel>
+            <translation>Éthiopie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Falkland Islands (the) [Malvinas]</masterLabel>
+            <translation>Îles Malouines (Les ) [Malvinas]</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Faroe Islands (the)</masterLabel>
+            <translation>Îles Féroé (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Fiji</masterLabel>
+            <translation>Fidji</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Finland</masterLabel>
+            <translation>Finlande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>France</masterLabel>
+            <translation><!-- France --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>France, Metropolitan</masterLabel>
+            <translation>France métropolitaine</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Afars and Issas</masterLabel>
+            <translation>Territoire français des Afars et des Issas</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Guiana</masterLabel>
+            <translation>Guyane française</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Polynesia</masterLabel>
+            <translation>Polynésie française</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Southern Territories (the)</masterLabel>
+            <translation>Terres australes françaises (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Southern and Antarctic Territories</masterLabel>
+            <translation>Terres australes et antarctiques françaises</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gabon</masterLabel>
+            <translation><!-- Gabon --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gambia (the)</masterLabel>
+            <translation>Gambie (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Georgia</masterLabel>
+            <translation>Géorgie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>German Democratic Republic</masterLabel>
+            <translation>République démocratique allemande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Germany</masterLabel>
+            <translation>Allemagne</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ghana</masterLabel>
+            <translation><!-- Ghana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gibraltar</masterLabel>
+            <translation><!-- Gibraltar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gilbert and Ellice Islands</masterLabel>
+            <translation>Îles Gilbert et Ellice</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Greece</masterLabel>
+            <translation>Grèce</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Greenland</masterLabel>
+            <translation>Groenland</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grenada</masterLabel>
+            <translation>Grenade</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guadeloupe</masterLabel>
+            <translation><!-- Guadeloupe --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guam</masterLabel>
+            <translation><!-- Guam --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guatemala</masterLabel>
+            <translation><!-- Guatemala --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guernsey</masterLabel>
+            <translation>Guernesey</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guinea</masterLabel>
+            <translation>Guinée</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guinea-Bissau</masterLabel>
+            <translation>Guinée-Bissau</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guyana</masterLabel>
+            <translation>Guyane</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Haiti</masterLabel>
+            <translation>Haïti</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Heard Island and McDonal Islands</masterLabel>
+            <translation>Îles Heard-et-MacDonald</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Holy See (the)</masterLabel>
+            <translation>Saint-Siège (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Honduras</masterLabel>
+            <translation><!-- Honduras --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hong Kong</masterLabel>
+            <translation><!-- Hong Kong --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hungary</masterLabel>
+            <translation>Hongrie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iceland</masterLabel>
+            <translation>Islande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>India</masterLabel>
+            <translation>Inde</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Indonesia</masterLabel>
+            <translation>Indonésie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iran (Islamic Republic of)</masterLabel>
+            <translation>Iran (République islamique)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iraq</masterLabel>
+            <translation><!-- Iraq --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ireland</masterLabel>
+            <translation>Irlande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Isle of Man</masterLabel>
+            <translation>Île de Man</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Israel</masterLabel>
+            <translation>Israël</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Italy</masterLabel>
+            <translation>Italie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jamaica</masterLabel>
+            <translation>Jamaïque</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Japan</masterLabel>
+            <translation>Japon</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jersey</masterLabel>
+            <translation><!-- Jersey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Johnston Island</masterLabel>
+            <translation>Île Johnston</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jordan</masterLabel>
+            <translation>Jordanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kazakhstan</masterLabel>
+            <translation><!-- Kazakhstan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kenya</masterLabel>
+            <translation><!-- Kenya --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kiribati</masterLabel>
+            <translation><!-- Kiribati --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Korea (the Democratic People&apos;s Republic of)</masterLabel>
+            <translation>Corée (La république démocratique populaire de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Korea (the Republic of)</masterLabel>
+            <translation>Corée (La république de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kuwait</masterLabel>
+            <translation>Koweït</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kyrgyzstan</masterLabel>
+            <translation>Kirghizistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lao People&apos;s Democratic Republic (the)</masterLabel>
+            <translation>République démocratique populaire lao (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Latvia</masterLabel>
+            <translation>Lettonie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lebanon</masterLabel>
+            <translation>Liban</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lesotho</masterLabel>
+            <translation><!-- Lesotho --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Liberia</masterLabel>
+            <translation>Libéria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Libya</masterLabel>
+            <translation>Libye</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Liechtenstein</masterLabel>
+            <translation><!-- Liechtenstein --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lithuania</masterLabel>
+            <translation>Lituanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Luxembourg</masterLabel>
+            <translation><!-- Luxembourg --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Macao</masterLabel>
+            <translation><!-- Macao --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Macedonia (the former Yugoslav Republic of)</masterLabel>
+            <translation>Macédoine (Ex-république yougoslave)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Madagascar</masterLabel>
+            <translation><!-- Madagascar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malawi</masterLabel>
+            <translation><!-- Malawi --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malaysia</masterLabel>
+            <translation>Malaisie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mali</masterLabel>
+            <translation><!-- Mali --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malta</masterLabel>
+            <translation>Malte</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Marshall Islands (the)</masterLabel>
+            <translation>Îles Marshall (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Martinique</masterLabel>
+            <translation><!-- Martinique --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mauritania</masterLabel>
+            <translation>Mauritanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mauritius</masterLabel>
+            <translation>Maurice</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mayotte</masterLabel>
+            <translation><!-- Mayotte --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mexico</masterLabel>
+            <translation>Mexique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Micronesia (Federated States of)</masterLabel>
+            <translation>Micronésie (États fédérés de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Midway Islands</masterLabel>
+            <translation>Îles Midway</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Moldova (the Republic of)</masterLabel>
+            <translation>Moldavie (La République de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Monaco</masterLabel>
+            <translation><!-- Monaco --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mongolia</masterLabel>
+            <translation>Mongolie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Montenegro</masterLabel>
+            <translation>Monténégro</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Montserrat</masterLabel>
+            <translation><!-- Montserrat --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Morocco</masterLabel>
+            <translation>Maroc</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mozambique</masterLabel>
+            <translation><!-- Mozambique --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Myanmar</masterLabel>
+            <translation>Birmanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Namibia</masterLabel>
+            <translation>Namibie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nauru</masterLabel>
+            <translation><!-- Nauru --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nepal</masterLabel>
+            <translation>Népal</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Netherlands (the)</masterLabel>
+            <translation>Pays-Bas (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Netherlands Antilles</masterLabel>
+            <translation>Antilles néerlandaises</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Neutral Zone</masterLabel>
+            <translation>Zone neutre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Caledonia</masterLabel>
+            <translation>Nouvelle-Calédonie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Hebrides</masterLabel>
+            <translation>Nouvelles-Hébrides</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Zealand</masterLabel>
+            <translation>Nouvelle-Zélande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nicaragua</masterLabel>
+            <translation><!-- Nicaragua --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Niger (the)</masterLabel>
+            <translation>Niger (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nigeria</masterLabel>
+            <translation>Nigéria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Niue</masterLabel>
+            <translation>Niué</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Norfolk Island</masterLabel>
+            <translation>Île Norfolk</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Northern Mariana Islands (the)</masterLabel>
+            <translation>Îles Mariannes du Nord (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Norway</masterLabel>
+            <translation>Norvège</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Oman</masterLabel>
+            <translation><!-- Oman --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pacific Islands (Trust Territory)</masterLabel>
+            <translation>Îles du Pacifique (Territoire sous tutelle)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pakistan</masterLabel>
+            <translation><!-- Pakistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Palau</masterLabel>
+            <translation><!-- Palau --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Palestine, State of</masterLabel>
+            <translation>Palestine, État de</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Panama</masterLabel>
+            <translation><!-- Panama --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Panama Canal Zone</masterLabel>
+            <translation>Zone du canal de Panama</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Papua New Guinea</masterLabel>
+            <translation>Papouasie-Nouvelle-Guinée</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Paraguay</masterLabel>
+            <translation><!-- Paraguay --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Peru</masterLabel>
+            <translation>Pérou</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Philippines (the)</masterLabel>
+            <translation>Philippines (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pitcairn</masterLabel>
+            <translation><!-- Pitcairn --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Poland</masterLabel>
+            <translation>Pologne</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Portugal</masterLabel>
+            <translation><!-- Portugal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Puerto Rico</masterLabel>
+            <translation>Porto Rico</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Qatar</masterLabel>
+            <translation><!-- Qatar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Romania</masterLabel>
+            <translation>Roumanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Russian Federation (the)</masterLabel>
+            <translation>Fédération de Russie (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Rwanda</masterLabel>
+            <translation><!-- Rwanda --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Réunion</masterLabel>
+            <translation><!-- Réunion --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Barthélemy</masterLabel>
+            <translation>Saint-Barthélemy</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Helena, Ascension and Tristan da Cunha</masterLabel>
+            <translation>Sainte-Hélène, Ascension et Tristan da Cunha</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Kitts and Nevis</masterLabel>
+            <translation>Saint-Christophe-et-Niévès</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Lucia</masterLabel>
+            <translation>Sainte Lucie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Martin (French part)</masterLabel>
+            <translation>Saint-Martin (Antilles françaises)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Pierre and Miquelon</masterLabel>
+            <translation>Saint-Pierre-et-Miquelon</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Vincent and the Grenadines</masterLabel>
+            <translation>Saint-Vincent-et-les-Grenadines</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Samoa</masterLabel>
+            <translation><!-- Samoa --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>San Marino</masterLabel>
+            <translation>San Marin</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sao Tome and Principe</masterLabel>
+            <translation>Sao Tomé-et-Principe</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saudi Arabia</masterLabel>
+            <translation>Arabie Saoudite</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Senegal</masterLabel>
+            <translation>Sénégal</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Serbia</masterLabel>
+            <translation>Serbie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Serbia and Montenegro</masterLabel>
+            <translation>Serbie et Monténégro</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Seychelles</masterLabel>
+            <translation><!-- Seychelles --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sierra Leone</masterLabel>
+            <translation><!-- Sierra Leone --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sikkim</masterLabel>
+            <translation><!-- Sikkim --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Singapore</masterLabel>
+            <translation>Singapour</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sint Maarten (Dutch part)</masterLabel>
+            <translation>Saint-Martin (Royaume des Pays-Bas)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Slovakia</masterLabel>
+            <translation>Slovaquie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Slovenia</masterLabel>
+            <translation>Slovénie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Solomon Islands</masterLabel>
+            <translation>Îles Solomon</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Somalia</masterLabel>
+            <translation>Somalie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Africa</masterLabel>
+            <translation>Afrique du Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Georgia and the South Sandwich Islands</masterLabel>
+            <translation>Géorgie du Sud-et-les Îles Sandwich du Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Sudan</masterLabel>
+            <translation>Soudan du Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Southern Rodesia</masterLabel>
+            <translation>Rhodésie du Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Spain</masterLabel>
+            <translation>Espagne</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sri Lanka</masterLabel>
+            <translation><!-- Sri Lanka --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sudan (the)</masterLabel>
+            <translation>Soudan (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Surinam</masterLabel>
+            <translation>Suriname</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Svalbard and Jan Mayen</masterLabel>
+            <translation>Svalbard et Jan Mayen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Swaziland</masterLabel>
+            <translation><!-- Swaziland --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sweden</masterLabel>
+            <translation>Suède</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Switzerland</masterLabel>
+            <translation>Suisse</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Syrian Arab Republic</masterLabel>
+            <translation>République arabe syrienne</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Taiwan (Province of China)</masterLabel>
+            <translation>Taïwan (Province de Chine)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tajikistan</masterLabel>
+            <translation>Tadjikistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tanzania, United Republic of</masterLabel>
+            <translation>Tanzanie, République unie de</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Thailand</masterLabel>
+            <translation>Thaïlande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Timor-Leste</masterLabel>
+            <translation><!-- Timor-Leste --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Togo</masterLabel>
+            <translation><!-- Togo --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tokelau</masterLabel>
+            <translation><!-- Tokelau --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tonga</masterLabel>
+            <translation><!-- Tonga --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Trinidad and Tobago</masterLabel>
+            <translation>Trinité-et-Tobago</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tunisia</masterLabel>
+            <translation>Tunisie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turkey</masterLabel>
+            <translation>Turquie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turkmenistan</masterLabel>
+            <translation>Turkménistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turks and Caicos Islands (the)</masterLabel>
+            <translation>Îles Turques-et-Caïques (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tuvalu</masterLabel>
+            <translation><!-- Tuvalu --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>USSR</masterLabel>
+            <translation>URSS</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uganda</masterLabel>
+            <translation>Ouganda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ukraine</masterLabel>
+            <translation><!-- Ukraine --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United Arab Emirates (the)</masterLabel>
+            <translation>Émirats arabes unis (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United Kingdom of Great Britain and Northern Ireland (the)</masterLabel>
+            <translation>Royaume-Uni de Grande-Bretagne et d&apos;Irlande du Nord (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United States Minor Outlying Islands (the)</masterLabel>
+            <translation>Îles mineures éloignées des États-Unis (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United States of America (the)</masterLabel>
+            <translation>États-Unis d&apos;Amérique (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Unites States Miscellaneous Pacific Islands</masterLabel>
+            <translation>Îles diverses du pacifique des États-Unis</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Upper Volta</masterLabel>
+            <translation>Haute-Volta</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uruguay</masterLabel>
+            <translation><!-- Uruguay --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uzbekistan</masterLabel>
+            <translation>Ouzbékistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Vanuatu</masterLabel>
+            <translation><!-- Vanuatu --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Venezuela (Bolivarian Republic of)</masterLabel>
+            <translation>Venezuela (République bolivarienne)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Viet Nam</masterLabel>
+            <translation>Vietnam</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Viet-Nam, Democratic Republic of</masterLabel>
+            <translation>Viêt Nam, République démocratique du</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Virgin Islands (British)</masterLabel>
+            <translation>Îles Vierges (britanniques)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Virgin Islands (U.S.)</masterLabel>
+            <translation>Îles Vierges (des États-Unis)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wake Island</masterLabel>
+            <translation>Île Wake</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wallis and Futuna</masterLabel>
+            <translation>Wallis-et-Futuna</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Western Sahara</masterLabel>
+            <translation>Sahara occidental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yemen</masterLabel>
+            <translation>Yémen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yemen, Democratic</masterLabel>
+            <translation>Yémen, Démocratique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yugoslavia</masterLabel>
+            <translation>Yougoslavie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zaire</masterLabel>
+            <translation>Zaïre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zambia</masterLabel>
+            <translation>Zambie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zimbabwe</masterLabel>
+            <translation><!-- Zimbabwe --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Åland Islands</masterLabel>
+            <translation>Îles Åland</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>Pays d&apos;origine</label>
+        <name>Country_of_Origin__c</name>
+        <picklistValues>
+            <masterLabel>Afghanistan</masterLabel>
+            <translation><!-- Afghanistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Albania</masterLabel>
+            <translation>Albanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Algeria</masterLabel>
+            <translation>Algérie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>American Samoa</masterLabel>
+            <translation>Samoa américaines</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Andorra</masterLabel>
+            <translation>Andorre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Angola</masterLabel>
+            <translation><!-- Angola --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Anguilla</masterLabel>
+            <translation><!-- Anguilla --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Antarctica</masterLabel>
+            <translation>Antarctique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Antigua and Barbuda</masterLabel>
+            <translation>Antigua et Barbuda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Argentina</masterLabel>
+            <translation>Argentine</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Armenia</masterLabel>
+            <translation>Arménie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Aruba</masterLabel>
+            <translation><!-- Aruba --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Australia</masterLabel>
+            <translation>Australie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Austria</masterLabel>
+            <translation>Autriche</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Azerbaijan</masterLabel>
+            <translation>Azerbaïdjan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bahamas (the)</masterLabel>
+            <translation>Bahamas (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bahrain</masterLabel>
+            <translation>Bahreïn</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bangladesh</masterLabel>
+            <translation><!-- Bangladesh --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Barbados</masterLabel>
+            <translation>Barbade</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belarus</masterLabel>
+            <translation>Biélorussie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belgium</masterLabel>
+            <translation>Belgique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belize</masterLabel>
+            <translation><!-- Belize --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Benin</masterLabel>
+            <translation>Bénin</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bermuda</masterLabel>
+            <translation>Bermudes</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bhutan</masterLabel>
+            <translation>Bhoutan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bolivia (Plurinational State of)</masterLabel>
+            <translation>Bolivie (État plurinational de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bonaire, Sint Eustatius and Saba</masterLabel>
+            <translation>Bonaire, Saint-Eustache et Saba</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bosnia and Herzegovina</masterLabel>
+            <translation>Bosnie-Herzégovine</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Botswana</masterLabel>
+            <translation><!-- Botswana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bouvet Island</masterLabel>
+            <translation>Île Bouvet</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Brazil</masterLabel>
+            <translation>Brésil</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>British Antarctic Territory</masterLabel>
+            <translation>Territoire antarctique britannique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>British Indian Ocean Territory (the)</masterLabel>
+            <translation>Territoire britannique de l&apos;océan Indien (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Brunei Darussalam</masterLabel>
+            <translation>Brunéi Darussalam</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bulgaria</masterLabel>
+            <translation>Bulgarie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burkina Faso</masterLabel>
+            <translation><!-- Burkina Faso --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burma</masterLabel>
+            <translation>Birmanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burundi</masterLabel>
+            <translation><!-- Burundi --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Byelorussian SSR</masterLabel>
+            <translation>RSS de Biélorussie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cabo Verde</masterLabel>
+            <translation>Cap-Vert</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cambodia</masterLabel>
+            <translation>Cambodge</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cameroon</masterLabel>
+            <translation>Cameroun</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Canada</masterLabel>
+            <translation><!-- Canada --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Canton and Enderbury Islands</masterLabel>
+            <translation>Îles Canton et Enderbury</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cayman Islands (the)</masterLabel>
+            <translation>Îles Caïman (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Central African Republic (the)</masterLabel>
+            <translation>République centrafricaine (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Chad</masterLabel>
+            <translation>Tchad</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Chile</masterLabel>
+            <translation>Chili</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>China</masterLabel>
+            <translation>Chine</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Christmas Island</masterLabel>
+            <translation>Île Christmas</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cocos (Keeling) Islands (the)</masterLabel>
+            <translation>Îles Cocos (Keeling) (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Colombia</masterLabel>
+            <translation>Colombie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Comoros (the)</masterLabel>
+            <translation>Comores (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Congo (the Democratic Republic of the)</masterLabel>
+            <translation>Congo (La république démocratique du)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Congo (the)</masterLabel>
+            <translation>Congo (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cook Islands (the)</masterLabel>
+            <translation>Îles Cook (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Costa Rica</masterLabel>
+            <translation><!-- Costa Rica --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Croatia</masterLabel>
+            <translation>Croatie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cuba</masterLabel>
+            <translation><!-- Cuba --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Curaçao</masterLabel>
+            <translation><!-- Curaçao --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cyprus</masterLabel>
+            <translation>Chypre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Czech Republic (the)</masterLabel>
+            <translation>République tchèque (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Czechoslovakia</masterLabel>
+            <translation>Tchécoslovaquie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Côte d&apos;Ivoire</masterLabel>
+            <translation><!-- Côte d&apos;Ivoire --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dahomey</masterLabel>
+            <translation><!-- Dahomey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Denmark</masterLabel>
+            <translation>Danemark</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Djibouti</masterLabel>
+            <translation><!-- Djibouti --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dominica</masterLabel>
+            <translation>Dominique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dominican Republic (the)</masterLabel>
+            <translation>République dominicaine (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dronning Maud Land</masterLabel>
+            <translation>Terre de la Reine-Maud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>East Timor</masterLabel>
+            <translation>Timor oriental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ecuador</masterLabel>
+            <translation>Équateur</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Egypt</masterLabel>
+            <translation>Égypte</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>El Salvador</masterLabel>
+            <translation>Salvador</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Equatorial Guinea</masterLabel>
+            <translation>Guinée équatoriale</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Eritrea</masterLabel>
+            <translation>Érythrée</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Estonia</masterLabel>
+            <translation>Estonie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ethiopia</masterLabel>
+            <translation>Éthiopie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Falkland Islands (the) [Malvinas]</masterLabel>
+            <translation>Îles Malouines (Les ) [Malvinas]</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Faroe Islands (the)</masterLabel>
+            <translation>Îles Féroé (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Fiji</masterLabel>
+            <translation>Fidji</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Finland</masterLabel>
+            <translation>Finlande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>France</masterLabel>
+            <translation><!-- France --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>France, Metropolitan</masterLabel>
+            <translation>France métropolitaine</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Afars and Issas</masterLabel>
+            <translation>Territoire français des Afars et des Issas</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Guiana</masterLabel>
+            <translation>Guyane française</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Polynesia</masterLabel>
+            <translation>Polynésie française</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Southern Territories (the)</masterLabel>
+            <translation>Terres australes françaises (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Southern and Antarctic Territories</masterLabel>
+            <translation>Terres australes et antarctiques françaises</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gabon</masterLabel>
+            <translation><!-- Gabon --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gambia (the)</masterLabel>
+            <translation>Gambie (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Georgia</masterLabel>
+            <translation>Géorgie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>German Democratic Republic</masterLabel>
+            <translation>République démocratique allemande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Germany</masterLabel>
+            <translation>Allemagne</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ghana</masterLabel>
+            <translation><!-- Ghana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gibraltar</masterLabel>
+            <translation><!-- Gibraltar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gilbert and Ellice Islands</masterLabel>
+            <translation>Îles Gilbert et Ellice</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Greece</masterLabel>
+            <translation>Grèce</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Greenland</masterLabel>
+            <translation>Groenland</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grenada</masterLabel>
+            <translation>Grenade</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guadeloupe</masterLabel>
+            <translation><!-- Guadeloupe --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guam</masterLabel>
+            <translation><!-- Guam --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guatemala</masterLabel>
+            <translation><!-- Guatemala --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guernsey</masterLabel>
+            <translation>Guernesey</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guinea</masterLabel>
+            <translation>Guinée</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guinea-Bissau</masterLabel>
+            <translation>Guinée-Bissau</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guyana</masterLabel>
+            <translation>Guyane</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Haiti</masterLabel>
+            <translation>Haïti</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Heard Island and McDonal Islands</masterLabel>
+            <translation>Îles Heard-et-MacDonald</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Holy See (the)</masterLabel>
+            <translation>Saint-Siège (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Honduras</masterLabel>
+            <translation><!-- Honduras --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hong Kong</masterLabel>
+            <translation><!-- Hong Kong --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hungary</masterLabel>
+            <translation>Hongrie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iceland</masterLabel>
+            <translation>Islande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>India</masterLabel>
+            <translation>Inde</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Indonesia</masterLabel>
+            <translation>Indonésie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iran (Islamic Republic of)</masterLabel>
+            <translation>Iran (République islamique)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iraq</masterLabel>
+            <translation><!-- Iraq --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ireland</masterLabel>
+            <translation>Irlande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Isle of Man</masterLabel>
+            <translation>Île de Man</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Israel</masterLabel>
+            <translation>Israël</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Italy</masterLabel>
+            <translation>Italie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jamaica</masterLabel>
+            <translation>Jamaïque</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Japan</masterLabel>
+            <translation>Japon</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jersey</masterLabel>
+            <translation><!-- Jersey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Johnston Island</masterLabel>
+            <translation>Île Johnston</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jordan</masterLabel>
+            <translation>Jordanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kazakhstan</masterLabel>
+            <translation><!-- Kazakhstan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kenya</masterLabel>
+            <translation><!-- Kenya --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kiribati</masterLabel>
+            <translation><!-- Kiribati --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Korea (the Democratic People&apos;s Republic of)</masterLabel>
+            <translation>Corée (La république démocratique populaire de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Korea (the Republic of)</masterLabel>
+            <translation>Corée (La république de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kuwait</masterLabel>
+            <translation>Koweït</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kyrgyzstan</masterLabel>
+            <translation>Kirghizistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lao People&apos;s Democratic Republic (the)</masterLabel>
+            <translation>République démocratique populaire lao (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Latvia</masterLabel>
+            <translation>Lettonie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lebanon</masterLabel>
+            <translation>Liban</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lesotho</masterLabel>
+            <translation><!-- Lesotho --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Liberia</masterLabel>
+            <translation>Libéria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Libya</masterLabel>
+            <translation>Libye</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Liechtenstein</masterLabel>
+            <translation><!-- Liechtenstein --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lithuania</masterLabel>
+            <translation>Lituanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Luxembourg</masterLabel>
+            <translation><!-- Luxembourg --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Macao</masterLabel>
+            <translation><!-- Macao --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Macedonia (the former Yugoslav Republic of)</masterLabel>
+            <translation>Macédoine (Ex-république yougoslave)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Madagascar</masterLabel>
+            <translation><!-- Madagascar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malawi</masterLabel>
+            <translation><!-- Malawi --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malaysia</masterLabel>
+            <translation>Malaisie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mali</masterLabel>
+            <translation><!-- Mali --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malta</masterLabel>
+            <translation>Malte</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Marshall Islands (the)</masterLabel>
+            <translation>Îles Marshall (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Martinique</masterLabel>
+            <translation><!-- Martinique --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mauritania</masterLabel>
+            <translation>Mauritanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mauritius</masterLabel>
+            <translation>Maurice</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mayotte</masterLabel>
+            <translation><!-- Mayotte --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mexico</masterLabel>
+            <translation>Mexique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Micronesia (Federated States of)</masterLabel>
+            <translation>Micronésie (États fédérés de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Midway Islands</masterLabel>
+            <translation>Îles Midway</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Moldova (the Republic of)</masterLabel>
+            <translation>Moldavie (La République de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Monaco</masterLabel>
+            <translation><!-- Monaco --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mongolia</masterLabel>
+            <translation>Mongolie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Montenegro</masterLabel>
+            <translation>Monténégro</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Montserrat</masterLabel>
+            <translation><!-- Montserrat --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Morocco</masterLabel>
+            <translation>Maroc</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mozambique</masterLabel>
+            <translation><!-- Mozambique --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Myanmar</masterLabel>
+            <translation>Birmanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Namibia</masterLabel>
+            <translation>Namibie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nauru</masterLabel>
+            <translation><!-- Nauru --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nepal</masterLabel>
+            <translation>Népal</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Netherlands (the)</masterLabel>
+            <translation>Pays-Bas (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Netherlands Antilles</masterLabel>
+            <translation>Antilles néerlandaises</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Neutral Zone</masterLabel>
+            <translation>Zone neutre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Caledonia</masterLabel>
+            <translation>Nouvelle-Calédonie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Hebrides</masterLabel>
+            <translation>Nouvelles-Hébrides</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Zealand</masterLabel>
+            <translation>Nouvelle-Zélande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nicaragua</masterLabel>
+            <translation><!-- Nicaragua --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Niger (the)</masterLabel>
+            <translation>Niger (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nigeria</masterLabel>
+            <translation>Nigéria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Niue</masterLabel>
+            <translation>Niué</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Norfolk Island</masterLabel>
+            <translation>Île Norfolk</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Northern Mariana Islands (the)</masterLabel>
+            <translation>Îles Mariannes du Nord (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Norway</masterLabel>
+            <translation>Norvège</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Oman</masterLabel>
+            <translation><!-- Oman --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pacific Islands (Trust Territory)</masterLabel>
+            <translation>Îles du Pacifique (Territoire sous tutelle)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pakistan</masterLabel>
+            <translation><!-- Pakistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Palau</masterLabel>
+            <translation><!-- Palau --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Palestine, State of</masterLabel>
+            <translation>Palestine, État de</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Panama</masterLabel>
+            <translation><!-- Panama --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Panama Canal Zone</masterLabel>
+            <translation>Zone du canal de Panama</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Papua New Guinea</masterLabel>
+            <translation>Papouasie-Nouvelle-Guinée</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Paraguay</masterLabel>
+            <translation><!-- Paraguay --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Peru</masterLabel>
+            <translation>Pérou</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Philippines (the)</masterLabel>
+            <translation>Philippines (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pitcairn</masterLabel>
+            <translation><!-- Pitcairn --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Poland</masterLabel>
+            <translation>Pologne</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Portugal</masterLabel>
+            <translation><!-- Portugal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Puerto Rico</masterLabel>
+            <translation>Porto Rico</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Qatar</masterLabel>
+            <translation><!-- Qatar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Romania</masterLabel>
+            <translation>Roumanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Russian Federation (the)</masterLabel>
+            <translation>Fédération de Russie (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Rwanda</masterLabel>
+            <translation><!-- Rwanda --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Réunion</masterLabel>
+            <translation><!-- Réunion --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Barthélemy</masterLabel>
+            <translation>Saint-Barthélemy</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Helena, Ascension and Tristan da Cunha</masterLabel>
+            <translation>Sainte-Hélène, Ascension et Tristan da Cunha</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Kitts and Nevis</masterLabel>
+            <translation>Saint-Christophe-et-Niévès</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Lucia</masterLabel>
+            <translation>Sainte Lucie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Martin (French part)</masterLabel>
+            <translation>Saint-Martin (Antilles françaises)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Pierre and Miquelon</masterLabel>
+            <translation>Saint-Pierre-et-Miquelon</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Vincent and the Grenadines</masterLabel>
+            <translation>Saint-Vincent-et-les-Grenadines</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Samoa</masterLabel>
+            <translation><!-- Samoa --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>San Marino</masterLabel>
+            <translation>San Marin</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sao Tome and Principe</masterLabel>
+            <translation>Sao Tomé-et-Principe</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saudi Arabia</masterLabel>
+            <translation>Arabie Saoudite</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Senegal</masterLabel>
+            <translation>Sénégal</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Serbia</masterLabel>
+            <translation>Serbie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Serbia and Montenegro</masterLabel>
+            <translation>Serbie et Monténégro</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Seychelles</masterLabel>
+            <translation><!-- Seychelles --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sierra Leone</masterLabel>
+            <translation><!-- Sierra Leone --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sikkim</masterLabel>
+            <translation><!-- Sikkim --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Singapore</masterLabel>
+            <translation>Singapour</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sint Maarten (Dutch part)</masterLabel>
+            <translation>Saint-Martin (Royaume des Pays-Bas)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Slovakia</masterLabel>
+            <translation>Slovaquie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Slovenia</masterLabel>
+            <translation>Slovénie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Solomon Islands</masterLabel>
+            <translation>Îles Solomon</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Somalia</masterLabel>
+            <translation>Somalie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Africa</masterLabel>
+            <translation>Afrique du Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Georgia and the South Sandwich Islands</masterLabel>
+            <translation>Géorgie du Sud-et-les Îles Sandwich du Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Sudan</masterLabel>
+            <translation>Soudan du Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Southern Rodesia</masterLabel>
+            <translation>Rhodésie du Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Spain</masterLabel>
+            <translation>Espagne</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sri Lanka</masterLabel>
+            <translation><!-- Sri Lanka --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sudan (the)</masterLabel>
+            <translation>Soudan (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Surinam</masterLabel>
+            <translation>Suriname</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Svalbard and Jan Mayen</masterLabel>
+            <translation>Svalbard et Jan Mayen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Swaziland</masterLabel>
+            <translation><!-- Swaziland --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sweden</masterLabel>
+            <translation>Suède</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Switzerland</masterLabel>
+            <translation>Suisse</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Syrian Arab Republic</masterLabel>
+            <translation>République arabe syrienne</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Taiwan (Province of China)</masterLabel>
+            <translation>Taïwan (Province de Chine)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tajikistan</masterLabel>
+            <translation>Tadjikistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tanzania, United Republic of</masterLabel>
+            <translation>Tanzanie, République unie de</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Thailand</masterLabel>
+            <translation>Thaïlande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Timor-Leste</masterLabel>
+            <translation><!-- Timor-Leste --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Togo</masterLabel>
+            <translation><!-- Togo --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tokelau</masterLabel>
+            <translation><!-- Tokelau --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tonga</masterLabel>
+            <translation><!-- Tonga --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Trinidad and Tobago</masterLabel>
+            <translation>Trinité-et-Tobago</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tunisia</masterLabel>
+            <translation>Tunisie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turkey</masterLabel>
+            <translation>Turquie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turkmenistan</masterLabel>
+            <translation>Turkménistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turks and Caicos Islands (the)</masterLabel>
+            <translation>Îles Turques-et-Caïques (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tuvalu</masterLabel>
+            <translation><!-- Tuvalu --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>USSR</masterLabel>
+            <translation>URSS</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uganda</masterLabel>
+            <translation>Ouganda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ukraine</masterLabel>
+            <translation><!-- Ukraine --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United Arab Emirates (the)</masterLabel>
+            <translation>Émirats arabes unis (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United Kingdom of Great Britain and Northern Ireland (the)</masterLabel>
+            <translation>Royaume-Uni de Grande-Bretagne et d&apos;Irlande du Nord (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United States Minor Outlying Islands (the)</masterLabel>
+            <translation>Îles mineures éloignées des États-Unis (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United States of America (the)</masterLabel>
+            <translation>États-Unis d&apos;Amérique (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Unites States Miscellaneous Pacific Islands</masterLabel>
+            <translation>Îles diverses du pacifique des États-Unis</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Upper Volta</masterLabel>
+            <translation>Haute-Volta</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uruguay</masterLabel>
+            <translation><!-- Uruguay --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uzbekistan</masterLabel>
+            <translation>Ouzbékistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Vanuatu</masterLabel>
+            <translation><!-- Vanuatu --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Venezuela (Bolivarian Republic of)</masterLabel>
+            <translation>Venezuela (République bolivarienne)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Viet Nam</masterLabel>
+            <translation>Vietnam</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Viet-Nam, Democratic Republic of</masterLabel>
+            <translation>Viêt Nam, République démocratique du</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Virgin Islands (British)</masterLabel>
+            <translation>Îles Vierges (britanniques)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Virgin Islands (U.S.)</masterLabel>
+            <translation>Îles Vierges (des États-Unis)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wake Island</masterLabel>
+            <translation>Île Wake</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wallis and Futuna</masterLabel>
+            <translation>Wallis-et-Futuna</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Western Sahara</masterLabel>
+            <translation>Sahara occidental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yemen</masterLabel>
+            <translation>Yémen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yemen, Democratic</masterLabel>
+            <translation>Yémen, Démocratique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yugoslavia</masterLabel>
+            <translation>Yougoslavie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zaire</masterLabel>
+            <translation>Zaïre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zambia</masterLabel>
+            <translation>Zambie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zimbabwe</masterLabel>
+            <translation><!-- Zimbabwe --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Åland Islands</masterLabel>
+            <translation>Îles Åland</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>L’adresse actuellement renseignée dans les champs d&apos;adresse du contact.</help>
+        <label>Adresse actuelle</label>
+        <name>Current_Address__c</name>
+        <relationshipLabel>Contacts (adresse actuelle)</relationshipLabel>
+    </fields>
+    <fields>
+        <help>Cette option marque le contact comme décédé, et l’exclut de la dénomination du foyer, des e-mails et des appels téléphoniques.</help>
+        <label>Décédé</label>
+        <name>Deceased__c</name>
+    </fields>
+    <fields>
+        <help>Cette option exclut le contact des e-mails et des appels téléphoniques.</help>
+        <label>Ne pas contacter</label>
+        <name>Do_Not_Contact__c</name>
+    </fields>
+    <fields>
+        <help>Si ce contact a plusieurs nationalités, elles peuvent être enregistrées ici.</help>
+        <label>Double nationalité</label>
+        <name>Dual_Citizenship__c</name>
+        <picklistValues>
+            <masterLabel>Afghanistan</masterLabel>
+            <translation><!-- Afghanistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Albania</masterLabel>
+            <translation>Albanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Algeria</masterLabel>
+            <translation>Algérie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>American Samoa</masterLabel>
+            <translation>Samoa américaines</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Andorra</masterLabel>
+            <translation>Andorre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Angola</masterLabel>
+            <translation><!-- Angola --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Anguilla</masterLabel>
+            <translation><!-- Anguilla --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Antarctica</masterLabel>
+            <translation>Antarctique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Antigua and Barbuda</masterLabel>
+            <translation>Antigua et Barbuda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Argentina</masterLabel>
+            <translation>Argentine</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Armenia</masterLabel>
+            <translation>Arménie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Aruba</masterLabel>
+            <translation><!-- Aruba --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Australia</masterLabel>
+            <translation>Australie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Austria</masterLabel>
+            <translation>Autriche</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Azerbaijan</masterLabel>
+            <translation>Azerbaïdjan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bahamas (the)</masterLabel>
+            <translation>Bahamas (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bahrain</masterLabel>
+            <translation>Bahreïn</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bangladesh</masterLabel>
+            <translation><!-- Bangladesh --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Barbados</masterLabel>
+            <translation>Barbade</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belarus</masterLabel>
+            <translation>Biélorussie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belgium</masterLabel>
+            <translation>Belgique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Belize</masterLabel>
+            <translation><!-- Belize --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Benin</masterLabel>
+            <translation>Bénin</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bermuda</masterLabel>
+            <translation>Bermudes</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bhutan</masterLabel>
+            <translation>Bhoutan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bolivia (Plurinational State of)</masterLabel>
+            <translation>Bolivie (État plurinational de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bonaire, Sint Eustatius and Saba</masterLabel>
+            <translation>Bonaire, Saint-Eustache et Saba</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bosnia and Herzegovina</masterLabel>
+            <translation>Bosnie-Herzégovine</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Botswana</masterLabel>
+            <translation><!-- Botswana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bouvet Island</masterLabel>
+            <translation>Île Bouvet</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Brazil</masterLabel>
+            <translation>Brésil</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>British Antarctic Territory</masterLabel>
+            <translation>Territoire antarctique britannique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>British Indian Ocean Territory (the)</masterLabel>
+            <translation>Territoire britannique de l&apos;océan Indien (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Brunei Darussalam</masterLabel>
+            <translation>Brunéi Darussalam</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Bulgaria</masterLabel>
+            <translation>Bulgarie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burkina Faso</masterLabel>
+            <translation><!-- Burkina Faso --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burma</masterLabel>
+            <translation>Birmanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Burundi</masterLabel>
+            <translation><!-- Burundi --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Byelorussian SSR</masterLabel>
+            <translation>RSS de Biélorussie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cabo Verde</masterLabel>
+            <translation>Cap-Vert</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cambodia</masterLabel>
+            <translation>Cambodge</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cameroon</masterLabel>
+            <translation>Cameroun</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Canada</masterLabel>
+            <translation><!-- Canada --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Canton and Enderbury Islands</masterLabel>
+            <translation>Îles Canton et Enderbury</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cayman Islands (the)</masterLabel>
+            <translation>Îles Caïman (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Central African Republic (the)</masterLabel>
+            <translation>République centrafricaine (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Chad</masterLabel>
+            <translation>Tchad</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Chile</masterLabel>
+            <translation>Chili</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>China</masterLabel>
+            <translation>Chine</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Christmas Island</masterLabel>
+            <translation>Île Christmas</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cocos (Keeling) Islands (the)</masterLabel>
+            <translation>Îles Cocos (Keeling) (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Colombia</masterLabel>
+            <translation>Colombie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Comoros (the)</masterLabel>
+            <translation>Comores (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Congo (the Democratic Republic of the)</masterLabel>
+            <translation>Congo (La république démocratique du)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Congo (the)</masterLabel>
+            <translation>Congo (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cook Islands (the)</masterLabel>
+            <translation>Îles Cook (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Costa Rica</masterLabel>
+            <translation><!-- Costa Rica --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Croatia</masterLabel>
+            <translation>Croatie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cuba</masterLabel>
+            <translation><!-- Cuba --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Curaçao</masterLabel>
+            <translation><!-- Curaçao --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cyprus</masterLabel>
+            <translation>Chypre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Czech Republic (the)</masterLabel>
+            <translation>République tchèque (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Czechoslovakia</masterLabel>
+            <translation>Tchécoslovaquie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Côte d&apos;Ivoire</masterLabel>
+            <translation><!-- Côte d&apos;Ivoire --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dahomey</masterLabel>
+            <translation><!-- Dahomey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Denmark</masterLabel>
+            <translation>Danemark</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Djibouti</masterLabel>
+            <translation><!-- Djibouti --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dominica</masterLabel>
+            <translation>Dominique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dominican Republic (the)</masterLabel>
+            <translation>République dominicaine (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Dronning Maud Land</masterLabel>
+            <translation>Terre de la Reine-Maud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>East Timor</masterLabel>
+            <translation>Timor oriental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ecuador</masterLabel>
+            <translation>Équateur</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Egypt</masterLabel>
+            <translation>Égypte</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>El Salvador</masterLabel>
+            <translation>Salvador</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Equatorial Guinea</masterLabel>
+            <translation>Guinée équatoriale</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Eritrea</masterLabel>
+            <translation>Érythrée</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Estonia</masterLabel>
+            <translation>Estonie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ethiopia</masterLabel>
+            <translation>Éthiopie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Falkland Islands (the) [Malvinas]</masterLabel>
+            <translation>Îles Malouines (Les ) [Malvinas]</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Faroe Islands (the)</masterLabel>
+            <translation>Îles Féroé (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Fiji</masterLabel>
+            <translation>Fidji</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Finland</masterLabel>
+            <translation>Finlande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>France</masterLabel>
+            <translation><!-- France --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>France, Metropolitan</masterLabel>
+            <translation>France métropolitaine</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Afars and Issas</masterLabel>
+            <translation>Territoire français des Afars et des Issas</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Guiana</masterLabel>
+            <translation>Guyane française</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Polynesia</masterLabel>
+            <translation>Polynésie française</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Southern Territories (the)</masterLabel>
+            <translation>Terres australes françaises (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>French Southern and Antarctic Territories</masterLabel>
+            <translation>Terres australes et antarctiques françaises</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gabon</masterLabel>
+            <translation><!-- Gabon --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gambia (the)</masterLabel>
+            <translation>Gambie (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Georgia</masterLabel>
+            <translation>Géorgie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>German Democratic Republic</masterLabel>
+            <translation>République démocratique allemande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Germany</masterLabel>
+            <translation>Allemagne</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ghana</masterLabel>
+            <translation><!-- Ghana --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gibraltar</masterLabel>
+            <translation><!-- Gibraltar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Gilbert and Ellice Islands</masterLabel>
+            <translation>Îles Gilbert et Ellice</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Greece</masterLabel>
+            <translation>Grèce</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Greenland</masterLabel>
+            <translation>Groenland</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grenada</masterLabel>
+            <translation>Grenade</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guadeloupe</masterLabel>
+            <translation><!-- Guadeloupe --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guam</masterLabel>
+            <translation><!-- Guam --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guatemala</masterLabel>
+            <translation><!-- Guatemala --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guernsey</masterLabel>
+            <translation>Guernesey</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guinea</masterLabel>
+            <translation>Guinée</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guinea-Bissau</masterLabel>
+            <translation>Guinée-Bissau</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Guyana</masterLabel>
+            <translation>Guyane</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Haiti</masterLabel>
+            <translation>Haïti</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Heard Island and McDonal Islands</masterLabel>
+            <translation>Îles Heard-et-MacDonald</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Holy See (the)</masterLabel>
+            <translation>Saint-Siège (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Honduras</masterLabel>
+            <translation><!-- Honduras --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hong Kong</masterLabel>
+            <translation><!-- Hong Kong --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hungary</masterLabel>
+            <translation>Hongrie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iceland</masterLabel>
+            <translation>Islande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>India</masterLabel>
+            <translation>Inde</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Indonesia</masterLabel>
+            <translation>Indonésie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iran (Islamic Republic of)</masterLabel>
+            <translation>Iran (République islamique)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Iraq</masterLabel>
+            <translation><!-- Iraq --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ireland</masterLabel>
+            <translation>Irlande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Isle of Man</masterLabel>
+            <translation>Île de Man</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Israel</masterLabel>
+            <translation>Israël</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Italy</masterLabel>
+            <translation>Italie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jamaica</masterLabel>
+            <translation>Jamaïque</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Japan</masterLabel>
+            <translation>Japon</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jersey</masterLabel>
+            <translation><!-- Jersey --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Johnston Island</masterLabel>
+            <translation>Île Johnston</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jordan</masterLabel>
+            <translation>Jordanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kazakhstan</masterLabel>
+            <translation><!-- Kazakhstan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kenya</masterLabel>
+            <translation><!-- Kenya --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kiribati</masterLabel>
+            <translation><!-- Kiribati --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Korea (the Democratic People&apos;s Republic of)</masterLabel>
+            <translation>Corée (La république démocratique populaire de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Korea (the Republic of)</masterLabel>
+            <translation>Corée (La république de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kuwait</masterLabel>
+            <translation>Koweït</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Kyrgyzstan</masterLabel>
+            <translation>Kirghizistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lao People&apos;s Democratic Republic (the)</masterLabel>
+            <translation>République démocratique populaire lao (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Latvia</masterLabel>
+            <translation>Lettonie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lebanon</masterLabel>
+            <translation>Liban</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lesotho</masterLabel>
+            <translation><!-- Lesotho --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Liberia</masterLabel>
+            <translation>Libéria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Libya</masterLabel>
+            <translation>Libye</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Liechtenstein</masterLabel>
+            <translation><!-- Liechtenstein --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Lithuania</masterLabel>
+            <translation>Lituanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Luxembourg</masterLabel>
+            <translation><!-- Luxembourg --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Macao</masterLabel>
+            <translation><!-- Macao --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Macedonia (the former Yugoslav Republic of)</masterLabel>
+            <translation>Macédoine (Ex-république yougoslave)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Madagascar</masterLabel>
+            <translation><!-- Madagascar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malawi</masterLabel>
+            <translation><!-- Malawi --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malaysia</masterLabel>
+            <translation>Malaisie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mali</masterLabel>
+            <translation><!-- Mali --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Malta</masterLabel>
+            <translation>Malte</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Marshall Islands (the)</masterLabel>
+            <translation>Îles Marshall (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Martinique</masterLabel>
+            <translation><!-- Martinique --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mauritania</masterLabel>
+            <translation>Mauritanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mauritius</masterLabel>
+            <translation>Maurice</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mayotte</masterLabel>
+            <translation><!-- Mayotte --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mexico</masterLabel>
+            <translation>Mexique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Micronesia (Federated States of)</masterLabel>
+            <translation>Micronésie (États fédérés de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Midway Islands</masterLabel>
+            <translation>Îles Midway</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Moldova (the Republic of)</masterLabel>
+            <translation>Moldavie (La République de)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Monaco</masterLabel>
+            <translation><!-- Monaco --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mongolia</masterLabel>
+            <translation>Mongolie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Montenegro</masterLabel>
+            <translation>Monténégro</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Montserrat</masterLabel>
+            <translation><!-- Montserrat --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Morocco</masterLabel>
+            <translation>Maroc</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mozambique</masterLabel>
+            <translation><!-- Mozambique --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Myanmar</masterLabel>
+            <translation>Birmanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Namibia</masterLabel>
+            <translation>Namibie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nauru</masterLabel>
+            <translation><!-- Nauru --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nepal</masterLabel>
+            <translation>Népal</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Netherlands (the)</masterLabel>
+            <translation>Pays-Bas (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Netherlands Antilles</masterLabel>
+            <translation>Antilles néerlandaises</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Neutral Zone</masterLabel>
+            <translation>Zone neutre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Caledonia</masterLabel>
+            <translation>Nouvelle-Calédonie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Hebrides</masterLabel>
+            <translation>Nouvelles-Hébrides</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>New Zealand</masterLabel>
+            <translation>Nouvelle-Zélande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nicaragua</masterLabel>
+            <translation><!-- Nicaragua --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Niger (the)</masterLabel>
+            <translation>Niger (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Nigeria</masterLabel>
+            <translation>Nigéria</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Niue</masterLabel>
+            <translation>Niué</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Norfolk Island</masterLabel>
+            <translation>Île Norfolk</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Northern Mariana Islands (the)</masterLabel>
+            <translation>Îles Mariannes du Nord (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Norway</masterLabel>
+            <translation>Norvège</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Oman</masterLabel>
+            <translation><!-- Oman --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pacific Islands (Trust Territory)</masterLabel>
+            <translation>Îles du Pacifique (Territoire sous tutelle)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pakistan</masterLabel>
+            <translation><!-- Pakistan --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Palau</masterLabel>
+            <translation><!-- Palau --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Palestine, State of</masterLabel>
+            <translation>Palestine, État de</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Panama</masterLabel>
+            <translation><!-- Panama --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Panama Canal Zone</masterLabel>
+            <translation>Zone du canal de Panama</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Papua New Guinea</masterLabel>
+            <translation>Papouasie-Nouvelle-Guinée</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Paraguay</masterLabel>
+            <translation><!-- Paraguay --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Peru</masterLabel>
+            <translation>Pérou</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Philippines (the)</masterLabel>
+            <translation>Philippines (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Pitcairn</masterLabel>
+            <translation><!-- Pitcairn --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Poland</masterLabel>
+            <translation>Pologne</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Portugal</masterLabel>
+            <translation><!-- Portugal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Puerto Rico</masterLabel>
+            <translation>Porto Rico</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Qatar</masterLabel>
+            <translation><!-- Qatar --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Romania</masterLabel>
+            <translation>Roumanie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Russian Federation (the)</masterLabel>
+            <translation>Fédération de Russie (La)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Rwanda</masterLabel>
+            <translation><!-- Rwanda --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Réunion</masterLabel>
+            <translation><!-- Réunion --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Barthélemy</masterLabel>
+            <translation>Saint-Barthélemy</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Helena, Ascension and Tristan da Cunha</masterLabel>
+            <translation>Sainte-Hélène, Ascension et Tristan da Cunha</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Kitts and Nevis</masterLabel>
+            <translation>Saint-Christophe-et-Niévès</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Lucia</masterLabel>
+            <translation>Sainte Lucie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Martin (French part)</masterLabel>
+            <translation>Saint-Martin (Antilles françaises)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Pierre and Miquelon</masterLabel>
+            <translation>Saint-Pierre-et-Miquelon</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saint Vincent and the Grenadines</masterLabel>
+            <translation>Saint-Vincent-et-les-Grenadines</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Samoa</masterLabel>
+            <translation><!-- Samoa --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>San Marino</masterLabel>
+            <translation>San Marin</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sao Tome and Principe</masterLabel>
+            <translation>Sao Tomé-et-Principe</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Saudi Arabia</masterLabel>
+            <translation>Arabie Saoudite</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Senegal</masterLabel>
+            <translation>Sénégal</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Serbia</masterLabel>
+            <translation>Serbie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Serbia and Montenegro</masterLabel>
+            <translation>Serbie et Monténégro</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Seychelles</masterLabel>
+            <translation><!-- Seychelles --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sierra Leone</masterLabel>
+            <translation><!-- Sierra Leone --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sikkim</masterLabel>
+            <translation><!-- Sikkim --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Singapore</masterLabel>
+            <translation>Singapour</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sint Maarten (Dutch part)</masterLabel>
+            <translation>Saint-Martin (Royaume des Pays-Bas)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Slovakia</masterLabel>
+            <translation>Slovaquie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Slovenia</masterLabel>
+            <translation>Slovénie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Solomon Islands</masterLabel>
+            <translation>Îles Solomon</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Somalia</masterLabel>
+            <translation>Somalie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Africa</masterLabel>
+            <translation>Afrique du Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Georgia and the South Sandwich Islands</masterLabel>
+            <translation>Géorgie du Sud-et-les Îles Sandwich du Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>South Sudan</masterLabel>
+            <translation>Soudan du Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Southern Rodesia</masterLabel>
+            <translation>Rhodésie du Sud</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Spain</masterLabel>
+            <translation>Espagne</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sri Lanka</masterLabel>
+            <translation><!-- Sri Lanka --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sudan (the)</masterLabel>
+            <translation>Soudan (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Surinam</masterLabel>
+            <translation>Suriname</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Svalbard and Jan Mayen</masterLabel>
+            <translation>Svalbard et Jan Mayen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Swaziland</masterLabel>
+            <translation><!-- Swaziland --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sweden</masterLabel>
+            <translation>Suède</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Switzerland</masterLabel>
+            <translation>Suisse</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Syrian Arab Republic</masterLabel>
+            <translation>République arabe syrienne</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Taiwan (Province of China)</masterLabel>
+            <translation>Taïwan (Province de Chine)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tajikistan</masterLabel>
+            <translation>Tadjikistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tanzania, United Republic of</masterLabel>
+            <translation>Tanzanie, République unie de</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Thailand</masterLabel>
+            <translation>Thaïlande</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Timor-Leste</masterLabel>
+            <translation><!-- Timor-Leste --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Togo</masterLabel>
+            <translation><!-- Togo --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tokelau</masterLabel>
+            <translation><!-- Tokelau --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tonga</masterLabel>
+            <translation><!-- Tonga --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Trinidad and Tobago</masterLabel>
+            <translation>Trinité-et-Tobago</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tunisia</masterLabel>
+            <translation>Tunisie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turkey</masterLabel>
+            <translation>Turquie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turkmenistan</masterLabel>
+            <translation>Turkménistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Turks and Caicos Islands (the)</masterLabel>
+            <translation>Îles Turques-et-Caïques (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Tuvalu</masterLabel>
+            <translation><!-- Tuvalu --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>USSR</masterLabel>
+            <translation>URSS</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uganda</masterLabel>
+            <translation>Ouganda</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Ukraine</masterLabel>
+            <translation><!-- Ukraine --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United Arab Emirates (the)</masterLabel>
+            <translation>Émirats arabes unis (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United Kingdom of Great Britain and Northern Ireland (the)</masterLabel>
+            <translation>Royaume-Uni de Grande-Bretagne et d&apos;Irlande du Nord (Le)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United States Minor Outlying Islands (the)</masterLabel>
+            <translation>Îles mineures éloignées des États-Unis (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>United States of America (the)</masterLabel>
+            <translation>États-Unis d&apos;Amérique (Les)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Unites States Miscellaneous Pacific Islands</masterLabel>
+            <translation>Îles diverses du pacifique des États-Unis</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Upper Volta</masterLabel>
+            <translation>Haute-Volta</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uruguay</masterLabel>
+            <translation><!-- Uruguay --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uzbekistan</masterLabel>
+            <translation>Ouzbékistan</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Vanuatu</masterLabel>
+            <translation><!-- Vanuatu --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Venezuela (Bolivarian Republic of)</masterLabel>
+            <translation>Venezuela (République bolivarienne)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Viet Nam</masterLabel>
+            <translation>Vietnam</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Viet-Nam, Democratic Republic of</masterLabel>
+            <translation>Viêt Nam, République démocratique du</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Virgin Islands (British)</masterLabel>
+            <translation>Îles Vierges (britanniques)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Virgin Islands (U.S.)</masterLabel>
+            <translation>Îles Vierges (des États-Unis)</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wake Island</masterLabel>
+            <translation>Île Wake</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wallis and Futuna</masterLabel>
+            <translation>Wallis-et-Futuna</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Western Sahara</masterLabel>
+            <translation>Sahara occidental</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yemen</masterLabel>
+            <translation>Yémen</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yemen, Democratic</masterLabel>
+            <translation>Yémen, Démocratique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Yugoslavia</masterLabel>
+            <translation>Yougoslavie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zaire</masterLabel>
+            <translation>Zaïre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zambia</masterLabel>
+            <translation>Zambie</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Zimbabwe</masterLabel>
+            <translation><!-- Zimbabwe --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Åland Islands</masterLabel>
+            <translation>Îles Åland</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>Appartenance ethnique</label>
+        <name>Ethnicity__c</name>
+        <picklistValues>
+            <masterLabel>Hispanic or Latino</masterLabel>
+            <translation><!-- Hispanic or Latino --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Not Hispanic or Latino</masterLabel>
+            <translation><!-- Not Hispanic or Latino --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Cochez cette case pour exclure ce contact de la salutation formelle du foyer.</help>
+        <label>Exclure de la salutation form. foyer</label>
+        <name>Exclude_from_Household_Formal_Greeting__c</name>
+    </fields>
+    <fields>
+        <help>Cochez cette case pour exclure ce contact de la salutation informelle du foyer.</help>
+        <label>Exclure de la salutation inform. foyer</label>
+        <name>Exclude_from_Household_Informal_Greeting__c</name>
+    </fields>
+    <fields>
+        <help>Cochez cette case pour exclure ce contact du nom du foyer.</help>
+        <label>Exclure du nom du foyer</label>
+        <name>Exclude_from_Household_Name__c</name>
+    </fields>
+    <fields>
+        <label>Loi FERPA aux États-Unis</label>
+        <name>FERPA__c</name>
+    </fields>
+    <fields>
+        <label>Candidat à une aide financière</label>
+        <name>Financial_Aid_Applicant__c</name>
+    </fields>
+    <fields>
+        <label>Sexe</label>
+        <name>Gender__c</name>
+        <picklistValues>
+            <masterLabel>Female</masterLabel>
+            <translation>Féminin</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Male</masterLabel>
+            <translation>Masculin</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>Détails de la loi HIPAA</label>
+        <name>HIPAA_Detail__c</name>
+    </fields>
+    <fields>
+        <label>Loi HIPAA aux États-Unis</label>
+        <name>HIPAA__c</name>
+    </fields>
+    <fields>
+        <label>Antécédents militaires</label>
+        <name>Military_Background__c</name>
+    </fields>
+    <fields>
+        <label>Service militaire</label>
+        <name>Military_Service__c</name>
+    </fields>
+    <fields>
+        <help>Détermine les noms de foyer dont ce contact ne fait PAS partie.</help>
+        <label>Exclusions de dénomination</label>
+        <name>Naming_Exclusions__c</name>
+        <picklistValues>
+            <masterLabel>Household__c.Formal_Greeting__c</masterLabel>
+            <translation><!-- Household__c.Formal_Greeting__c --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Household__c.Informal_Greeting__c</masterLabel>
+            <translation><!-- Household__c.Informal_Greeting__c --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Household__c.Name</masterLabel>
+            <translation><!-- Household__c.Name --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Quel numéro de téléphone doit être utilisé pour la plupart des communications impliquant ce contact ?</help>
+        <label>Téléphone préféré</label>
+        <name>PreferredPhone__c</name>
+        <picklistValues>
+            <masterLabel>Home</masterLabel>
+            <translation>Domicile</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mobile</masterLabel>
+            <translation><!-- Mobile --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Other</masterLabel>
+            <translation>Autre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation>Professionnel</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Quel e-mail doit être utilisé pour la plupart des communications impliquant ce contact ?</help>
+        <label>Adresse e-mail préférée</label>
+        <name>Preferred_Email__c</name>
+        <picklistValues>
+            <masterLabel>Alternate</masterLabel>
+            <translation>Autre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>University</masterLabel>
+            <translation>Université</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation>Professionnel</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Quel est le type de l’adresse postale ?</help>
+        <label>Type d&apos;adresse principal</label>
+        <name>Primary_Address_Type__c</name>
+        <picklistValues>
+            <masterLabel>Home</masterLabel>
+            <translation>Domicile</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Other</masterLabel>
+            <translation>Autre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation>Professionnel</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>Foyer principal</label>
+        <name>Primary_Household__c</name>
+        <relationshipLabel>Contacts (foyer principal)</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Organisation professionnelle principale</label>
+        <name>Primary_Organization__c</name>
+        <relationshipLabel>Contacts (organisation principale)</relationshipLabel>
+    </fields>
+    <fields>
+        <label><!-- Race --></label>
+        <name>Race__c</name>
+        <picklistValues>
+            <masterLabel>American Indian or Alaska Native</masterLabel>
+            <translation>Amérindien ou natif d&apos;Alaska</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Asian</masterLabel>
+            <translation>Asiatique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Black or African American</masterLabel>
+            <translation>Noir ou afro-américain</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hispanic or Latino</masterLabel>
+            <translation>Hispanique ou Latino-Américain</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Native Hawaiian or Other Pacific Islander</masterLabel>
+            <translation>Natif d&apos;Hawaï ou d&apos;une autre île du Pacifique</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>White</masterLabel>
+            <translation>Blanc</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label><!-- Religion --></label>
+        <name>Religion__c</name>
+        <picklistValues>
+            <masterLabel>Atheist</masterLabel>
+            <translation>Athée</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Buddhist</masterLabel>
+            <translation>Bouddhiste</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Christian</masterLabel>
+            <translation>Chrétien</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hindu</masterLabel>
+            <translation>Hindou</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Jewish</masterLabel>
+            <translation>Juif</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Muslim</masterLabel>
+            <translation>Musulman</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Other</masterLabel>
+            <translation>Autre</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Quel est le type de l’autre adresse ?</help>
+        <label>Type d&apos;adresse secondaire</label>
+        <name>Secondary_Address_Type__c</name>
+        <picklistValues>
+            <masterLabel>Home</masterLabel>
+            <translation>Domicile</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Other</masterLabel>
+            <translation>Autre</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation>Professionnel</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>Numéro de sécurité sociale</label>
+        <name>Social_Security_Number__c</name>
+    </fields>
+    <fields>
+        <help>Adresse e-mail officielle de l&apos;université.</help>
+        <label>Adresse e-mail de l&apos;université</label>
+        <name>UniversityEmail__c</name>
+    </fields>
+    <fields>
+        <help>Afficher le champ Adresse e-mail préférée.</help>
+        <label>Adresse e-mail professionnelle</label>
+        <name>WorkEmail__c</name>
+    </fields>
+    <fields>
+        <help>Afficher le champ « Téléphone préféré ».</help>
+        <label>Téléphone professionnel</label>
+        <name>WorkPhone__c</name>
+    </fields>
+    <fields>
+        <help>Formule : l&apos;adresse postale si le Type d’adresse principale est Professionnel, l&apos;autre adresse si le Type d’adresse secondaire est Professionnel.</help>
+        <label>Adresse professionnelle</label>
+        <name>Work_Address__c</name>
+    </fields>
+    <fields>
+        <help>Si cette case est cochée, la référence Adresse actuelle du contact remplace l’adresse par défaut ou l’adresse saisonnière du foyer.</help>
+        <label>Ne pas mettre à jour automatiquement</label>
+        <name>is_Address_Override__c</name>
+    </fields>
+    <layouts>
+        <layout>HEDA Contact Layout</layout>
+        <sections>
+            <label><!-- Additional Information --></label>
+            <section>Additional Information</section>
+        </sections>
+        <sections>
+            <label>Préférences de communication</label>
+            <section>Communication Preferences</section>
+        </sections>
+        <sections>
+            <label>Détails du contact</label>
+            <section>Contact Details</section>
+        </sections>
+        <sections>
+            <label>Affiliations principales</label>
+            <section>Primary Affiliations</section>
+        </sections>
+    </layouts>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Course_Enrollment__c-fr.objectTranslation
+++ b/src/objectTranslations/Course_Enrollment__c-fr.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Course Connection --></value>
+        <value>Connexion au cours</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Course Connection --></value>
+        <value>Connexions aux cours</value>
     </caseValues>
     <fields>
         <help>Le programme académique auquel l&apos;étudiant est inscrit.</help>
@@ -67,7 +67,7 @@
             <translation>Ancien</translation>
         </picklistValues>
     </fields>
-    <gender><!-- Masculine --></gender>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Course Enrollment Layout</layout>
         <sections>
@@ -88,5 +88,5 @@
         <label>Étudiant</label>
         <name>Student</name>
     </recordTypes>
-    <startsWith><!-- Consonant --></startsWith>
+    <startsWith>Consonant</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Course_Enrollment__c-fr.objectTranslation
+++ b/src/objectTranslations/Course_Enrollment__c-fr.objectTranslation
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Course Connection --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Course Connection --></value>
+    </caseValues>
+    <fields>
+        <help>Le programme académique auquel l&apos;étudiant est inscrit.</help>
+        <label>Programme académique du contact</label>
+        <name>Account__c</name>
+        <relationshipLabel>Connexions aux cours</relationshipLabel>
+    </fields>
+    <fields>
+        <label><!-- Affiliation --></label>
+        <name>Affiliation__c</name>
+        <relationshipLabel>Connexion au cours</relationshipLabel>
+    </fields>
+    <fields>
+        <help>L&apos;étudiant inscrit au cours.</help>
+        <label><!-- Contact --></label>
+        <name>Contact__c</name>
+        <relationshipLabel>Connexions aux cours</relationshipLabel>
+    </fields>
+    <fields>
+        <help>L&apos;offre de cours à laquelle l&apos;étudiant est inscrit. Le cours est offert pour une durée spécifique.</help>
+        <label>ID d&apos;offre de cours</label>
+        <name>Course_Offering__c</name>
+        <relationshipLabel>Connexion au cours</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Crédits tentés</label>
+        <name>Credits_Attempted__c</name>
+    </fields>
+    <fields>
+        <label>Crédits gagnés</label>
+        <name>Credits_Earned__c</name>
+    </fields>
+    <fields>
+        <label>Niveau</label>
+        <name>Grade__c</name>
+    </fields>
+    <fields>
+        <help>Représente la connexion principale du cours.</help>
+        <label>Principal</label>
+        <name>Primary__c</name>
+    </fields>
+    <fields>
+        <help>Le programme auquel l&apos;étudiant est inscrit. Associe un étudiant à un programme académique.</help>
+        <label>ID d&apos;inscription au programme</label>
+        <name>Program_Enrollment__c</name>
+        <relationshipLabel>Connexions aux cours</relationshipLabel>
+    </fields>
+    <fields>
+        <help>Représente le statut de connexion au cours.</help>
+        <label>Statut</label>
+        <name>Status__c</name>
+        <picklistValues>
+            <masterLabel>Current</masterLabel>
+            <translation>Actuel</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Former</masterLabel>
+            <translation>Ancien</translation>
+        </picklistValues>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <layouts>
+        <layout>HEDA Course Enrollment Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Course Connection ID --></nameFieldLabel>
+    <recordTypes>
+        <label><!-- Default --></label>
+        <name>Default</name>
+    </recordTypes>
+    <recordTypes>
+        <label>Professeur</label>
+        <name>Faculty</name>
+    </recordTypes>
+    <recordTypes>
+        <label>Étudiant</label>
+        <name>Student</name>
+    </recordTypes>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Course_Offering__c-fr.objectTranslation
+++ b/src/objectTranslations/Course_Offering__c-fr.objectTranslation
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Course Offering --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Course Offering --></value>
+    </caseValues>
+    <fields>
+        <label>Capacité</label>
+        <name>Capacity__c</name>
+    </fields>
+    <fields>
+        <label>Cours</label>
+        <name>Course__c</name>
+        <relationshipLabel>Offres de cours</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Date de fin</label>
+        <name>End_Date__c</name>
+    </fields>
+    <fields>
+        <label>Professeur principal</label>
+        <name>Faculty__c</name>
+        <relationshipLabel>Offres de cours</relationshipLabel>
+    </fields>
+    <fields>
+        <label>ID de section</label>
+        <name>Section_ID__c</name>
+    </fields>
+    <fields>
+        <label>Date de début</label>
+        <name>Start_Date__c</name>
+    </fields>
+    <fields>
+        <label>Durée</label>
+        <name>Term__c</name>
+        <relationshipLabel>Offres de cours</relationshipLabel>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <layouts>
+        <layout>HEDA Course Offering Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Course Offering ID --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Course_Offering__c-fr.objectTranslation
+++ b/src/objectTranslations/Course_Offering__c-fr.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Course Offering --></value>
+        <value>Offre de cours</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Course Offering --></value>
+        <value>Offres de cours</value>
     </caseValues>
     <fields>
         <label>Capacité</label>
@@ -39,7 +39,7 @@
         <name>Term__c</name>
         <relationshipLabel>Offres de cours</relationshipLabel>
     </fields>
-    <gender><!-- Masculine --></gender>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Course Offering Layout</layout>
         <sections>
@@ -47,6 +47,6 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <nameFieldLabel><!-- Course Offering ID --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <nameFieldLabel>ID d&apos;offre de cours</nameFieldLabel>
+    <startsWith>Vowel</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Course__c-fr.objectTranslation
+++ b/src/objectTranslations/Course__c-fr.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Course --></value>
+        <value>Cours</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Course --></value>
+        <value>Cours</value>
     </caseValues>
     <fields>
         <label>Service</label>
@@ -29,7 +29,7 @@
         <label>Description étendue</label>
         <name>Extended_Description__c</name>
     </fields>
-    <gender><!-- Masculine --></gender>
+    <gender>Masculine</gender>
     <layouts>
         <layout>HEDA Course Layout</layout>
         <sections>
@@ -37,6 +37,6 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <nameFieldLabel><!-- Course Name --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <nameFieldLabel>Nom du cours</nameFieldLabel>
+    <startsWith>Consonant</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Course__c-fr.objectTranslation
+++ b/src/objectTranslations/Course__c-fr.objectTranslation
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Course --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Course --></value>
+    </caseValues>
+    <fields>
+        <label>Service</label>
+        <name>Account__c</name>
+        <relationshipLabel>Cours</relationshipLabel>
+    </fields>
+    <fields>
+        <label>ID de cours</label>
+        <name>Course_ID__c</name>
+    </fields>
+    <fields>
+        <label>Heures de crédit</label>
+        <name>Credit_Hours__c</name>
+    </fields>
+    <fields>
+        <label><!-- Description --></label>
+        <name>Description__c</name>
+    </fields>
+    <fields>
+        <label>Description étendue</label>
+        <name>Extended_Description__c</name>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <layouts>
+        <layout>HEDA Course Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Course Name --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Error__c-fr.objectTranslation
+++ b/src/objectTranslations/Error__c-fr.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Error --></value>
+        <value>Erreur</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Error --></value>
+        <value>Erreurs</value>
     </caseValues>
     <fields>
         <help>S&apos;il est connu, contexte dans lequel l&apos;erreur a été générée.</help>
@@ -53,7 +53,7 @@
         <label>Trace de la pile</label>
         <name>Stack_Trace__c</name>
     </fields>
-    <gender><!-- Masculine --></gender>
+    <gender>Feminine</gender>
     <nameFieldLabel><!-- Error Number --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <startsWith>Vowel</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Error__c-fr.objectTranslation
+++ b/src/objectTranslations/Error__c-fr.objectTranslation
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Error --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Error --></value>
+    </caseValues>
+    <fields>
+        <help>S&apos;il est connu, contexte dans lequel l&apos;erreur a été générée.</help>
+        <label>Type de contexte</label>
+        <name>Context_Type__c</name>
+    </fields>
+    <fields>
+        <help>Date et heure auxquelles l’erreur s’est produite</help>
+        <label>Date et heure</label>
+        <name>Datetime__c</name>
+    </fields>
+    <fields>
+        <help>Indique si une notification par e-mail concernant cette erreur a été envoyée.</help>
+        <label>E-mail envoyé</label>
+        <name>Email_Sent__c</name>
+    </fields>
+    <fields>
+        <help>Type de l’erreur qui s&apos;est produite</help>
+        <label>Type d’erreur</label>
+        <name>Error_Type__c</name>
+    </fields>
+    <fields>
+        <help>Texte complet du message d’erreur</help>
+        <label>Message complet</label>
+        <name>Full_Message__c</name>
+    </fields>
+    <fields>
+        <help>S&apos;il est connu, type de l’objet sur lequel l’erreur s’est produite.</help>
+        <label>Type d’objet</label>
+        <name>Object_Type__c</name>
+    </fields>
+    <fields>
+        <help>Indique si l’erreur a été publiée dans Chatter.</help>
+        <label>Publiée dans Chatter</label>
+        <name>Posted_in_Chatter__c</name>
+    </fields>
+    <fields>
+        <help>S&apos;il est disponible, lien vers l’enregistrement qui a entraîné l’erreur.</help>
+        <label>URL de l’enregistrement</label>
+        <name>Record_URL__c</name>
+    </fields>
+    <fields>
+        <help>Trace de la pile de l’erreur déclenchée, si elle disponible à l&apos;exécution.</help>
+        <label>Trace de la pile</label>
+        <name>Stack_Trace__c</name>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <nameFieldLabel><!-- Error Number --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Hierarchy_Settings__c-fr.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-fr.objectTranslation
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Hierarchy Settings --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Hierarchy Settings --></value>
+    </caseValues>
+    <fields>
+        <help>Définit le modèle de compte. Doit correspondre à « Individuel ». Remplace le champ personnalisé Contact.SystemAccountProcessor__c.</help>
+        <label>Processeur de compte</label>
+        <name>Account_Processor__c</name>
+    </fields>
+    <fields>
+        <help>Type d&apos;enregistrement des comptes dans lesquels plusieurs adresses doivent être activées.</help>
+        <label>Comptes à adresses multiples</label>
+        <name>Accounts_Addresses_Enabled__c</name>
+    </fields>
+    <fields>
+        <help>Type d&apos;enregistrement des comptes qui doivent être supprimés si tous les contacts enfants ont été supprimés.</help>
+        <label>Comptes à supprimer</label>
+        <name>Accounts_to_Delete__c</name>
+    </fields>
+    <fields>
+        <help>Statut d&apos;une affiliation lors de la suppression de l&apos;inscription au programme associé. Si cette option est sélectionnée, l&apos;affiliation n&apos;est pas supprimée, mais son statut change.</help>
+        <label>Statut affil. suppr. inscription progr.</label>
+        <name>Affl_ProgEnroll_Del_Status__c</name>
+    </fields>
+    <fields>
+        <help>Détermine si une affiliation est automatiquement supprimée lorsque l&apos;inscription au programme associé est supprimée, sinon le statut change en Ancien.</help>
+        <label>Suppr. affiliation inscription programme</label>
+        <name>Affl_ProgEnroll_Del__c</name>
+    </fields>
+    <fields>
+        <help>Les relations automatiquement créées sont dédupliquées pour empêcher la création d’enregistrements Relation en double entre deux contacts. Cochez cette case pour désactiver ce comportement et autoriser plusieurs relations de même type entre deux contacts</help>
+        <label>Autoriser rel. dupliquées auto. créées</label>
+        <name>Allow_AutoCreated_Duplicates__c</name>
+    </fields>
+    <fields>
+        <label>Dernière exé. vérif. erreur asynchrone</label>
+        <name>Async_Error_Check_Last_Run__c</name>
+    </fields>
+    <fields>
+        <help>Support gestion adresses des contacts.</help>
+        <label>Support gestion adresses des contacts.</label>
+        <name>Contacts_Addresses_Enabled__c</name>
+    </fields>
+    <fields>
+        <help>Si cette case est cochée, l&apos;infrastructure de gestion des erreurs de l&apos;architecture HEDA est désactivée.</help>
+        <label>Désactiver la gestion des erreurs</label>
+        <name>Disable_Error_Handling__c</name>
+    </fields>
+    <fields>
+        <help>Sélectionnez cette case afin de désactiver l&apos;application du champ Adresse e-mail préférée pour les contacts.</help>
+        <label>Désactiver application e-mail préféré</label>
+        <name>Disable_Preferred_Email_Enforcement__c</name>
+    </fields>
+    <fields>
+        <label>Activer les connexions aux cours</label>
+        <name>Enable_Course_Connections__c</name>
+    </fields>
+    <fields>
+        <help>Cochez cette case pour activer les instructions de débogage dans le code du package géré.</help>
+        <label>Activer le débogage</label>
+        <name>Enable_Debug__c</name>
+    </fields>
+    <fields>
+        <help>Cochez cette case si vous souhaitez que le système publie des notifications pour certains types d’erreur.</help>
+        <label>Notifications d’erreur</label>
+        <name>Error_Notifications_On__c</name>
+    </fields>
+    <fields>
+        <help>Sélectionnez le type d’utilisateur auquel les notifications sont envoyées.</help>
+        <label>Destinataires des notifications d’erreur</label>
+        <name>Error_Notifications_To__c</name>
+    </fields>
+    <fields>
+        <label>Type d&apos;enregistrement de professeur</label>
+        <name>Faculty_RecType__c</name>
+    </fields>
+    <fields>
+        <help>Type d&apos;enregistrement de compte qui prend en charge le comportement des adresses du foyer.</help>
+        <label>Type enregistr. compte adresses du foyer</label>
+        <name>Household_Addresses_RecType__c</name>
+    </fields>
+    <fields>
+        <help>Détermine la méthode de génération de la relation réciproque. Elle correspond à un paramètre de liste qui utilise des paramètres personnalisés par sexe ou à une inversion de valeur (de « Parent-Enfant » à « Enfant-Parent »)</help>
+        <label>Méthode de réciprocité</label>
+        <name>Reciprocal_Method__c</name>
+    </fields>
+    <fields>
+        <help>Si cette valeur est renseignée, le champ est prérempli lors de la création de relations depuis le visualiseur de relations (pour en savoir plus, reportez-vous à la description)</help>
+        <label>ID du champ Nom de la relation</label>
+        <name>Relationship_Name_Field_Id__c</name>
+    </fields>
+    <fields>
+        <help>Si cette valeur est renseignée, le champ est prérempli lors de la création de relations depuis le visualiseur de relations (pour en savoir plus, reportez-vous à la description)</help>
+        <label>ID du champ ID de nom de la relation</label>
+        <name>Relationship_Name_Id_Field_Id__c</name>
+    </fields>
+    <fields>
+        <help>Si cette case est cochée, les modifications d’un champ d’adresse d’un contact ou d’un compte entraînent la mise à jour de l’adresse existante, au lieu de créer une autre adresse.</help>
+        <label>Modif. adresse traitée comme mise à jour</label>
+        <name>Simple_Address_Change_Treated_as_Update__c</name>
+    </fields>
+    <fields>
+        <help>Cochez cette case si vous souhaitez enregistrer les erreurs dans la base de données.</help>
+        <label>Enregistrer les erreurs</label>
+        <name>Store_Errors_On__c</name>
+    </fields>
+    <fields>
+        <label>Type d&apos;enregistrement d&apos;étudiant</label>
+        <name>Student_RecType__c</name>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Program_Enrollment__c-fr.objectTranslation
+++ b/src/objectTranslations/Program_Enrollment__c-fr.objectTranslation
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Program Enrollment --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Program Enrollment --></value>
+    </caseValues>
+    <fields>
+        <help>Le programme auquel l&apos;étudiant est inscrit.</help>
+        <label>Programme</label>
+        <name>Account__c</name>
+        <relationshipLabel>Inscriptions au programme</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Date d&apos;admission</label>
+        <name>Admission_Date__c</name>
+    </fields>
+    <fields>
+        <help>La relation contact-compte à laquelle cette information académique est associée.</help>
+        <label><!-- Affiliation --></label>
+        <name>Affiliation__c</name>
+        <relationshipLabel>Inscriptions au programme</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Date de soumission de la candidature</label>
+        <name>Application_Submitted_Date__c</name>
+    </fields>
+    <fields>
+        <label>Année d&apos;étude</label>
+        <name>Class_Standing__c</name>
+        <picklistValues>
+            <masterLabel>Freshman</masterLabel>
+            <translation>Première année</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Junior</masterLabel>
+            <translation>Troisième année</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Senior</masterLabel>
+            <translation>Quatrième année</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Sophomore</masterLabel>
+            <translation>Deuxième année</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Le contact parent.</help>
+        <label><!-- Contact --></label>
+        <name>Contact__c</name>
+        <relationshipLabel>Inscriptions au programme</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Crédits tentés</label>
+        <name>Credits_Attempted__c</name>
+    </fields>
+    <fields>
+        <label>Crédits gagnés</label>
+        <name>Credits_Earned__c</name>
+    </fields>
+    <fields>
+        <label>Éligible à l&apos;inscription</label>
+        <name>Eligible_to_Enroll__c</name>
+    </fields>
+    <fields>
+        <label>Date de fin</label>
+        <name>End_Date__c</name>
+    </fields>
+    <fields>
+        <label>Statut d&apos;inscription</label>
+        <name>Enrollment_Status__c</name>
+        <picklistValues>
+            <masterLabel>Full-time</masterLabel>
+            <translation>Temps complet</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Half-time</masterLabel>
+            <translation>Mi-temps</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Less than half-time</masterLabel>
+            <translation>Inférieur à mi-temps</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label>Moyenne générale</label>
+        <name>GPA__c</name>
+    </fields>
+    <fields>
+        <label>Année de la classe</label>
+        <name>Graduation_Year__c</name>
+    </fields>
+    <fields>
+        <label>Date de début</label>
+        <name>Start_Date__c</name>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <layouts>
+        <layout>HEDA Program Enrollment Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Program Enrollment ID --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Program_Enrollment__c-fr.objectTranslation
+++ b/src/objectTranslations/Program_Enrollment__c-fr.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Program Enrollment --></value>
+        <value>Inscription au programme</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Program Enrollment --></value>
+        <value>Inscriptions au programme</value>
     </caseValues>
     <fields>
         <help>Le programme auquel l&apos;étudiant est inscrit.</help>
@@ -98,7 +98,7 @@
         <label>Date de début</label>
         <name>Start_Date__c</name>
     </fields>
-    <gender><!-- Masculine --></gender>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Program Enrollment Layout</layout>
         <sections>
@@ -107,5 +107,5 @@
         </sections>
     </layouts>
     <nameFieldLabel><!-- Program Enrollment ID --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <startsWith>Vowel</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Relationship_Auto_Create__c-fr.objectTranslation
+++ b/src/objectTranslations/Relationship_Auto_Create__c-fr.objectTranslation
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Relationship Auto-Create --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Relationship Auto-Create --></value>
+    </caseValues>
+    <fields>
+        <help>Types de campagne éligibles pour cette création automatique de membres de campagne (reste vide pour la création automatique de contacts)</help>
+        <label>Types de campagne</label>
+        <name>Campaign_Types__c</name>
+    </fields>
+    <fields>
+        <help>L’insertion ou la modification de champ qui déclenche la création de cette relation</help>
+        <label>Champ</label>
+        <name>Field__c</name>
+    </fields>
+    <fields>
+        <help>L’objet auquel cette relation automatique est associée</help>
+        <label>Objet</label>
+        <name>Object__c</name>
+    </fields>
+    <fields>
+        <help>Le type de relation à créer entre l’objet de base et l’objet lié. L’objet lié reçoit la relation réciproque, si elle disponible.</help>
+        <label>Type de relation</label>
+        <name>Relationship_Type__c</name>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Relationship_Lookup__c-fr.objectTranslation
+++ b/src/objectTranslations/Relationship_Lookup__c-fr.objectTranslation
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Relationship Lookup --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Relationship Lookup --></value>
+    </caseValues>
+    <fields>
+        <help>Indique si ce lien réciproque est actif.</help>
+        <label>Actif</label>
+        <name>Active__c</name>
+    </fields>
+    <fields>
+        <help>La valeur utilisée par le champ de sexe du contact correspond aux valeurs de l’étiquette personnalisée Féminin, ou la formule de salutation du contact indique le sexe.</help>
+        <label>Féminin</label>
+        <name>Female__c</name>
+    </fields>
+    <fields>
+        <help>La valeur utilisée par le champ de sexe du contact correspond aux valeurs de l’étiquette personnalisée Masculin, ou la formule de salutation du contact indique le sexe.</help>
+        <label>Masculin</label>
+        <name>Male__c</name>
+    </fields>
+    <fields>
+        <help>La valeur utilisée par le champ de sexe de ce contact ne correspond pas aux valeurs des étiquettes personnalisées Féminin ou Masculin, et la formule de salutation du contact n’indique pas le sexe.</help>
+        <label>Neutre</label>
+        <name>Neutral__c</name>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Relationship__c-fr.objectTranslation
+++ b/src/objectTranslations/Relationship__c-fr.objectTranslation
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Relationship --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Relationship --></value>
+    </caseValues>
+    <fields>
+        <help>Le contact associé est le ______ de ce contact.</help>
+        <label><!-- Contact --></label>
+        <name>Contact__c</name>
+        <relationshipLabel>Relations</relationshipLabel>
+    </fields>
+    <fields>
+        <help>Informations supplémentaires sur cette relation</help>
+        <label><!-- Description --></label>
+        <name>Description__c</name>
+    </fields>
+    <fields>
+        <help>Contact à utiliser en cas d&apos;urgence.</help>
+        <label>Contact d&apos;urgence</label>
+        <name>Emergency_Contact__c</name>
+    </fields>
+    <fields>
+        <help>Champ système qui relie les deux côtés d’une relation. Ce champ ne doit pas être modifié directement. La relation réciproque est de type opposé à cette relation, si le type existe.</help>
+        <label>Relation réciproque</label>
+        <name>ReciprocalRelationship__c</name>
+        <relationshipLabel>Relations</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Contact associé</label>
+        <name>RelatedContact__c</name>
+        <relationshipLabel>Liste des relations masquées</relationshipLabel>
+    </fields>
+    <fields>
+        <help>Formule de texte qui construit une phrase expliquant la relation entre les deux contacts</help>
+        <label>Explication de la relation</label>
+        <name>Relationship_Explanation__c</name>
+    </fields>
+    <fields>
+        <help>Champ système qui indique si cette relation a été automatiquement créée en tant que relation réciproque d’une autre relation.</help>
+        <label><!-- _SYSTEM: SystemCreated --></label>
+        <name>SYSTEM_SystemCreated__c</name>
+    </fields>
+    <fields>
+        <help>Statut de la relation.</help>
+        <label>Statut</label>
+        <name>Status__c</name>
+        <picklistValues>
+            <masterLabel>Current</masterLabel>
+            <translation>Actuel</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Former</masterLabel>
+            <translation>Ancien</translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Champ qui décrit comment le contact associé est connecté au contact.</help>
+        <label><!-- Type --></label>
+        <name>Type__c</name>
+        <picklistValues>
+            <masterLabel>Aunt</masterLabel>
+            <translation>Tante</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Child</masterLabel>
+            <translation>Enfant</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Cousin</masterLabel>
+            <translation><!-- Cousin --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Coworker</masterLabel>
+            <translation>Collègue</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Daughter</masterLabel>
+            <translation>Fille</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Employee</masterLabel>
+            <translation>Employé</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Employer</masterLabel>
+            <translation>Employeur</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Family</masterLabel>
+            <translation>Famille</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Father</masterLabel>
+            <translation>Père</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Friend</masterLabel>
+            <translation>Ami</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grandchild</masterLabel>
+            <translation>Petit-enfant</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Granddaughter</masterLabel>
+            <translation>Petite-fille</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grandfather</masterLabel>
+            <translation>Grand-père</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grandmother</masterLabel>
+            <translation>Grand-mère</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grandparent</masterLabel>
+            <translation>Grand-parent</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Grandson</masterLabel>
+            <translation>Petit-fils</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Husband</masterLabel>
+            <translation>Mari</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mother</masterLabel>
+            <translation>Mère</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Parent</masterLabel>
+            <translation><!-- Parent --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Partner</masterLabel>
+            <translation>Partenaire</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Son</masterLabel>
+            <translation>Fils</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Uncle</masterLabel>
+            <translation>Oncle</translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Wife</masterLabel>
+            <translation>Épouse</translation>
+        </picklistValues>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <layouts>
+        <layout>HEDA Relationship Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+        <sections>
+            <label>Informations de relation</label>
+            <section>Relationship Information</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Relationship Key --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+    <validationRules>
+        <errorMessage>Au lieu de modifier les contacts d’une relation existante, supprimez cette relation et créez une autre relation entre les nouveaux contacts.</errorMessage>
+        <name>Related_Contact_Do_Not_Change</name>
+    </validationRules>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Relationship__c-fr.objectTranslation
+++ b/src/objectTranslations/Relationship__c-fr.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Relationship --></value>
+        <value>Relation</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Relationship --></value>
+        <value>Relations</value>
     </caseValues>
     <fields>
         <help>Le contact associé est le ______ de ce contact.</help>
@@ -155,7 +155,7 @@
             <translation>Épouse</translation>
         </picklistValues>
     </fields>
-    <gender><!-- Masculine --></gender>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Relationship Layout</layout>
         <sections>
@@ -168,7 +168,7 @@
         </sections>
     </layouts>
     <nameFieldLabel><!-- Relationship Key --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <startsWith>Consonant</startsWith>
     <validationRules>
         <errorMessage>Au lieu de modifier les contacts d’une relation existante, supprimez cette relation et créez une autre relation entre les nouveaux contacts.</errorMessage>
         <name>Related_Contact_Do_Not_Change</name>

--- a/src/objectTranslations/Term__c-fr.objectTranslation
+++ b/src/objectTranslations/Term__c-fr.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Term --></value>
+        <value>Durée</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Term --></value>
+        <value>Durées</value>
     </caseValues>
     <fields>
         <label>Compte</label>
@@ -21,7 +21,7 @@
         <label>Date de début</label>
         <name>Start_Date__c</name>
     </fields>
-    <gender><!-- Masculine --></gender>
+    <gender>Feminine</gender>
     <layouts>
         <layout>HEDA Term Layout</layout>
         <sections>
@@ -29,6 +29,6 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <nameFieldLabel><!-- Term Name --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <nameFieldLabel>Nom de la durée</nameFieldLabel>
+    <startsWith>Consonant</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Term__c-fr.objectTranslation
+++ b/src/objectTranslations/Term__c-fr.objectTranslation
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Term --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Term --></value>
+    </caseValues>
+    <fields>
+        <label>Compte</label>
+        <name>Account__c</name>
+        <relationshipLabel>Durée</relationshipLabel>
+    </fields>
+    <fields>
+        <label>Date de fin</label>
+        <name>End_Date__c</name>
+    </fields>
+    <fields>
+        <label>Date de début</label>
+        <name>Start_Date__c</name>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <layouts>
+        <layout>HEDA Term Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Term Name --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Trigger_Handler__c-fr.objectTranslation
+++ b/src/objectTranslations/Trigger_Handler__c-fr.objectTranslation
@@ -2,11 +2,11 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Trigger Handler --></value>
+        <value>Gestionnaire de déclencheur</value>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Trigger Handler --></value>
+        <value>Gestionnaires de déclencheurs</value>
     </caseValues>
     <fields>
         <help>Indique que ce module est actif</help>
@@ -90,7 +90,7 @@
         <label><!-- Usernames to Exclude --></label>
         <name>Usernames_to_Exclude__c</name>
     </fields>
-    <gender><!-- Masculine --></gender>
+    <gender>Masculine</gender>
     <layouts>
         <layout>HEDA Trigger Handler Layout</layout>
         <sections>
@@ -98,6 +98,6 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <nameFieldLabel><!-- Trigger Handler Name --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <nameFieldLabel>Nom du gestionnaire de déclencheur</nameFieldLabel>
+    <startsWith>Consonant</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Trigger_Handler__c-fr.objectTranslation
+++ b/src/objectTranslations/Trigger_Handler__c-fr.objectTranslation
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Trigger Handler --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Trigger Handler --></value>
+    </caseValues>
+    <fields>
+        <help>Indique que ce module est actif</help>
+        <label>Actif</label>
+        <name>Active__c</name>
+    </fields>
+    <fields>
+        <help>Indique que ce module doit être exécuté de façon asynchrone dans cette transaction</help>
+        <label>Asynchrone</label>
+        <name>Asynchronous__c</name>
+    </fields>
+    <fields>
+        <help>Nom de la classe à exécuter</help>
+        <label>Classe</label>
+        <name>Class__c</name>
+    </fields>
+    <fields>
+        <help>Nom du champ utilisé pour le filtrage.</help>
+        <label>Champ de filtrage</label>
+        <name>Filter_Field__c</name>
+    </fields>
+    <fields>
+        <help>Valeur du champ utilisé pour le filtrage.</help>
+        <label>Valeur de filtrage</label>
+        <name>Filter_Value__c</name>
+    </fields>
+    <fields>
+        <help>Ordre dans lequel ce module doit être exécuté. Aide à maintenir les dépendances dans les modules et les données.</help>
+        <label>Ordre de chargement</label>
+        <name>Load_Order__c</name>
+    </fields>
+    <fields>
+        <help>Nom de l’objet pour lequel ce gestionnaire doit être exécuté</help>
+        <label>Objet</label>
+        <name>Object__c</name>
+    </fields>
+    <fields>
+        <label>Propriété par espace de noms</label>
+        <name>Owned_by_Namespace__c</name>
+    </fields>
+    <fields>
+        <help>Action dans laquelle ce module doit être déclenché</help>
+        <label>Action de déclencheur</label>
+        <name>Trigger_Action__c</name>
+        <picklistValues>
+            <masterLabel>AfterDelete</masterLabel>
+            <translation><!-- AfterDelete --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>AfterInsert</masterLabel>
+            <translation><!-- AfterInsert --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>AfterUndelete</masterLabel>
+            <translation><!-- AfterUndelete --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>AfterUpdate</masterLabel>
+            <translation><!-- AfterUpdate --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>BeforeDelete</masterLabel>
+            <translation><!-- BeforeDelete --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>BeforeInsert</masterLabel>
+            <translation><!-- BeforeInsert --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>BeforeUpdate</masterLabel>
+            <translation><!-- BeforeUpdate --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help>Cochez cette case si vous comptez gérer l’enregistrement vous-même. Notez que les mises à jour du package ne mettent pas à jour l’enregistrement.</help>
+        <label>Géré par l&apos;utilisateur</label>
+        <name>User_Managed__c</name>
+    </fields>
+    <fields>
+        <help><!-- Semicolon separated list of Salesforce usernames that this trigger will NOT run for. Leave blank to run for all users. --></help>
+        <label><!-- Usernames to Exclude --></label>
+        <name>Usernames_to_Exclude__c</name>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <layouts>
+        <layout>HEDA Trigger Handler Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Trigger Handler Name --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/package.xml
+++ b/src/package.xml
@@ -517,35 +517,51 @@
     </types>
     <types>
         <members>Account-es</members>
+        <members>Account-fr</members>
         <members>Address__c-en_US</members>
         <members>Address__c-es</members>
+        <members>Address__c-fr</members>
         <members>Affiliation__c-en_US</members>
         <members>Affiliation__c-es</members>
+        <members>Affiliation__c-fr</members>
         <members>Affl_Mappings__c-en_US</members>
         <members>Affl_Mappings__c-es</members>
+        <members>Affl_Mappings__c-fr</members>
         <members>Contact-es</members>
+        <members>Contact-fr</members>
         <members>Course_Enrollment__c-en_US</members>
         <members>Course_Enrollment__c-es</members>
+        <members>Course_Enrollment__c-fr</members>
         <members>Course_Offering__c-en_US</members>
         <members>Course_Offering__c-es</members>
+        <members>Course_Offering__c-fr</members>
         <members>Course__c-en_US</members>
         <members>Course__c-es</members>
+        <members>Course__c-fr</members>
         <members>Error__c-en_US</members>
         <members>Error__c-es</members>
+        <members>Error__c-fr</members>
         <members>Hierarchy_Settings__c-en_US</members>
         <members>Hierarchy_Settings__c-es</members>
+        <members>Hierarchy_Settings__c-fr</members>
         <members>Program_Enrollment__c-en_US</members>
         <members>Program_Enrollment__c-es</members>
+        <members>Program_Enrollment__c-fr</members>
         <members>Relationship_Auto_Create__c-en_US</members>
         <members>Relationship_Auto_Create__c-es</members>
+        <members>Relationship_Auto_Create__c-fr</members>
         <members>Relationship_Lookup__c-en_US</members>
         <members>Relationship_Lookup__c-es</members>
+        <members>Relationship_Lookup__c-fr</members>
         <members>Relationship__c-en_US</members>
         <members>Relationship__c-es</members>
+        <members>Relationship__c-fr</members>
         <members>Term__c-en_US</members>
         <members>Term__c-es</members>
+        <members>Term__c-fr</members>
         <members>Trigger_Handler__c-en_US</members>
         <members>Trigger_Handler__c-es</members>
+        <members>Trigger_Handler__c-fr</members>
         <name>CustomObjectTranslation</name>
     </types>
     <types>
@@ -592,6 +608,7 @@
     </types>
     <types>
         <members>es</members>
+        <members>fr</members>
         <name>Translations</name>
     </types>
     <types>

--- a/src/translations/fr.translation
+++ b/src/translations/fr.translation
@@ -1,0 +1,623 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Translations xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customApplications>
+        <label><!-- HEDA --></label>
+        <name>HEDA</name>
+    </customApplications>
+    <customLabels>
+        <label>Les affiliations principales mappées sont affichées dans une section spéciale Affiliations principales de l&apos;enregistrement Contact. La valeur définie en tant que Principal pour le Type d&apos;enregistrement du compte est affichée dans les champs correspondants de l&apos;enregistrement Contact, comme suit. Pour plus d&apos;informations, reportez-vous à</label>
+        <name>AfflMappingsDescription</name>
+    </customLabels>
+    <customLabels>
+        <label>Lors de la suppression d&apos;une inscription à un programme, supprimez l&apos;affiliation associée.</label>
+        <name>AfflProgEnrollDeleted</name>
+    </customLabels>
+    <customLabels>
+        <label>Les paramètres de validité de création automatique de relations sont introuvables. Vérifiez les paramètres de validité des champs sous Paramètres HEDA | Relations | Création automatique, puis réessayez.</label>
+        <name>AutoCreateFieldError</name>
+    </customLabels>
+    <customLabels>
+        <label>Définissez Champ de filtrage, ou Champ de filtrage et Valeur de filtrage.</label>
+        <name>BothFieldAndValue</name>
+    </customLabels>
+    <customLabels>
+        <label>Impossible de supprimer l&apos;enregistrement, car des enregistrements enfants existent. Supprimez d&apos;abord les enregistrements enfants.</label>
+        <name>CannotDelete</name>
+    </customLabels>
+    <customLabels>
+        <label>Compte</label>
+        <name>DefaultAccountName</name>
+    </customLabels>
+    <customLabels>
+        <label>Compte administratif</label>
+        <name>DefaultAdminName</name>
+    </customLabels>
+    <customLabels>
+        <label>Foyer</label>
+        <name>DefaultHouseholdName</name>
+    </customLabels>
+    <customLabels>
+        <label>Féminin</label>
+        <name>Female</name>
+    </customLabels>
+    <customLabels>
+        <label>Valeur de champ de filtrage non valide définie pour </label>
+        <name>InvalidFilter</name>
+    </customLabels>
+    <customLabels>
+        <label>Masculin</label>
+        <name>Male</name>
+    </customLabels>
+    <customLabels>
+        <label>L&apos;e-mail spécifié dans Adresse e-mail préférée est introuvable. Assurez-vous de saisir l&apos;étiquette d&apos;un champ d&apos;adresse e-mail personnalisé existant.</label>
+        <name>PreferredEmailMatchMustExist</name>
+    </customLabels>
+    <customLabels>
+        <label>L&apos;e-mail sélectionné pour Adresse e-mail préférée ne peut pas être vide.</label>
+        <name>PreferredEmailMatchNotNull</name>
+    </customLabels>
+    <customLabels>
+        <label>Indiquez l&apos;adresse e-mail préférée.</label>
+        <name>PreferredEmailRequiredError</name>
+    </customLabels>
+    <customLabels>
+        <label>est</label>
+        <name>Relationship_Explanation_Connector</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Relationship Split --></label>
+        <name>Relationship_Split</name>
+    </customLabels>
+    <customLabels>
+        <label>Les relations automatiques permettent d&apos;identifier vos propres champs personnalisés dans les objets Contact ou Membre de campagne qui déclenchent la création du type de relation de votre choix. Par exemple une référence « Référent » entre un Membre de campagne et un Contact peut créer des relations « Référent » et « Référé » entre les deux Contacts (notez que cette fonctionnalité n&apos;est pas disponible pour les objets Pistes ou Membre de campagne qui référencent des Pistes).</label>
+        <name>RelationshipsAutoDescription</name>
+    </customLabels>
+    <customLabels>
+        <label>Ces paramètres permettent de configurer des relations réciproques ou la relation « correspondante » entre deux Contacts. Par exemple, si un père est associé à son fils, le fils doit de la même façon être associé à son père. Vous pouvez spécifier la valeur Type du Nom, puis la valeur réciproque en fonction du sexe du Contact à connecter. Vous pouvez définir une réciprocité masculine, une réciprocité féminine, et une réciprocité neutre utilisée lorsque le sexe ne peut pas être déterminé.</label>
+        <name>RelationshipsLookupDescription</name>
+    </customLabels>
+    <customLabels>
+        <label>Les enregistrements d&apos;adresse doivent être créés uniquement en tant qu&apos;enfants de Compte ou Contact.</label>
+        <name>addrHhAdmAccountOnly</name>
+    </customLabels>
+    <customLabels>
+        <label>La possibilité d&apos;ajouter plusieurs adresses est désactivée pour ce type d&apos;enregistrement Compte. Pour l&apos;activer, accédez à Paramètres HEDA, cliquez sur Comptes et Contacts, puis sélectionnez la case appropriée en regard de Types de compte avec plusieurs adresses activés.</label>
+        <name>addrNotEnabledAccount</name>
+    </customLabels>
+    <customLabels>
+        <label>La possibilité d&apos;ajouter plusieurs adresses est désactivée pour les Contacts. Pour l&apos;activer, accédez à Paramètres HEDA, cliquez sur Comptes et Contacts, puis sélectionnez la case en regard de Contacts avec plusieurs adresses activés.</label>
+        <name>addrNotEnabledContact</name>
+    </customLabels>
+    <customLabels>
+        <label>Les plages de dates des adresses saisonnières ne peuvent pas se superposer.</label>
+        <name>addrSeasonalOverlap</name>
+    </customLabels>
+    <customLabels>
+        <label>Tous les champs de début et de fin du jour et du mois d&apos;une adresse doivent être définis ou aucun ne doit être défini.</label>
+        <name>addrSeasonalPartial</name>
+    </customLabels>
+    <customLabels>
+        <label>Une adresse doit avoir une année de début et une année de fin définies ou aucune année définie.</label>
+        <name>addrSeasonalPartialYear</name>
+    </customLabels>
+    <customLabels>
+        <label>Les enregistrements d&apos;adresse doivent être créés uniquement en tant qu&apos;enfants de Compte ou Contact.</label>
+        <name>addrValidParentObjects</name>
+    </customLabels>
+    <customLabels>
+        <label>Le type d&apos;enregistrement de compte {0} n&apos;existe pas. Demandez à votre administrateur de vérifier les types d&apos;enregistrement dans les mappages d&apos;affiliation.</label>
+        <name>afflNullPointerError</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Error message for TDTM filtering functionality. --></label>
+        <name>duplicateFieldInFilter</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Error message for TDTM filtering functionality. --></label>
+        <name>duplicateWithHEDAField</name>
+    </customLabels>
+    <customLabels>
+        <label>Un champ obligatoire n&apos;est pas défini. Ce champ peut se situer dans cet enregistrement ou dans un enregistrement associé.</label>
+        <name>exceptionRequiredField</name>
+    </customLabels>
+    <customLabels>
+        <label>Une règle de validation empêche le traitement de l&apos;enregistrement. Cette règle peut se situer dans cet enregistrement, ou dans un enregistrement associé en cours de mise à jour. MESSAGE DE VALIDATION :</label>
+        <name>exceptionValidationRule</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Error message for TDTM filtering functionality. --></label>
+        <name>fieldWithHEDANamespace</name>
+    </customLabels>
+    <customLabels>
+        <label>Le type d&apos;enregistrement de compte défini n&apos;existe pas :</label>
+        <name>noAccRecType</name>
+    </customLabels>
+    <customLabels>
+        <label>Aucun mappage d&apos;affiliation à afficher. Essayez d&apos;en créer en utilisant le formulaire ci-dessous.</label>
+        <name>noAfflMappings</name>
+    </customLabels>
+    <customLabels>
+        <label>Aucun paramètre de création automatique à afficher. Essayez d&apos;en créer en utilisant le formulaire ci-dessous.</label>
+        <name>noAutoCreateSettings</name>
+    </customLabels>
+    <customLabels>
+        <label>Aucun paramètre de réciprocité à afficher. Essayez d&apos;en créer en utilisant le formulaire ci-dessous.</label>
+        <name>noRecSettings</name>
+    </customLabels>
+    <customLabels>
+        <label>E-mail (standard)</label>
+        <name>preferredBatchDefaultEmail</name>
+    </customLabels>
+    <customLabels>
+        <label>Modèle de compte par défaut :</label>
+        <name>stgAccModelTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Type d&apos;enregistrement de compte qui prend en charge les adresses de foyer :</label>
+        <name>stgAccountRecordTypeSupportsHHAddress</name>
+    </customLabels>
+    <customLabels>
+        <label>Types de compte avec plusieurs adresses activés :</label>
+        <name>stgAccountTypesMultiAddressesEnabled</name>
+    </customLabels>
+    <customLabels>
+        <label>Types de compte sans contact à supprimer :</label>
+        <name>stgAccoutTypesWithoutContactsDelete</name>
+    </customLabels>
+    <customLabels>
+        <label>Si nécessaire, ajoutez « Hispanique ou Latino-Américain » en tant que valeur de liste de sélection dans le champ Appartenance ethnique.</label>
+        <name>stgAddHispanicOrLatinoPicklistValue</name>
+    </customLabels>
+    <customLabels>
+        <label>Si nécessaire, ajoutez « Non Hispanique ou Latino-Américain » en tant que valeur de liste de sélection dans le champ Appartenance ethnique.</label>
+        <name>stgAddNotHispanicOrLatinoPicklistValue</name>
+    </customLabels>
+    <customLabels>
+        <label>Après avoir exécuté le remplissage :</label>
+        <name>stgAfterRunBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Saisissez le nom du groupe Chatter à rechercher</label>
+        <name>stgAutoCompleteEnterChatterGroupName</name>
+    </customLabels>
+    <customLabels>
+        <label>Saisissez le nom de l&apos;utilisateur à rechercher</label>
+        <name>stgAutoCompleteEnterUserName</name>
+    </customLabels>
+    <customLabels>
+        <label>Sélectionner un groupe Chatter</label>
+        <name>stgAutoCompleteSelectChatterGroup</name>
+    </customLabels>
+    <customLabels>
+        <label>Sélectionner un utilisateur</label>
+        <name>stgAutoCompleteSelectUser</name>
+    </customLabels>
+    <customLabels>
+        <label>Inscription automatique</label>
+        <name>stgAutoEnrollment</name>
+    </customLabels>
+    <customLabels>
+        <label>Rôle d&apos;inscription automatique</label>
+        <name>stgAutoEnrollmentRole</name>
+    </customLabels>
+    <customLabels>
+        <label>Statut d&apos;inscription automatique</label>
+        <name>stgAutoEnrollmentStatus</name>
+    </customLabels>
+    <customLabels>
+        <label>Le remplissage a été mis en file d&apos;attente avec succès. Un e-mail sera envoyé une fois le lot terminé.</label>
+        <name>stgBackfillQueuedEmailSent</name>
+    </customLabels>
+    <customLabels>
+        <label>Avant d&apos;exécuter le remplissage :</label>
+        <name>stgBeforeRunBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Ajouter un mappage</label>
+        <name>stgBtnAddMapping</name>
+    </customLabels>
+    <customLabels>
+        <label>Ajouter un paramètre</label>
+        <name>stgBtnAddSetting</name>
+    </customLabels>
+    <customLabels>
+        <label>Annuler</label>
+        <name>stgBtnCancel</name>
+    </customLabels>
+    <customLabels>
+        <label>Modifier</label>
+        <name>stgBtnEdit</name>
+    </customLabels>
+    <customLabels>
+        <label>Exécuter le remplissage</label>
+        <name>stgBtnRunBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Exécuter la copie</label>
+        <name>stgBtnRunCopy</name>
+    </customLabels>
+    <customLabels>
+        <label>Enregistrer</label>
+        <name>stgBtnSave</name>
+    </customLabels>
+    <customLabels>
+        <label>Le nettoyage a été mis en file d&apos;attente avec succès. Un e-mail sera envoyé une fois le lot terminé.</label>
+        <name>stgCleanupQueuedEmailSent</name>
+    </customLabels>
+    <customLabels>
+        <label>Type d&apos;enregistrement de compte</label>
+        <name>stgColAccountRecordType</name>
+    </customLabels>
+    <customLabels>
+        <label>Actif</label>
+        <name>stgColActive</name>
+    </customLabels>
+    <customLabels>
+        <label>Types de campagne</label>
+        <name>stgColCampTypes</name>
+    </customLabels>
+    <customLabels>
+        <label>Champ d&apos;affiliation principal du contact</label>
+        <name>stgColContactPrimaryAfflField</name>
+    </customLabels>
+    <customLabels>
+        <label>Féminin</label>
+        <name>stgColFemale</name>
+    </customLabels>
+    <customLabels>
+        <label>Champ</label>
+        <name>stgColField</name>
+    </customLabels>
+    <customLabels>
+        <label>Masculin</label>
+        <name>stgColMale</name>
+    </customLabels>
+    <customLabels>
+        <label>Neutre</label>
+        <name>stgColNeutral</name>
+    </customLabels>
+    <customLabels>
+        <label>Objet</label>
+        <name>stgColObject</name>
+    </customLabels>
+    <customLabels>
+        <label>Type de relation</label>
+        <name>stgColRelType</name>
+    </customLabels>
+    <customLabels>
+        <label>Rôle</label>
+        <name>stgColRole</name>
+    </customLabels>
+    <customLabels>
+        <label>Statut</label>
+        <name>stgColStatus</name>
+    </customLabels>
+    <customLabels>
+        <label>Je comprends et je suis prêt(e) à exécuter le remplissage</label>
+        <name>stgConfirmReadyRunBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Contacts avec plusieurs adresses activés :</label>
+        <name>stgContactMultiAddressesEnabled</name>
+    </customLabels>
+    <customLabels>
+        <label>La tâche Apex par lot a traité {0} lots avec {1} échecs.</label>
+        <name>stgCourseDescriptionCopyEmailBody</name>
+    </customLabels>
+    <customLabels>
+        <label>Tâche de copie de la description du cours terminée avec le statut :</label>
+        <name>stgCourseDescriptionCopyEmailSubject</name>
+    </customLabels>
+    <customLabels>
+        <label>Type d&apos;enregistrement de professeur par défaut :</label>
+        <name>stgDefaultFacultyTypeTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Type d&apos;enregistrement d&apos;étudiant actif par défaut :</label>
+        <name>stgDefaultStudentTypeTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Non, changez seulement le statut sur :</label>
+        <name>stgDeleteRelatedAfflNo</name>
+    </customLabels>
+    <customLabels>
+        <label>Oui :</label>
+        <name>stgDeleteRelatedAfflYes</name>
+    </customLabels>
+    <customLabels>
+        <label>Désactiver la gestion des erreurs :</label>
+        <name>stgDisableErrorHandlingTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Désactiver l&apos;application de l&apos;adresse e-mail préférée :</label>
+        <name>stgDisablePreferredEmailEnforcement</name>
+    </customLabels>
+    <customLabels>
+        <label>Activer les connexions aux cours :</label>
+        <name>stgEnableCourseConnectionsTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Notifications d’erreur à :</label>
+        <name>stgErrorNotiTo</name>
+    </customLabels>
+    <customLabels>
+        <label>Destinataires des notifications d’erreur :</label>
+        <name>stgErrorNotifRecipientsTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Remplissage de l&apos;appartenance ethnique et de la race pour les contacts</label>
+        <name>stgEthnicityRaceBackfillContacts</name>
+    </customLabels>
+    <customLabels>
+        <label>Définition du modèle de compte. Le modèle recommandé est « Administratif ».</label>
+        <name>stgHelpAccountModel</name>
+    </customLabels>
+    <customLabels>
+        <label>Le type d&apos;enregistrement des comptes qui seront automatiquement supprimés si tous leurs contacts enfants sont supprimés.</label>
+        <name>stgHelpAccoutsDeletedIfChildContactsDeleted</name>
+    </customLabels>
+    <customLabels>
+        <label>Les types d&apos;enregistrement de compte qui prennent en charge la gestion des adresses multiples.</label>
+        <name>stgHelpAddressAccRecType</name>
+    </customLabels>
+    <customLabels>
+        <label>Sélectionnez cette option pour activer la gestion des adresses multiples pour les contacts.</label>
+        <name>stgHelpContactAddrs</name>
+    </customLabels>
+    <customLabels>
+        <label>Ne pas exiger une adresse e-mail préférée pour les contacts.</label>
+        <name>stgHelpContactPreferredEmail</name>
+    </customLabels>
+    <customLabels>
+        <label>Le processus a été mis en file d&apos;attente avec succès. Un e-mail sera envoyé une fois la tâche terminée.</label>
+        <name>stgHelpCopyQueuedEmailSent</name>
+    </customLabels>
+    <customLabels>
+        <label>Le Remplissage des connexions aux cours doit être utilisé uniquement lors de l&apos;activation initiale des Connexions au cours, et seulement dans les organisations dans lesquelles des Offres de cours et des Connexions aux cours (inscriptions) existaient avant l&apos;activation de la fonctionnalité. Le Remplissage convertit tous les contacts répertoriés en tant que professeurs dans une Connexion au cours (inscription) ou une Offre de cours en Type d&apos;enregistrement de professeur par défaut. Le Remplissage convertit ensuite les Contacts des Connexions aux cours (inscriptions) restantes en Type d&apos;enregistrement d&apos;étudiant actif par défaut.</label>
+        <name>stgHelpCourseConnBackfillDescription</name>
+    </customLabels>
+    <customLabels>
+        <label>Dans HEDA 1.30, le champ Description étendue a été ajouté pour pouvoir saisir des descriptions de cours plus longues.</label>
+        <name>stgHelpCoursesDataMigration</name>
+    </customLabels>
+    <customLabels>
+        <label>Cet utilitaire copie les valeurs du champ Description du cours dans le champ Description étendue. Ce processus peut prendre du temps, mais vous pouvez fermer cette page en toute sécurité, le processus continuera en arrière-plan.</label>
+        <name>stgHelpCoursesDataMigrationCopiesValues</name>
+    </customLabels>
+    <customLabels>
+        <label>Si un cours a déjà une valeur de Description étendue, nous ne la remplaçons pas.</label>
+        <name>stgHelpCoursesDataMigrationDontOverwrite</name>
+    </customLabels>
+    <customLabels>
+        <label>Une fois le processus terminé, pensez à mettre à jour les présentations de page et les autres zones de l&apos;application qui référencent les champs Description.</label>
+        <name>stgHelpCoursesDataMigrationUpdatePageLayouts</name>
+    </customLabels>
+    <customLabels>
+        <label>Le type d&apos;enregistrement par défaut lors de la création de Connexions aux cours pour un membre professeur.</label>
+        <name>stgHelpDefaultFacultyType</name>
+    </customLabels>
+    <customLabels>
+        <label>Le type d&apos;enregistrement par défaut lors de la création de Connexions aux cours pour des étudiants actifs.</label>
+        <name>stgHelpDefaultStudentType</name>
+    </customLabels>
+    <customLabels>
+        <label>Vous devez activer les Connexions aux cours avant d&apos;exécuter le Remplissage des connexions aux cours.</label>
+        <name>stgHelpEnableCourseConnBeforeBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Vous devez activer les Connexions aux cours avant de modifier les types d&apos;enregistrement.</label>
+        <name>stgHelpEnableCourseConnBeforeRecordTypes</name>
+    </customLabels>
+    <customLabels>
+        <label>Les Connexions aux cours associent un contact à une offre de cours. L&apos;activation de cette case permet de choisir la création de la connexion pour un étudiant ou pour un professeur (les deux types d&apos;enregistrement par défaut). Une fois cette case sélectionnée, vous devez définir un Type d&apos;enregistrement d&apos;étudiant actif par défaut et un Type d&apos;enregistrement de professeur par défaut. Si vous activez cette fonctionnalité pour la première fois, il est vivement recommandé d&apos;exécuter le Remplissage dans votre organisation.</label>
+        <name>stgHelpEnableCourseConnections</name>
+    </customLabels>
+    <customLabels>
+        <label>Pour les contacts existants qui n&apos;ont pas spécifié d&apos;adresse e-mail préférée, le processus de nettoyage vérifie qu&apos;une adresse e-mail standard ou personnalisée du contact est définie en tant qu&apos;adresse e-mail préférée.</label>
+        <name>stgHelpEnsureExistContactPreferEmail</name>
+    </customLabels>
+    <customLabels>
+        <label>Si cette case est cochée, l&apos;infrastructure de gestion des erreurs de l&apos;architecture HEDA est désactivée.</label>
+        <name>stgHelpErrorDisable</name>
+    </customLabels>
+    <customLabels>
+        <label>Cochez cette case si vous souhaitez que le système publie des notifications pour certains types d’erreur.</label>
+        <name>stgHelpErrorNotifyOn</name>
+    </customLabels>
+    <customLabels>
+        <label>Vous pouvez envoyer des notifications par e-mail à tous les administrateurs système, à un seul utilisateur ou à un groupe Chatter. Les valeurs valides sont « Tous les administrateurs systèmes, l&apos;ID d&apos;un utilisateur de votre organisation ou l&apos;ID d&apos;un groupe Chatter. Vous ne pouvez saisir qu&apos;une seule valeur.</label>
+        <name>stgHelpErrorNotifyTo</name>
+    </customLabels>
+    <customLabels>
+        <label>Utilisez le Remplissage de l&apos;appartenance ethnique et de la race uniquement si votre organisation a utilisé le champ Appartenance ethnique avant l&apos;ajout du champ Race et le retrait des valeurs du champ Appartenance ethnique dans la version 1.28 d&apos;HEDA. Si la valeur Appartenance ethnique du contact est différente de « Non Hispanique ou Latino-Américain » ou « Hispanique ou Latino-Américain », le Remplissage copie les valeurs dans le champ Race. Les valeurs de liste de sélection standard et toutes les valeurs personnalisées que vous avez ajoutées sont éligibles pour la copie.</label>
+        <name>stgHelpEthnicityRaceBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Cochez cette case pour activer la gestion des adresses de comptes administratifs et de foyer.</label>
+        <name>stgHelpHouseAdmAccountAddressMgmt</name>
+    </customLabels>
+    <customLabels>
+        <label>Le type d&apos;enregistrement Compte qui représente le mieux les foyers. HEDA utilise par défaut le type d&apos;enregistrement Compte de foyer. Vous pouvez toutefois utiliser un autre type d&apos;enregistrement.</label>
+        <name>stgHelpHouseholdRecType</name>
+    </customLabels>
+    <customLabels>
+        <label>Si votre organisation a déjà ajouté au champ Appartenance ethnique des valeurs de liste de sélection personnalisées que vous souhaitez utiliser dans le champ Race, copiez ces valeurs dans le champ Race.</label>
+        <name>stgHelpIfCustomValuesEthnicityCopyRace</name>
+    </customLabels>
+    <customLabels>
+        <label>Cochez cette case pour activer la gestion des adresses de comptes d’organisation.</label>
+        <name>stgHelpOrgAccountAddressMgmt</name>
+    </customLabels>
+    <customLabels>
+        <label>Les relations automatiquement créées sont automatiquement dédupliquées afin d&apos;empêcher la création d’enregistrements de relation en double entre deux contacts. Cochez cette case pour désactiver ce comportement et autoriser plusieurs relations de même type entre deux contacts.</label>
+        <name>stgHelpRelAutoCreatedDup</name>
+    </customLabels>
+    <customLabels>
+        <label>Détermine la méthode de génération de la relation réciproque : soit un paramètre de liste qui utilise des paramètres personnalisés par genre (voir l’onglet de relations réciproques), soit une inversion de valeur (de « Parent-Enfant » à « Enfant-Parent »)</label>
+        <name>stgHelpRelReciprocalMethod</name>
+    </customLabels>
+    <customLabels>
+        <label>Retirez toutes les valeurs de liste de sélection du champ Appartenance ethnique, à l&apos;exception de « Non Hispanique ou Latino-Américain » et « Hispanique ou Latino-Américain ». Nous recommandons de remplacer chaque valeur retirée par l&apos;une des valeurs valides restantes, plutôt que de les supprimer des enregistrements existants. À compter de la version 1.28 d&apos;HEDA, « Non Hispanique ou Latino-Américain » et « Hispanique ou Latino-Américain » sont les seules valeurs d&apos;Appartenance ethnique valides.</label>
+        <name>stgHelpRemoveAllPicklistValuesEthnicityExceptHispanicOrLatino</name>
+    </customLabels>
+    <customLabels>
+        <label>Traite les modifications apportées aux champs d&apos;adresse individuels Contact ou Compte en tant que mises à jour de l&apos;adresse existante (c&apos;est-à-dire, sans créer un autre objet Adresse). Traite également les espaces vides et les modifications des requêtes en tant que mises à jour.</label>
+        <name>stgHelpSimpleAddrChangeIsUpdate</name>
+    </customLabels>
+    <customLabels>
+        <label>Cochez cette case si vous souhaitez enregistrer les erreurs dans la base de données.</label>
+        <name>stgHelpStoreErrorsOn</name>
+    </customLabels>
+    <customLabels>
+        <label>Si vous avez des dépendances aux valeurs antérieures du champ Appartenance ethnique, par exemple dans des rapports, mettez-les à jour.</label>
+        <name>stgHelpUpdateReportIfDependenciesEthnicity</name>
+    </customLabels>
+    <customLabels>
+        <label>Nouveau mappage d&apos;affiliations</label>
+        <name>stgNewAfflMapping</name>
+    </customLabels>
+    <customLabels>
+        <label>Tous les administrateurs système</label>
+        <name>stgOptAllSysAdmins</name>
+    </customLabels>
+    <customLabels>
+        <label>Groupe Chatter</label>
+        <name>stgOptChatterGroup</name>
+    </customLabels>
+    <customLabels>
+        <label>Sélectionnez...</label>
+        <name>stgOptSelect</name>
+    </customLabels>
+    <customLabels>
+        <label>Utilisateur</label>
+        <name>stgOptUser</name>
+    </customLabels>
+    <customLabels>
+        <label>La tâche Apex par lot a traité {0} enregistrements avec {1} échecs.</label>
+        <name>stgPreferredEmailBatchEmailBody</name>
+    </customLabels>
+    <customLabels>
+        <label>Tâche Adresse e-mail préférée terminée avec le statut :</label>
+        <name>stgPreferredEmailBatchEmailSubject</name>
+    </customLabels>
+    <customLabels>
+        <label>Nettoyage des données d&apos;adresse e-mail préférée :</label>
+        <name>stgPreferredEmailDataCleanup</name>
+    </customLabels>
+    <customLabels>
+        <label>Exécutez ce processus de nettoyage de données après l&apos;activation initiale de l&apos;exigence Adresse e-mail préférée ou après une période de non application de l&apos;exigence.</label>
+        <name>stgRunCleanUpEnableFirstTime</name>
+    </customLabels>
+    <customLabels>
+        <label>Sélectionner un type de destinataire</label>
+        <name>stgSelectReciType</name>
+    </customLabels>
+    <customLabels>
+        <label>Envoyer les notifications d&apos;erreur :</label>
+        <name>stgSendErrorsTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Simple modification d’adresse traitée en tant que mise à jour :</label>
+        <name>stgSimpleAddressChangeUpdate</name>
+    </customLabels>
+    <customLabels>
+        <label>Stocker les erreurs :</label>
+        <name>stgStoreErrorsTitle</name>
+    </customLabels>
+    <customLabels>
+        <label>Comptes et contacts</label>
+        <name>stgTabAccCont</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- stgTabAffl --></label>
+        <name>stgTabAffl</name>
+    </customLabels>
+    <customLabels>
+        <label>Mappages d&apos;affiliations</label>
+        <name>stgTabAfflMappings</name>
+    </customLabels>
+    <customLabels>
+        <label>Création automatique</label>
+        <name>stgTabAutocreation</name>
+    </customLabels>
+    <customLabels>
+        <label>Remplissage</label>
+        <name>stgTabBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Cours</label>
+        <name>stgTabCourse</name>
+    </customLabels>
+    <customLabels>
+        <label>Connexions aux cours</label>
+        <name>stgTabCourseConn</name>
+    </customLabels>
+    <customLabels>
+        <label>Nom</label>
+        <name>stgTabName</name>
+    </customLabels>
+    <customLabels>
+        <label>Champ d&apos;affiliation principal</label>
+        <name>stgTabPrimaryAfflField</name>
+    </customLabels>
+    <customLabels>
+        <label>Paramètres de réciprocité</label>
+        <name>stgTabReciprocalSettings</name>
+    </customLabels>
+    <customLabels>
+        <label>Relations</label>
+        <name>stgTabRel</name>
+    </customLabels>
+    <customLabels>
+        <label>Paramètres</label>
+        <name>stgTabSettings</name>
+    </customLabels>
+    <customLabels>
+        <label>Système</label>
+        <name>stgTabSystem</name>
+    </customLabels>
+    <customLabels>
+        <label>Autoriser les relations dupliquées automatiquement créées :</label>
+        <name>stgTitleAllowAutocreatedDuplicateRel</name>
+    </customLabels>
+    <customLabels>
+        <label>Paramètres de l&apos;ensemble de l&apos;application</label>
+        <name>stgTitleAppwideSettings</name>
+    </customLabels>
+    <customLabels>
+        <label>Remplissage de la connexion au cours :</label>
+        <name>stgTitleCourseConnectionBackfill</name>
+    </customLabels>
+    <customLabels>
+        <label>Cours : migration des données de description</label>
+        <name>stgTitleCoursesDescriptionDataMigration</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- stgTitleHEDAConfig --></label>
+        <name>stgTitleHEDAConfig</name>
+    </customLabels>
+    <customLabels>
+        <label>Paramètres HEDA</label>
+        <name>stgTitleHEDASettings</name>
+    </customLabels>
+    <customLabels>
+        <label>Nouveau paramètre de création automatique</label>
+        <name>stgTitleNewAutocreateSetting</name>
+    </customLabels>
+    <customLabels>
+        <label>Nouveau paramètre de réciprocité</label>
+        <name>stgTitleNewReciSetting</name>
+    </customLabels>
+    <customLabels>
+        <label>Méthode de réciprocité :</label>
+        <name>stgTitleReciMethod</name>
+    </customLabels>
+    <customLabels>
+        <label>Erreur</label>
+        <name>stgToastError</name>
+    </customLabels>
+    <customTabs>
+        <label>Paramètres HEDA</label>
+        <name>HEDA_Settings</name>
+    </customTabs>
+</Translations>


### PR DESCRIPTION
# Critical Changes

# Changes
- We're excited to announce that French is now a fully supported language in HEDA. To verify that French is enabled in your org, from Setup, go to Language Settings, and verify that French is listed in the "Displayed Languages" list. You can then change the language for your org or have users change their personal language settings.

# Issues Closed

# New Metadata
Account-fr.objectTranslation
Address__c-fr.objectTranslation
Affiliation__c-fr.objectTranslation
Affl_Mappings__c-fr.objectTranslation
Contact-fr.objectTranslation
Course_Enrollment__c-fr.objectTranslation
Course_Offering__c-fr.objectTranslation
Course__c-fr.objectTranslation
Error__c-fr.objectTranslation
Hierarchy_Settings__c-fr.objectTranslation
Program_Enrollment__c-fr.objectTranslation
Relationship_Auto_Create__c-fr.objectTranslation
Relationship_Lookup__c-fr.objectTranslation
Relationship__c-fr.objectTranslation
Term__c-fr.objectTranslation
Trigger_Handler__c-fr.objectTranslation
fr..translation

# Deleted Metadata

# Testing Notes

To change your language preference in a Salesforce org:
1. In Lightning, click your profile image in the top-right, then "Settings"
2. Select Language & Time Zone in the left menu
3. Update language to "francais"