### PR TITLE
Fixing reparenting affiliation creating duplicate affiliation

### DIFF
--- a/src/classes/AFFL_AccChange_TDTM.cls
+++ b/src/classes/AFFL_AccChange_TDTM.cls
@@ -123,14 +123,18 @@ public with sharing class AFFL_AccChange_TDTM extends TDTM_Runnable {
                        	TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_AccChange_TDTM, true);
                    	}
                    	i++;
+                    //Turn off CON_PrimaryAffls_TDTM_After_Update temporarily to avoid creating duplicate affiliation
+                    TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
                	}
            	}
         }
+
         TDTM_TriggerHandler.processDML(dmlWrapper, true);
         dmlWrapper = null;  
         if(triggerAction == TDTM_Runnable.Action.AfterUpdate)
         {      
           	TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_AccChange_TDTM, false);
+            TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
         }
         return dmlWrapper;
     }

--- a/src/classes/AFFL_ContactAccChange_TEST.cls
+++ b/src/classes/AFFL_ContactAccChange_TEST.cls
@@ -136,6 +136,10 @@ public with sharing class AFFL_ContactAccChange_TEST {
         //Confirm primary field has been updated
         contact = [select Primary_Organization__c from Contact where ID =:contact.ID];
         System.assertEquals(bizOrg2.ID, contact.Primary_Organization__c);
+
+        //Make sure we are not creating duplicate affiliations
+        List<Affiliation__c> affls = [select Id from Affiliation__c];
+        System.assertEquals(1, affls.size());
     }
     
     @isTest
@@ -159,6 +163,10 @@ public with sharing class AFFL_ContactAccChange_TEST {
         contact = [select Primary_Organization__c, Primary_Household__c from Contact where ID =:contact.ID];
         System.assertEquals(null, contact.Primary_Organization__c);
         System.assertEquals(householdOrg1.ID, contact.Primary_Household__c);
+
+        //Make sure we are not creating duplicate affiliations
+        List<Affiliation__c> affls = [select Id from Affiliation__c];
+        System.assertEquals(1, affls.size());
     }
     
     @isTest

--- a/src/classes/AFFL_ContactAccChange_TEST.cls
+++ b/src/classes/AFFL_ContactAccChange_TEST.cls
@@ -98,6 +98,10 @@ public with sharing class AFFL_ContactAccChange_TEST {
         //Confirm Primary Business Organization field has been populated in contact2
         contact2 = [select Primary_Organization__c from Contact where ID =:contact2.ID];
         System.assertEquals(bizAffl1.Account__c, contact2.Primary_Organization__c);
+
+        //Make sure we are not creating duplicate affiliations
+        List<Affiliation__c> affls = [select Id from Affiliation__c];
+        System.assertEquals(1, affls.size());
     }
     
     @isTest

--- a/src/classes/AFFL_ContactChange_TDTM.cls
+++ b/src/classes/AFFL_ContactChange_TDTM.cls
@@ -97,9 +97,11 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 
 	                       //Populate same field in new Contact
 	                       newRelatedContact.put(lookupFieldName, affl.Account__c);
-	                       dmlWrapper.objectsToUpdate.add(newRelatedContact);
+						   TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
+						   dmlWrapper.objectsToUpdate.add(newRelatedContact);
+						   TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated);
 
-	                       //afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
+						   //afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
                            //AFFL_MultiRecordType_TDTM will run after this class, and will take care of that.
 	                   }
 

--- a/src/classes/AFFL_ContactChange_TDTM.cls
+++ b/src/classes/AFFL_ContactChange_TDTM.cls
@@ -110,7 +110,10 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 
 	                       	//Populate same field in new Contact
 	                       	newRelatedContact.put(lookupFieldName, affl.Account__c);
-	                       	dmlWrapper.objectsToUpdate.add(newRelatedContact);
+                            TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
+                            dmlWrapper.objectsToUpdate.add(newRelatedContact);
+                            TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated);
+
 
 	                       	//afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
                            	//AFFL_MultiRecordType_TDTM will run after this class, and will take care of that.

