### PR TITLE
Setting owner field on Account. Creating test.

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -457,6 +457,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                 }
                 a.Phone = c.Phone;
                 a.Fax = c.Fax;
+                a.OwnerId = c.OwnerId;
 
                 if(defaultRecTypeID == UTIL_CustomSettingsFacade.getSettings().Household_Addresses_RecType__c) {
                     ADDR_Addresses_UTIL.copyAddressStdSObj(c, 'Mailing', a, 'Billing');

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -579,12 +579,12 @@ private class ACCT_IndividualAccounts_TEST {
         system.assertEquals(con.FirstName + ' ' + con.LastName + ' Household', assertAccount.Name);
     }
 
-/*********************************************************************************************************
-* @description
-* Update the custom setting of automatic household naming as true
-* Delete the contact linked to a Household Account
-* Make sure the Account's name is set back based on account naming setting.
-*/
+    /*********************************************************************************************************
+    * @description
+    * Update the custom setting of automatic household naming as true
+    * Delete the contact linked to a Household Account
+    * Make sure the Account's name is set back based on account naming setting.
+    */
     @isTest
     public static void deleteContactFromHHAccAutomatic() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
@@ -617,12 +617,12 @@ private class ACCT_IndividualAccounts_TEST {
         system.assertEquals(con.FirstName + ' ' + con.LastName + ' Household', assertAccount.Name);
     }
 
-/*********************************************************************************************************
-* @description
-* Update the custom setting of automatic household naming as true
-* Disconnect the contact from a Household Account
-* Make sure the Account's name is set back based on account naming setting.
-*/
+    /*********************************************************************************************************
+    * @description
+    * Update the custom setting of automatic household naming as true
+    * Disconnect the contact from a Household Account
+    * Make sure the Account's name is set back based on account naming setting.
+    */
     @isTest
     public static void disconnectContactFromHHAccAutomatic() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
@@ -657,12 +657,12 @@ private class ACCT_IndividualAccounts_TEST {
         system.assertEquals(con.FirstName + ' ' + con.LastName + ' Household', assertAccount.Name);
     }
 
-/*********************************************************************************************************
-* @description
-* Update the custom setting of automatic household naming as true
-* Delete all the contacts linked to a Household Account
-* Make sure the Account's name is set back based on account naming setting.
-*/
+    /*********************************************************************************************************
+    * @description
+    * Update the custom setting of automatic household naming as true
+    * Delete all the contacts linked to a Household Account
+    * Make sure the Account's name is set back based on account naming setting.
+    */
     @isTest
     public static void deleteAllContactsFromHHAccAutomatic() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
@@ -696,11 +696,11 @@ private class ACCT_IndividualAccounts_TEST {
         system.assertEquals('Household', assertAccount.Name);
     }
 
-/*********************************************************************************************************
-* @description
-* Remove primary contact from household account
-* Make sure the primary contact of household account is cleared up
-*/
+    /*********************************************************************************************************
+    * @description
+    * Remove primary contact from household account
+    * Make sure the primary contact of household account is cleared up
+    */
     @isTest
     public static void hhAccountNoChildContactResetPrimaryContact() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe.getHhAccRecTypeID()));
@@ -717,11 +717,11 @@ private class ACCT_IndividualAccounts_TEST {
         system.assertEquals(null, assertAccount.Primary_Contact__c);
     }
 
-/*********************************************************************************************************
-* @description
-* Add a contact to a household account
-* Make sure the primary contact of household account is not changed
-*/
+    /*********************************************************************************************************
+    * @description
+    * Add a contact to a household account
+    * Make sure the primary contact of household account is not changed
+    */
     @isTest
     public static void hhAccountNewChildContactNotResetPrimaryContact() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe.getHhAccRecTypeID()));
@@ -745,11 +745,11 @@ private class ACCT_IndividualAccounts_TEST {
 
     }
 
-/*********************************************************************************************************
-* @description
-* Switch contacts between two household accounts
-* Make sure primary contacts are updated correctly
-*/
+    /*********************************************************************************************************
+    * @description
+    * Switch contacts between two household accounts
+    * Make sure primary contacts are updated correctly
+    */
     @isTest
     public static void hhAccountSwitchChildContactResetPrimaryContact() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe.getHhAccRecTypeID()));
@@ -775,6 +775,30 @@ private class ACCT_IndividualAccounts_TEST {
         Account assertAccount2 = [Select Primary_Contact__c FROM Account WHERE Id = :acc2.Id LIMIT 1];
         system.assertEquals(con2.Id, assertAccount.Primary_Contact__c);
         system.assertEquals(con.Id, assertAccount2.Primary_Contact__c);
+    }
 
