### PR TITLE
Fix noAutoCreateSettings custom label bug by replacing dynamic custom…

### DIFF
--- a/src/aura/STG_CMP_Rel/STG_CMP_RelHelper.js
+++ b/src/aura/STG_CMP_Rel/STG_CMP_RelHelper.js
@@ -35,7 +35,7 @@
 			if(response.getState() === "SUCCESS") {
 				var settings = response.getReturnValue();
 				if(settings.length === 0) {
-					this.setMessageLabel(component, "v.noAutoCreateSettings", prefix, "noAutoCreateSettings");
+					component.set("v.noAutoCreateSettings", $A.get("$Label.c.noAutoCreateSettings"));
 				}
 				component.set("v.autoCreateSettings", this.removePrefixListSettings(settings, prefix));
 	    	} else if(response.getState() === "ERROR") {


### PR DESCRIPTION
… label referencing with $Label.c.[LabelName]

# Critical Changes

# Changes
Fixes an error occuring in namespaced scratch orgs when clicking on checkboxes of HEDA setting page
# Issues Closed
Fixes 583
# New Metadata

# Deleted Metadata

# Testing Notes