--- a/src/classes/AFFL_ContactChange_TDTM.cls
+++ b/src/classes/AFFL_ContactChange_TDTM.cls
@@ -76,58 +76,55 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
                     }
                 }
 
-                            TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
-                            dmlWrapper.objectsToUpdate.add(newRelatedContact);
-                            TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated);
 	            for (SObject so : newlist) {
-	               Affiliation__c affl = (Affiliation__c)so;
-	               Affiliation__c afflOld;
-	               if(oldlist[i] != null)
-	                   afflOld = (Affiliation__c)oldlist[i];
+                    Affiliation__c affl = (Affiliation__c)so;
+                    Affiliation__c afflOld;
+               		if(oldlist[i] != null)
+                   		afflOld = (Affiliation__c)oldlist[i];
 
-	               String lookupFieldLabel = AFFL_MultiRecordType_TDTM.afflMapper.mapAccRecTypeToContactLabel.get(affl.Affiliation_Type__c);
-	               String lookupFieldName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabel);
+	               	String lookupFieldLabel = AFFL_MultiRecordType_TDTM.afflMapper.mapAccRecTypeToContactLabel.get(affl.Affiliation_Type__c);
+	               	String lookupFieldName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabel);
 
-				   if (isAfflTypeEnforced) {
-					   ERR_ExceptionHandler.handleAfflNullRecordTypeException(affl, afflMapper.validAccRecordTypesInMappings);
-				   }
+					if (isAfflTypeEnforced) {
+						ERR_ExceptionHandler.handleAfflNullRecordTypeException(affl, afflMapper.validAccRecordTypesInMappings);
+					}
 
-	               //AFTER UPDATE
-	               if(triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+	               	//AFTER UPDATE
+	               	if(triggerAction == TDTM_Runnable.Action.AfterUpdate) {
 
-    		           Contact newRelatedContact, oldRelatedContact;
-		               if(newlist != null) {
-		                  newRelatedContact = newRelatedContactsMap.get(affl.Contact__c);
-		               }
-		               if(oldlist != null) {
-		                  oldRelatedContact = oldRelatedContactsMap.get(afflOld.Contact__c);
-		               }
+    		           	Contact newRelatedContact, oldRelatedContact;
+		               	if(newlist != null) {
+		                  	newRelatedContact = newRelatedContactsMap.get(affl.Contact__c);
+		               	}
+		               	if(oldlist != null) {
+		                  	oldRelatedContact = oldRelatedContactsMap.get(afflOld.Contact__c);
+		               	}
 
-	                   //CONTACT FIELD CHANGED
-	                   if(affl.Primary__c && affl.Contact__c != null && afflOld.Contact__c != null
-	                   && affl.Contact__c != afflOld.Contact__c && newRelatedContact != null && oldRelatedContact != null && lookupFieldName != null) {
+	                   	//CONTACT FIELD CHANGED
+	                   	if(affl.Primary__c && affl.Contact__c != null && afflOld.Contact__c != null
+	                   		&& affl.Contact__c != afflOld.Contact__c && newRelatedContact != null && oldRelatedContact != null && lookupFieldName != null) {
 
-	                       //Clear matching primary affiliation field in old Contact
-	                       oldRelatedContact.put(lookupFieldName, null);
-	                       dmlWrapper.objectsToUpdate.add(oldRelatedContact);
+	                       	//Clear matching primary affiliation field in old Contact
+	                       	oldRelatedContact.put(lookupFieldName, null);
+	                       	dmlWrapper.objectsToUpdate.add(oldRelatedContact);
 
-	                       //Populate same field in new Contact
-	                       newRelatedContact.put(lookupFieldName, affl.Account__c);
-	                       dmlWrapper.objectsToUpdate.add(newRelatedContact);
+	                       	//Populate same field in new Contact
+	                       	newRelatedContact.put(lookupFieldName, affl.Account__c);
+	                       	dmlWrapper.objectsToUpdate.add(newRelatedContact);
 
-	                       //afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
-                           //AFFL_MultiRecordType_TDTM will run after this class, and will take care of that.
-	                   }
+	                       	//afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
+                           	//AFFL_MultiRecordType_TDTM will run after this class, and will take care of that.
+	                   	}
 
-	                   //CONTACT FIELD CLEARED - same as if the Affiliation was deleted.
-	                   if(affl.Primary__c && afflOld.Contact__c != null && affl.Contact__c == null && lookupFieldName != null) {
-	                       afflMulti.processAfflDeleted(afflOld, oldRelatedContact, lookupFieldName, dmlWrapper);
-	                   }
-	               }
-	               i++;
-	           }
-	       }
-           TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM, true);
+	                   	//CONTACT FIELD CLEARED - same as if the Affiliation was deleted.
+	                   	if(affl.Primary__c && afflOld.Contact__c != null && affl.Contact__c == null && lookupFieldName != null) {
+	                       	afflMulti.processAfflDeleted(afflOld, oldRelatedContact, lookupFieldName, dmlWrapper);
+	                   	}
+	               	}
+	               	i++;
+	           	}
+	       	}
+           	TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM, true);
         }
         TDTM_TriggerHandler.processDML(dmlWrapper, true);
         dmlWrapper = null;        