+    /**
+     * @description Validate that when inserting a new Account for a Contact, it uses the same OwnerId as the
+     * Contact that was inserted (especially if the Contact.OwnerId is set to a value other than the current user).
+     */
+    private static testMethod void test_insertAsOtherUser() {
+
+        // Create a single new User
+        Id sysAdminProfileId = UTIL_Profile.getInstance().getProfileIds(UTIL_Profile.SYSTEM_ADMINISTRATOR)[0];
+        User tempUser = new User(LastName = 'TestSysAdminUserA', Email = 'test_insertAsOtherUser@email.npsp',
+                ProfileId = sysAdminProfileId, isActive = true, UserName = 'test_insertAsOtherUser@email.npsp',
+                Alias = 'tu08534', TimeZoneSidKey = 'America/Los_Angeles',
+                LocaleSidKey = 'en_US', LanguageLocaleKey = 'en_US', EmailEncodingKey = 'ISO-8859-1');
+        insert tempUser;
+
+        Id currUserId = UserInfo.getUserId();
+        Contact c = UTIL_UnitTestData_TEST.getContact();
+        c.OwnerId = currUserId;
+        System.runAs(tempUser) {
+            insert c;
+            c = [SELECT Id, OwnerId, Account.OwnerId FROM Contact WHERE Id = :c.Id LIMIT 1];
+            system.assertEquals(c.OwnerId, currUserId, 'The Contact owner should be current system admin user');
+            system.assertEquals(c.Account.OwnerId, currUserId, 'The Account owner should be the same as the Contact Owner');
+        }
     }
 }

