### PR TITLE
Fixing namespace error on HEDA Settings page when NPSP and HEDA are i…

### DIFF
--- a/src/pages/STG_Settings.page
+++ b/src/pages/STG_Settings.page
@@ -23,8 +23,8 @@
         
         var namespace = '';
         var namespacePrefix = '';
-        //This would work with any class. We are just using the one with the shortest name.
-        var gettingnamespace = sforce.connection.query("SELECT NamespacePrefix FROM ApexClass where Name = 'REL_Utils' LIMIT 1"); 
+        //This should be a class unique to HEDA so the namespace comes through correctly
+        var gettingnamespace = sforce.connection.query("SELECT NamespacePrefix FROM ApexClass where Name = 'CCON_Faculty_TDTM' LIMIT 1"); 
         var getname = gettingnamespace.getArray("records");
 		if(getname.length > 0) { 
 		    namespace = getname[0].NamespacePrefix;


### PR DESCRIPTION
…nstalled in the same org

The issue here was that a query to get the "hed" namespace was using a class name that is also in NPSP, meaning sometimes it returned "npsp", causing the error.

# Critical Changes

# Changes

- In the rare case that NPSP and HEDA are installed in the same org, the HEDA Settings page no longer loads with an error.

# Issues Closed

Fixes #581 

# New Metadata

# Deleted Metadata

# Testing Notes

This one is tricky to test:

1. Setup an org with the managed package version of NPSP, 
2. Next, install the HEDA managed package, including this change, to ensure that both namespaces are being used.
2. Navigate to the HEDA app, then HEDA Settings page.
3. The page should load correctly, with no "internal server error" message.