--- a/src/classes/AFFL_ContactChange_TDTM.cls
+++ b/src/classes/AFFL_ContactChange_TDTM.cls
@@ -35,6 +35,7 @@
 * @description Handles the Contact in a primary Affiliation being changed or cleared.
 */
 public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
+
 	//Get the primary affiliation fields defined in the Affiliation Mappings
 	public static AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
 
@@ -75,56 +76,58 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
                     }
                 }
 
-                for (SObject so : newlist) {
-                    Affiliation__c affl = (Affiliation__c)so;
-                    Affiliation__c afflOld;
-                    if (oldlist[i] != null)
-                        afflOld = (Affiliation__c)oldlist[i];
-
-                    String lookupFieldLabel = AFFL_MultiRecordType_TDTM.afflMapper.mapAccRecTypeToContactLabel.get(affl.Affiliation_Type__c);
-                    String lookupFieldName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabel);
-
-                    if (isAfflTypeEnforced) {
-                        ERR_ExceptionHandler.handleAfflNullRecordTypeException(affl, afflMapper.validAccRecordTypesInMappings);
-                    }
-
-                    //AFTER UPDATE
-                    if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
-
-                        Contact newRelatedContact, oldRelatedContact;
-                        if (newlist != null) {
-                            newRelatedContact = newRelatedContactsMap.get(affl.Contact__c);
-                        }
-                        if (oldlist != null) {
-                            oldRelatedContact = oldRelatedContactsMap.get(afflOld.Contact__c);
-                        }
-
-                        //CONTACT FIELD CHANGED
-                        if (affl.Primary__c && affl.Contact__c != null && afflOld.Contact__c != null
-                            && affl.Contact__c != afflOld.Contact__c && newRelatedContact != null && oldRelatedContact != null && lookupFieldName != null) {
-
-                            //Clear matching primary affiliation field in old Contact
-                            oldRelatedContact.put(lookupFieldName, null);
-                            dmlWrapper.objectsToUpdate.add(oldRelatedContact);
-
-                            //Populate same field in new Contact
-                            newRelatedContact.put(lookupFieldName, affl.Account__c);
                             TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
                             dmlWrapper.objectsToUpdate.add(newRelatedContact);
                             TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated);