--- a/src/classes/ERR_Notifier.cls
+++ b/src/classes/ERR_Notifier.cls
@@ -71,10 +71,12 @@ public class ERR_Notifier {
                 if (errorNotifRecipient instanceof id && errorNotifRecipient.startsWith(NotificationOptions.user)) {
                     List<User> useremaillist = new List<User>();
                     useremaillist = [select email from User where id = :errorNotifRecipient and isActive = true];
-                    for (User u : useremaillist)
+                    for (User u : useremaillist) {
                         sendList.add(u.email);
+                    }
                 } else if(errorNotifRecipient == NotificationOptions.sysAdmins) {
-                    list<User> sysadminlist = [select email from User where User.Profile.Name = 'System Administrator' and isActive = true];
+                    List<User> sysadminlist = [select email from User where User.Profile.Name = :UTIL_Profile.SYSTEM_ADMINISTRATOR
+                    and isActive = true];
                     for (User u : sysadminlist) {
                         sendList.add(u.email);
                     }

--- a/src/classes/UTIL_Profile.cls
+++ b/src/classes/UTIL_Profile.cls
@@ -35,7 +35,15 @@
 */
 public class UTIL_Profile {
     /** @description System Administrator Profile Name */
-    public static final String SYSTEM_ADMINISTRATOR = 'System Administrator';
+    public static final String SYSTEM_ADMINISTRATOR {
+        public get {
+            return [SELECT name FROM Profile
+                    WHERE (UserType = 'Standard'
+                            AND PermissionsCustomizeApplication = true)
+                    ORDER BY CreatedDate ASC limit 1][0].Name;
+        }
+        private set;
+    }
 
     /** @description static instance of the current class (UTIL_Profile). It is used as the instance in a Singleton context */
     private static UTIL_Profile utilProfile;

--- a/src/classes/UTIL_Profile.cls
+++ b/src/classes/UTIL_Profile.cls
@@ -1,0 +1,99 @@
+/*
+    Copyright (c) 2018, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2018
+* @group Utilities
+* @description Utility for Profiles
+*/
+public class UTIL_Profile {
+    /** @description System Administrator Profile Name */
+    public static final String SYSTEM_ADMINISTRATOR = 'System Administrator';
+
+    /** @description static instance of the current class (UTIL_Profile). It is used as the instance in a Singleton context */
+    private static UTIL_Profile utilProfile;
+
+    /** @description Map of the Profiles grouped by Name */
+    private Map<String, List<Profile>> profilesByName;
+
+    /*********************************************************************************************************
+    * @description Get the instance of the current class
+    * @return UTIL_Profile The instance of the current class.
+    */
+    public static UTIL_Profile getInstance() {
+        if (utilProfile == null) {
+            utilProfile = new UTIL_Profile();
+        }
+        return utilProfile;
+    }
+
+    /*********************************************************************************************************
+    * @description The Constructor, which is private because we are using the Singleton Pattern.
+    * The UTIL_Profile object needs to be constructed only from the static method getInstance()
+    */
+    private UTIL_Profile() {
+        profilesByName = getProfilesByName();
+    }
+
+    /*********************************************************************************************************
+    * @description Get Profile Ids for the specified Profile Name
+    * @param profileName Profile Name
+    * @return List<Id> List of Profile Ids
+    */
+    public List<Id> getProfileIds(String profileName) {
+        if (profilesByName.containsKey(profileName) == false) {
+            return new List<Id>();
+        }
+
+        Set<Id> profileIds = new Map<Id, Profile>(profilesByName.get(profileName)).keySet();
+        return new List<Id>(profileIds);
+    }
+
+    /*********************************************************************************************************
+    * @description Build a Map of Profiles grouped by Name
+    * @return Map<String, List<Profile>> Map of Profiles grouped by Name
+    */
+    private Map<String, List<Profile>> getProfilesByName() {
+        Map<String, List<Profile>> result = new Map<String, List<Profile>>();
+
+        for (Profile currentProfile :[
+                SELECT Name
+                FROM Profile
+        ]) {
+            if (result.containsKey(currentProfile.Name) == false) {
+                result.put(currentProfile.Name, new List<Profile>());
+            }
+
+            result.get(currentProfile.Name).add(currentProfile);
+        }
+
+        return result;
+    }
+}

--- a/src/classes/UTIL_Profile.cls-meta.xml
+++ b/src/classes/UTIL_Profile.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>42.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/UTIL_Profile_TEST.cls
+++ b/src/classes/UTIL_Profile_TEST.cls
@@ -1,0 +1,120 @@
+/*
+    Copyright (c) 2018 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2018
+* @group Utilities
+* @description Unit tests for UTIL_Profile class
+*/
+@isTest
+private class UTIL_Profile_TEST {
+
+    /**************************************************************************************************************************
+    @description Test multiple calls of the method getInstance() to make sure the UTIL_Profile instance is constructed only once.
+    verify: The query should run only once.
+    ***************************************************************************************************************************/
+    private static testMethod void testGetInstanceQueriesOnceOnMultipleCalls() {
+        System.assertEquals(0, Limits.getQueries(), 'The query count should be 0');
+
+        UTIL_Profile profileUtil = UTIL_Profile.getInstance();
+        //The getInstance() executes a query on the Profile.
+        System.assertNotEquals(null, profileUtil, 'The getInstance() should return an instance of UTIL_Profile');
+        System.assertEquals(1, Limits.getQueries(), 'The query count should be 1 because the getInstance() constructs the UTIL_Profile');
+
+        profileUtil = UTIL_Profile.getInstance();
+
+        //Verify the getInstance() does not execute the query again.
+        System.assertNotEquals(null, profileUtil, 'The getInstance() should have the same instance of UTIL_Profile');
+        System.assertEquals(1, Limits.getQueries(), 'The query count should not increase');
+    }
+
+    /**************************************************************************************************************************
+    @description Test the getProfileIds() with valid Profile name.
+    verify: getProfileIds() returns all Profile Ids for the specified Profile Name
+    ***************************************************************************************************************************/
+    private static testMethod void testGetProfileIdsWithValidProfileName() {
+        Map<String, List<Profile>> orgProfilesByName = getProfilesByName();
+
+        Test.startTest();
+        UTIL_Profile profileUtil = UTIL_Profile.getInstance();
+        Test.stopTest();
+
+        System.assertNotEquals(null, profileUtil, 'The GetInstance should return an instance of UTIL_Profile');
+
+        for (String profileName : orgProfilesByName.keySet()) {
+            List<Id> profileIds = profileUtil.getProfileIds(profileName);
+            Set<Id> currentProfileIds = new Map<Id, Profile>(orgProfilesByName.get(profileName)).keySet();
+
+            System.assertEquals(
+                    currentProfileIds.size(),
+                    profileIds.size(),
+                    'The number of Profiles for ' + profileName + ' profile should be equal to the profileUtil.getProfileIds()'
+            );
+
+            System.assert(currentProfileIds.containsAll(profileIds), 'Expected and retrieved Profile Ids should be the same');
+        }
+    }
+
+    /**************************************************************************************************************************
+    @description Test the getProfileIds() with invalid Profile name.
+    verify: getProfileIds() returns empty List
+    ***************************************************************************************************************************/
+    private static testMethod void testGetProfileIdsWithInvalidProfileName() {
+        Test.startTest();
+        UTIL_Profile profileUtil = UTIL_Profile.getInstance();
+        Test.stopTest();
+
+        System.assertNotEquals(null, profileUtil, 'The getInstance() should return an instance of UTIL_Profile');
+        System.assertEquals(0, profileUtil.getProfileIds('INVALID_PROFILE_NAME').size(), 'No profile Id should be returned');
+    }
+
+    // Helpers
+    /////////////
+
+    /*********************************************************************************************************
+    * @description Get a Map of all Profiles grouped by Name
+    * @return Map<String, List<Profile>> Map of Profiles grouped by Name
+    */
+    private static Map<String, List<Profile>> getProfilesByName() {
+        Map<String, List<Profile>> result = new Map<String,List<Profile>>();
+
+        for (Profile currentProfile :[
+                SELECT Name
+                FROM Profile
+        ]) {
+            if (result.containsKey(currentProfile.Name) == false) {
+                result.put(currentProfile.Name, new List<Profile>());
+            }
+            result.get(currentProfile.Name).add(currentProfile);
+        }
+
+        return result;
+    }
+}

--- a/src/classes/UTIL_Profile_TEST.cls-meta.xml
+++ b/src/classes/UTIL_Profile_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>42.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
# Critical Changes

# Changes
- The owner ID for an automatically-created Account will now be set to match the owner ID for the Contact.

# Issues Closed
Fixes #622. 

# New Metadata

# Deleted Metadata

# Testing Notes