-                            //afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
-                            //AFFL_MultiRecordType_TDTM will run after this class, and will take care of that.
-                        }
+	            for (SObject so : newlist) {
+	               Affiliation__c affl = (Affiliation__c)so;
+	               Affiliation__c afflOld;
+	               if(oldlist[i] != null)
+	                   afflOld = (Affiliation__c)oldlist[i];
 
-                        //CONTACT FIELD CLEARED - same as if the Affiliation was deleted.
-                        if (affl.Primary__c && afflOld.Contact__c != null && affl.Contact__c == null && lookupFieldName != null) {
-                            afflMulti.processAfflDeleted(afflOld, oldRelatedContact, lookupFieldName, dmlWrapper);
-                        }
-                    }
-                    i++;
-                }
-            }
-            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM, true);
+	               String lookupFieldLabel = AFFL_MultiRecordType_TDTM.afflMapper.mapAccRecTypeToContactLabel.get(affl.Affiliation_Type__c);
+	               String lookupFieldName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabel);
+
+				   if (isAfflTypeEnforced) {
+					   ERR_ExceptionHandler.handleAfflNullRecordTypeException(affl, afflMapper.validAccRecordTypesInMappings);
+				   }
+
+	               //AFTER UPDATE
+	               if(triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+
+    		           Contact newRelatedContact, oldRelatedContact;
+		               if(newlist != null) {
+		                  newRelatedContact = newRelatedContactsMap.get(affl.Contact__c);
+		               }
+		               if(oldlist != null) {
+		                  oldRelatedContact = oldRelatedContactsMap.get(afflOld.Contact__c);
+		               }
+
+	                   //CONTACT FIELD CHANGED
+	                   if(affl.Primary__c && affl.Contact__c != null && afflOld.Contact__c != null
+	                   && affl.Contact__c != afflOld.Contact__c && newRelatedContact != null && oldRelatedContact != null && lookupFieldName != null) {
+
+	                       //Clear matching primary affiliation field in old Contact
+	                       oldRelatedContact.put(lookupFieldName, null);
+	                       dmlWrapper.objectsToUpdate.add(oldRelatedContact);
+
+	                       //Populate same field in new Contact
+	                       newRelatedContact.put(lookupFieldName, affl.Account__c);
+	                       dmlWrapper.objectsToUpdate.add(newRelatedContact);
+
+	                       //afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
+                           //AFFL_MultiRecordType_TDTM will run after this class, and will take care of that.
+	                   }
+
+	                   //CONTACT FIELD CLEARED - same as if the Affiliation was deleted.
+	                   if(affl.Primary__c && afflOld.Contact__c != null && affl.Contact__c == null && lookupFieldName != null) {
+	                       afflMulti.processAfflDeleted(afflOld, oldRelatedContact, lookupFieldName, dmlWrapper);
+	                   }
+	               }
+	               i++;
+	           }
+	       }
+           TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM, true);
         }
         TDTM_TriggerHandler.processDML(dmlWrapper, true);
         dmlWrapper = null;        

--- a/src/classes/AFFL_ContactChange_TDTM.cls
+++ b/src/classes/AFFL_ContactChange_TDTM.cls
@@ -57,72 +57,74 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 
         DmlWrapper dmlWrapper = new DmlWrapper();
 
-        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM)) {
+        if (!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM)) {
 
             AFFL_MultiRecordType_TDTM afflMulti = new AFFL_MultiRecordType_TDTM();
             Map<ID, Contact> newRelatedContactsMap, oldRelatedContactsMap;
 
-            if(newlist != null && newlist.size() > 0) {
+            if (newlist != null && newlist.size() > 0) {
                 Integer i = 0;
 
                 // Query all the primary affiliation lookup fields on the contact - they are not available in the trigger.
-                if(triggerAction == TDTM_Runnable.Action.AfterUpdate) {
-                    if(newlist != null) {
+                if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+                    if (newlist != null) {
                         newRelatedContactsMap = afflMulti.queryAfflLookupFields(newlist);
                     }
-                    if(oldlist != null) {
+                    if (oldlist != null) {
                        oldRelatedContactsMap = afflMulti.queryAfflLookupFields(oldlist);
                     }
                 }
-	            for (SObject so : newlist) {
+
+                for (SObject so : newlist) {
                     Affiliation__c affl = (Affiliation__c)so;
                     Affiliation__c afflOld;
-               		if(oldlist[i] != null)
-                   		afflOld = (Affiliation__c)oldlist[i];
+                    if (oldlist[i] != null)
+                        afflOld = (Affiliation__c)oldlist[i];
 
-	               	String lookupFieldLabel = AFFL_MultiRecordType_TDTM.afflMapper.mapAccRecTypeToContactLabel.get(affl.Affiliation_Type__c);
-	               	String lookupFieldName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabel);
+                    String lookupFieldLabel = AFFL_MultiRecordType_TDTM.afflMapper.mapAccRecTypeToContactLabel.get(affl.Affiliation_Type__c);
+                    String lookupFieldName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabel);
 
-					if (isAfflTypeEnforced) {
-						ERR_ExceptionHandler.handleAfflNullRecordTypeException(affl, afflMapper.validAccRecordTypesInMappings);
-					}
+                    if (isAfflTypeEnforced) {
+                        ERR_ExceptionHandler.handleAfflNullRecordTypeException(affl, afflMapper.validAccRecordTypesInMappings);
+                    }
 
-	               	//AFTER UPDATE
-	               	if(triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+                    //AFTER UPDATE
+                    if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
 
-    		           	Contact newRelatedContact, oldRelatedContact;
-		               	if(newlist != null) {
-		                  	newRelatedContact = newRelatedContactsMap.get(affl.Contact__c);
-		               	}
-		               	if(oldlist != null) {
-		                  	oldRelatedContact = oldRelatedContactsMap.get(afflOld.Contact__c);
-		               	}
+                        Contact newRelatedContact, oldRelatedContact;
+                        if (newlist != null) {
+                            newRelatedContact = newRelatedContactsMap.get(affl.Contact__c);
+                        }
+                        if (oldlist != null) {
+                            oldRelatedContact = oldRelatedContactsMap.get(afflOld.Contact__c);
+                        }
 
-	                   	//CONTACT FIELD CHANGED
-	                   	if(affl.Primary__c && affl.Contact__c != null && afflOld.Contact__c != null
-	                   		&& affl.Contact__c != afflOld.Contact__c && newRelatedContact != null && oldRelatedContact != null && lookupFieldName != null) {
+                        //CONTACT FIELD CHANGED
+                        if (affl.Primary__c && affl.Contact__c != null && afflOld.Contact__c != null
+                            && affl.Contact__c != afflOld.Contact__c && newRelatedContact != null && oldRelatedContact != null && lookupFieldName != null) {
 
-	                       	//Clear matching primary affiliation field in old Contact
-	                       	oldRelatedContact.put(lookupFieldName, null);
-	                       	dmlWrapper.objectsToUpdate.add(oldRelatedContact);
+                            //Clear matching primary affiliation field in old Contact
+                            oldRelatedContact.put(lookupFieldName, null);
+                            dmlWrapper.objectsToUpdate.add(oldRelatedContact);
 
-	                       	//Populate same field in new Contact
-	                       	newRelatedContact.put(lookupFieldName, affl.Account__c);
-	                       	dmlWrapper.objectsToUpdate.add(newRelatedContact);
+                            //Populate same field in new Contact
+                            newRelatedContact.put(lookupFieldName, affl.Account__c);
+                            TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
+                            dmlWrapper.objectsToUpdate.add(newRelatedContact);
+                            TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated);
+                            //afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
+                            //AFFL_MultiRecordType_TDTM will run after this class, and will take care of that.
+                        }
 
-	                       	//afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
-                           	//AFFL_MultiRecordType_TDTM will run after this class, and will take care of that.
-	                   	}
-
-	                   	//CONTACT FIELD CLEARED - same as if the Affiliation was deleted.
-	                   	if(affl.Primary__c && afflOld.Contact__c != null && affl.Contact__c == null && lookupFieldName != null) {
-	                       	afflMulti.processAfflDeleted(afflOld, oldRelatedContact, lookupFieldName, dmlWrapper);
-	                   	}
-	               	}
-	               	i++;
-	           	}
-	       	}
-           	TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM, true);
+                        //CONTACT FIELD CLEARED - same as if the Affiliation was deleted.
+                        if (affl.Primary__c && afflOld.Contact__c != null && affl.Contact__c == null && lookupFieldName != null) {
+                            afflMulti.processAfflDeleted(afflOld, oldRelatedContact, lookupFieldName, dmlWrapper);
+                        }
+                    }
+                    i++;
+                }
+            }
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM, true);
         }
         TDTM_TriggerHandler.processDML(dmlWrapper, true);
         dmlWrapper = null;        

--- a/src/classes/AFFL_ContactChange_TDTM.cls
+++ b/src/classes/AFFL_ContactChange_TDTM.cls
@@ -36,7 +36,16 @@
 */
 public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 
-    /*******************************************************************************************************
+	//Get the primary affiliation fields defined in the Affiliation Mappings
+	public static AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
+
+	/*******************************************************************************************************
+    * @description If affiliation type is enforced.
+    */
+	private static boolean isAfflTypeEnforced = UTIL_CustomSettingsFacade.getSettings().Affiliation_Record_Type_Enforced__c;
+
+
+	/*******************************************************************************************************
     * @description Handles Affiliation management.
     * @param listNew the list of Accounts from trigger new.
     * @param listOld the list of Accounts from trigger old.
@@ -76,6 +85,10 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 	               String lookupFieldLabel = AFFL_MultiRecordType_TDTM.afflMapper.mapAccRecTypeToContactLabel.get(affl.Affiliation_Type__c);
 	               String lookupFieldName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabel);
 
+				   if (isAfflTypeEnforced) {
+					   ERR_ExceptionHandler.handleAfflNullRecordTypeException(affl, afflMapper.validAccRecordTypesInMappings);
+				   }
+
 	               //AFTER UPDATE
 	               if(triggerAction == TDTM_Runnable.Action.AfterUpdate) {
 
@@ -89,7 +102,7 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 
 	                   //CONTACT FIELD CHANGED
 	                   if(affl.Primary__c && affl.Contact__c != null && afflOld.Contact__c != null
-	                   && affl.Contact__c != afflOld.Contact__c && newRelatedContact != null && oldRelatedContact != null) {
+	                   && affl.Contact__c != afflOld.Contact__c && newRelatedContact != null && oldRelatedContact != null && lookupFieldName != null) {
 
 	                       //Clear matching primary affiliation field in old Contact
 	                       oldRelatedContact.put(lookupFieldName, null);
@@ -106,7 +119,7 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 	                   }
 
 	                   //CONTACT FIELD CLEARED - same as if the Affiliation was deleted.
-	                   if(affl.Primary__c && afflOld.Contact__c != null && affl.Contact__c == null) {
+	                   if(affl.Primary__c && afflOld.Contact__c != null && affl.Contact__c == null && lookupFieldName != null) {
 	                       afflMulti.processAfflDeleted(afflOld, oldRelatedContact, lookupFieldName, dmlWrapper);
 	                   }
 	               }

--- a/src/classes/AFFL_ContactChange_TDTM.cls
+++ b/src/classes/AFFL_ContactChange_TDTM.cls
@@ -110,10 +110,7 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 
 	                       	//Populate same field in new Contact
 	                       	newRelatedContact.put(lookupFieldName, affl.Account__c);
-                            TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
                             dmlWrapper.objectsToUpdate.add(newRelatedContact);
-                            TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated);
-
 
 	                       	//afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
                            	//AFFL_MultiRecordType_TDTM will run after this class, and will take care of that.
@@ -125,6 +122,8 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 	                   	}
 	               	}
 	               	i++;
+                    //Turn off CON_PrimaryAffls_TDTM_After_Update temporarily to avoid creating duplicate affiliation
+                    TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
 	           	}
 	       	}
            	TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM, true);
@@ -132,6 +131,9 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
         TDTM_TriggerHandler.processDML(dmlWrapper, true);
         dmlWrapper = null;        
         TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM, false);
+        if (triggerAction == TDTM_Runnable.Action.AfterUpdate){
+            TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
+        }
         return dmlWrapper;
     }
 }

--- a/src/classes/AFFL_ContactChange_TDTM.cls
+++ b/src/classes/AFFL_ContactChange_TDTM.cls
@@ -36,16 +36,16 @@
 */
 public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 
-	//Get the primary affiliation fields defined in the Affiliation Mappings
-	public static AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
+    //Get the primary affiliation fields defined in the Affiliation Mappings
+    public static AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
 
-	/*******************************************************************************************************
+    /*******************************************************************************************************
     * @description If affiliation type is enforced.
     */
-	private static boolean isAfflTypeEnforced = UTIL_CustomSettingsFacade.getSettings().Affiliation_Record_Type_Enforced__c;
+    private static boolean isAfflTypeEnforced = UTIL_CustomSettingsFacade.getSettings().Affiliation_Record_Type_Enforced__c;
 
 
-	/*******************************************************************************************************
+    /*******************************************************************************************************
     * @description Handles Affiliation management.
     * @param listNew the list of Accounts from trigger new.
     * @param listOld the list of Accounts from trigger old.
@@ -63,8 +63,8 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
             AFFL_MultiRecordType_TDTM afflMulti = new AFFL_MultiRecordType_TDTM();
             Map<ID, Contact> newRelatedContactsMap, oldRelatedContactsMap;
 
-	        if(newlist != null && newlist.size() > 0) {
-	            Integer i = 0;
+            if(newlist != null && newlist.size() > 0) {
+                Integer i = 0;
 
                 // Query all the primary affiliation lookup fields on the contact - they are not available in the trigger.
                 if(triggerAction == TDTM_Runnable.Action.AfterUpdate) {
@@ -76,57 +76,56 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
                     }
                 }
 
-	            for (SObject so : newlist) {
-	               Affiliation__c affl = (Affiliation__c)so;
-	               Affiliation__c afflOld;
-	               if(oldlist[i] != null)
-	                   afflOld = (Affiliation__c)oldlist[i];
+                for (SObject so : newlist) {
+                    Affiliation__c affl = (Affiliation__c)so;
+                    Affiliation__c afflOld;
+                    if(oldlist[i] != null)
+                        afflOld = (Affiliation__c)oldlist[i];
 
-	               String lookupFieldLabel = AFFL_MultiRecordType_TDTM.afflMapper.mapAccRecTypeToContactLabel.get(affl.Affiliation_Type__c);
-	               String lookupFieldName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabel);
+                    String lookupFieldLabel = AFFL_MultiRecordType_TDTM.afflMapper.mapAccRecTypeToContactLabel.get(affl.Affiliation_Type__c);
+                    String lookupFieldName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabel);
 
-				   if (isAfflTypeEnforced) {
-					   ERR_ExceptionHandler.handleAfflNullRecordTypeException(affl, afflMapper.validAccRecordTypesInMappings);
-				   }
+                    if (isAfflTypeEnforced) {
+                        ERR_ExceptionHandler.handleAfflNullRecordTypeException(affl, afflMapper.validAccRecordTypesInMappings);
+                    }
 
-	               //AFTER UPDATE
-	               if(triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+                    //AFTER UPDATE
+                    if(triggerAction == TDTM_Runnable.Action.AfterUpdate) {
 
-    		           Contact newRelatedContact, oldRelatedContact;
-		               if(newlist != null) {
-		                  newRelatedContact = newRelatedContactsMap.get(affl.Contact__c);
-		               }
-		               if(oldlist != null) {
-		                  oldRelatedContact = oldRelatedContactsMap.get(afflOld.Contact__c);
-		               }
+                        Contact newRelatedContact, oldRelatedContact;
+                        if(newlist != null) {
+                            newRelatedContact = newRelatedContactsMap.get(affl.Contact__c);
+                        }
+                        if(oldlist != null) {
+                            oldRelatedContact = oldRelatedContactsMap.get(afflOld.Contact__c);
+                        }
 
-	                   //CONTACT FIELD CHANGED
-	                   if(affl.Primary__c && affl.Contact__c != null && afflOld.Contact__c != null
-	                   && affl.Contact__c != afflOld.Contact__c && newRelatedContact != null && oldRelatedContact != null && lookupFieldName != null) {
+                        //CONTACT FIELD CHANGED
+                        if(affl.Primary__c && affl.Contact__c != null && afflOld.Contact__c != null
+                            && affl.Contact__c != afflOld.Contact__c && newRelatedContact != null && oldRelatedContact != null && lookupFieldName != null) {
 
-	                       //Clear matching primary affiliation field in old Contact
-	                       oldRelatedContact.put(lookupFieldName, null);
-	                       dmlWrapper.objectsToUpdate.add(oldRelatedContact);
+                            //Clear matching primary affiliation field in old Contact
+                            oldRelatedContact.put(lookupFieldName, null);
+                            dmlWrapper.objectsToUpdate.add(oldRelatedContact);
 
-	                       //Populate same field in new Contact
-	                       newRelatedContact.put(lookupFieldName, affl.Account__c);
-						   TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
-						   dmlWrapper.objectsToUpdate.add(newRelatedContact);
-						   TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated);
+                            //Populate same field in new Contact
+                            newRelatedContact.put(lookupFieldName, affl.Account__c);
+                            TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_After_Update);
+                            dmlWrapper.objectsToUpdate.add(newRelatedContact);
+                            TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated);
+                            //afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
+                            //AFFL_MultiRecordType_TDTM will run after this class, and will take care of that.
+                        }
 
-						   //afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
-                           //AFFL_MultiRecordType_TDTM will run after this class, and will take care of that.
-	                   }
-
-	                   //CONTACT FIELD CLEARED - same as if the Affiliation was deleted.
-	                   if(affl.Primary__c && afflOld.Contact__c != null && affl.Contact__c == null && lookupFieldName != null) {
-	                       afflMulti.processAfflDeleted(afflOld, oldRelatedContact, lookupFieldName, dmlWrapper);
-	                   }
-	               }
-	               i++;
-	           }
-	       }
-           TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM, true);
+                        //CONTACT FIELD CLEARED - same as if the Affiliation was deleted.
+                        if(affl.Primary__c && afflOld.Contact__c != null && affl.Contact__c == null && lookupFieldName != null) {
+                            afflMulti.processAfflDeleted(afflOld, oldRelatedContact, lookupFieldName, dmlWrapper);
+                        }
+                    }
+                    i++;
+                }
+            }
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_ContactChange_TDTM, true);
         }
         TDTM_TriggerHandler.processDML(dmlWrapper, true);
         dmlWrapper = null;        


### PR DESCRIPTION
# Critical Changes

# Changes
We've fixed a bug that created duplicate Affiliations when users reparented an existing Primary Affiliation with a different Contact/Account.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
1. Deploy HEDA to a scratch org
2. Create a non-admin account(business org etc)
3. Create two contacts
4. Set the primary field(primary business org for instance) as contact#1
5. Go to contact#1 and find the new affiliation(affiliation#1) under related list(affiliation account)
6. Go to affiliation record page and update the parent contact to contact#2
7. Make sure no new affiliation is created, affiliation#1 is under contact#2 and is primary.