### PR TITLE
Refactoring custom label references in HEDA setting page

### DIFF
--- a/src/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_DropdownHelper.js
+++ b/src/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_DropdownHelper.js
@@ -8,11 +8,7 @@
     onSelectChange : function(component) {
         var selectedVal = component.find("nameFormatDropDown").get("v.value");
         var prefix = component.get("v.namespacePrefix");
-        if (prefix === 'hed__') {
-            var accNamingOther = $A.get("$Label.hed.acctNamingOther");
-        } else {
-            var accNamingOther = $A.get("$Label.c.acctNamingOther");
-        }
+        var accNamingOther = $A.get("$Label.c.acctNamingOther");
         if(selectedVal === accNamingOther) {
             component.set("v.otherDisplay", true);
         } else {
@@ -28,11 +24,7 @@
         component.set("v.setting", selectedVal);
         component.set("v.nameFormat", selectedVal);
         var prefix = component.get("v.namespacePrefix");
-        if (prefix === 'hed__') {
-            var accNamingOther = $A.get("$Label.hed.acctNamingOther");
-        } else {
-            var accNamingOther = $A.get("$Label.c.acctNamingOther");
-        }
+        var accNamingOther = $A.get("$Label.c.acctNamingOther");
         if (selectedVal === ($A.get("$Label.c.acctNamingOther")))
         {
             selectedVal = component.find("otherText").get("v.value");
@@ -43,43 +35,23 @@
     getAdminAccNameFormatOptions : function(component) {
         var adminAccNameFormatOptions = [];
         var prefix = component.get("v.namespacePrefix");
-        if (prefix === 'hed__')
-        {
-            adminAccNameFormatOptions.push($A.get("$Label.hed.lastNameAdminAcc"));
-            adminAccNameFormatOptions.push($A.get("$Label.hed.firstNameLastNameAdminACC"));
-            adminAccNameFormatOptions.push($A.get("$Label.hed.lastNameFirstNameAdminAcc"));
-            adminAccNameFormatOptions.push($A.get("$Label.hed.acctNamingOther"));
-        }else{
-            adminAccNameFormatOptions.push($A.get("$Label.c.lastNameAdminAcc"));
-            adminAccNameFormatOptions.push($A.get("$Label.c.firstNameLastNameAdminACC"));
-            adminAccNameFormatOptions.push($A.get("$Label.c.lastNameFirstNameAdminAcc"));  
-            adminAccNameFormatOptions.push($A.get("$Label.c.acctNamingOther"));
-          
-        }
+        adminAccNameFormatOptions.push($A.get("$Label.c.lastNameAdminAcc"));
+        adminAccNameFormatOptions.push($A.get("$Label.c.firstNameLastNameAdminACC"));
+        adminAccNameFormatOptions.push($A.get("$Label.c.lastNameFirstNameAdminAcc"));
+        adminAccNameFormatOptions.push($A.get("$Label.c.acctNamingOther"));
         component.set("v.adminAccNameFormatOptions", adminAccNameFormatOptions);
     },
 
     getHHAccNameFormatOptions : function(component) {
         var hhNameFormatOptions = [];
         var prefix = component.get("v.namespacePrefix");
-        if (prefix === 'hed__')
-        {
-            hhNameFormatOptions.push($A.get("$Label.hed.lastNameHH"));
-            hhNameFormatOptions.push($A.get("$Label.hed.lastNameFirstNameHH"));
-            hhNameFormatOptions.push($A.get("$Label.hed.firstNameLastNameHH"));
-            hhNameFormatOptions.push($A.get("$Label.hed.lastNameFamily"));
-            hhNameFormatOptions.push($A.get("$Label.hed.lastNameFirstNameFamily"));
-            hhNameFormatOptions.push($A.get("$Label.hed.firstNameLastNameFamily"));
-            hhNameFormatOptions.push($A.get("$Label.hed.acctNamingOther"));
-        }else{
-            hhNameFormatOptions.push($A.get("$Label.c.lastNameHH"));
-            hhNameFormatOptions.push($A.get("$Label.c.lastNameFirstNameHH"));
-            hhNameFormatOptions.push($A.get("$Label.c.firstNameLastNameHH"));
-            hhNameFormatOptions.push($A.get("$Label.c.lastNameFamily"));
-            hhNameFormatOptions.push($A.get("$Label.c.lastNameFirstNameFamily"));
-            hhNameFormatOptions.push($A.get("$Label.c.firstNameLastNameFamily"));
-            hhNameFormatOptions.push($A.get("$Label.c.acctNamingOther"));
-        }
+        hhNameFormatOptions.push($A.get("$Label.c.lastNameHH"));
+        hhNameFormatOptions.push($A.get("$Label.c.lastNameFirstNameHH"));
+        hhNameFormatOptions.push($A.get("$Label.c.firstNameLastNameHH"));
+        hhNameFormatOptions.push($A.get("$Label.c.lastNameFamily"));
+        hhNameFormatOptions.push($A.get("$Label.c.lastNameFirstNameFamily"));
+        hhNameFormatOptions.push($A.get("$Label.c.firstNameLastNameFamily"));
+        hhNameFormatOptions.push($A.get("$Label.c.acctNamingOther"));
         component.set("v.hhNameFormatOptions", hhNameFormatOptions);
     }
 })

--- a/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
+++ b/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
@@ -111,12 +111,7 @@
         </div>
 
         <div class="slds-col slds-size--1-of-2">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgSimpleAddressChangeUpdate}" class="slds-text-body--small" />
-                <aura:set attribute="else">
-                    <ui:outputText value="{!$Label.c.stgSimpleAddressChangeUpdate}" class="slds-text-body--small" />
-                </aura:set>
-            </aura:if>      
+            <ui:outputText value="{!$Label.c.stgSimpleAddressChangeUpdate}" class="slds-text-body--small" />     
         </div>
         <div class="slds-col slds-size--1-of-2">
             <div class="slds-form-element">

--- a/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
+++ b/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
@@ -11,12 +11,7 @@
 
     <div class="slds-grid slds-wrap">
         <div class="slds-col slds-size--1-of-2">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgDisablePreferredEmailEnforcement}"/>
-                <aura:set attribute="else">
-                    <ui:outputText value="{!$Label.c.stgDisablePreferredEmailEnforcement}"/>
-                </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgDisablePreferredEmailEnforcement}"/>
         </div>
         <div class="slds-col slds-size--1-of-2">
             <div class="slds-form-element">
@@ -37,62 +32,33 @@
             </div>
         </div>
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgHelpContactPreferredEmail}" class="slds-text-body--small" />
-                <aura:set attribute="else">
-                    <ui:outputText value="{!$Label.c.stgHelpContactPreferredEmail}" class="slds-text-body--small" />
-                </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgHelpContactPreferredEmail}" class="slds-text-body--small" />
         </div>
 
         <div class="slds-col slds-size--1-of-2 slds-p-right--xx-large">
             <h2>
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputText value="{!$Label.hed.stgPreferredEmailDataCleanup}" class="slds-text-body--small" />
-                    <aura:set attribute="else">
-                        <ui:outputText value="{!$Label.c.stgPreferredEmailDataCleanup}" class="slds-text-body--small" />
-                    </aura:set>
-                </aura:if>
+                <ui:outputText value="{!$Label.c.stgPreferredEmailDataCleanup}" class="slds-text-body--small" />
             </h2>
             <div class="slds-text-body--small">
                 <p>
-                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        <ui:outputText value="{!$Label.hed.stgRunCleanUpEnableFirstTime}" class="slds-text-body--small" />
-                        <aura:set attribute="else">
-                            <ui:outputText value="{!$Label.c.stgRunCleanUpEnableFirstTime}" class="slds-text-body--small" />
-                        </aura:set>
-                    </aura:if>
+                    <ui:outputText value="{!$Label.c.stgRunCleanUpEnableFirstTime}" class="slds-text-body--small" />
                 </p>
                 <p>
-                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        <ui:outputText value="{!$Label.hed.stgHelpEnsureExistContactPreferEmail}" class="slds-text-body--small" />
-                        <aura:set attribute="else">
-                            <ui:outputText value="{!$Label.c.stgHelpEnsureExistContactPreferEmail}" class="slds-text-body--small" />
-                        </aura:set>
-                    </aura:if>                    
+                    <ui:outputText value="{!$Label.c.stgHelpEnsureExistContactPreferEmail}" class="slds-text-body--small" />
                 </p>
             </div>
         </div>
         <div class="slds-col slds-size--1-of-2">
             <lightning:button variant="brand" label="Run Cleanup" iconName="utility:copy" iconPosition="left" onclick="{! c.runCleanUp }" aura:id="cleanUpBtn" disabled="{!or(and(v.hierarchySettings.Disable_Preferred_Email_Enforcement__c , v.isView), !v.isView)}"  />
             <br />
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText aura:id="cleanUpMsg" value="{!$Label.hed.stgCleanupQueuedEmailSent}" class="slds-text-color--weak slds-hide" />
-                <aura:set attribute="else">
-                    <ui:outputText aura:id="cleanUpMsg" value="{!$Label.c.stgCleanupQueuedEmailSent}" class="slds-text-color--weak slds-hide" />
-                </aura:set>
-            </aura:if>
+            <ui:outputText aura:id="cleanUpMsg" value="{!$Label.c.stgCleanupQueuedEmailSent}" class="slds-text-color--weak slds-hide" />
         </div>
 
         <hr class="slds-border--top slds-m-top--medium slds-m-bottom--medium" style="width:100%;" />
         
         <div class="slds-col slds-size--1-of-2">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgContactMultiAddressesEnabled}" class="slds-text-body--small" />
-                <aura:set attribute="else">
-                    <ui:outputText value="{!$Label.c.stgContactMultiAddressesEnabled}" class="slds-text-body--small" />
-                </aura:set>
-            </aura:if></div>
+            <ui:outputText value="{!$Label.c.stgContactMultiAddressesEnabled}" class="slds-text-body--small" />
+        </div>
         <div class="slds-col slds-size--1-of-2">
             <div class="slds-form-element">
                 <div class="slds-form-element__control">
@@ -112,21 +78,11 @@
             </div>
         </div>
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgHelpContactAddrs}" class="slds-text-body--small" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgHelpContactAddrs}" class="slds-text-body--small" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgHelpContactAddrs}" class="slds-text-body--small" />
         </div>
 
-        <div class="slds-col slds-size--1-of-2">            
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgAccountRecordTypeSupportsHHAddress}" class="slds-text-body--small" />
-                <aura:set attribute="else">
-                    <ui:outputText value="{!$Label.c.stgAccountRecordTypeSupportsHHAddress}" class="slds-text-body--small" />
-                </aura:set>
-            </aura:if>
+        <div class="slds-col slds-size--1-of-2">
+            <ui:outputText value="{!$Label.c.stgAccountRecordTypeSupportsHHAddress}" class="slds-text-body--small" />
         </div>
         <div class="slds-col slds-size--1-of-2">
             <c:CMP_RecTypes_Dropdown class="hh-addresses-account-record-type"
@@ -139,29 +95,14 @@
         </div>
 
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgHelpHouseholdRecType}" class="slds-text-body--small" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgHelpHouseholdRecType}" class="slds-text-body--small" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgHelpHouseholdRecType}" class="slds-text-body--small" />
         </div>
 
         <div class="slds-col slds-size--1-of-2">
-            <div>            
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputText value="{!$Label.hed.stgAccountTypesMultiAddressesEnabled}" class="slds-text-body--small" />
-                    <aura:set attribute="else">
-                        <ui:outputText value="{!$Label.c.stgAccountTypesMultiAddressesEnabled}" class="slds-text-body--small" />
-                    </aura:set>
-                </aura:if>
+            <div>
+                <ui:outputText value="{!$Label.c.stgAccountTypesMultiAddressesEnabled}" class="slds-text-body--small" />
             </div>
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgHelpAddressAccRecType}" class="slds-text-body--small" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgHelpAddressAccRecType}" class="slds-text-body--small" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgHelpAddressAccRecType}" class="slds-text-body--small" />
         </div>
         <div class="slds-col slds-size--1-of-2 slds-m-bottom--medium">
             <c:CMP_RecTypes setting="{!v.hierarchySettings.Accounts_Addresses_Enabled__c}"
@@ -196,30 +137,15 @@
             </div>
         </div>
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgHelpSimpleAddrChangeIsUpdate}" class="slds-text-body--small" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgHelpSimpleAddrChangeIsUpdate}" class="slds-text-body--small" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgHelpSimpleAddrChangeIsUpdate}" class="slds-text-body--small" />
         </div>
 
         <div class="slds-col slds-size--1-of-2">
             <div>
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputText value="{!$Label.hed.stgAccoutTypesWithoutContactsDelete}" class="slds-text-body--small" />
-                    <aura:set attribute="else">
-                        <ui:outputText value="{!$Label.c.stgAccoutTypesWithoutContactsDelete}" class="slds-text-body--small" />
-                    </aura:set>
-                </aura:if> 
+                <ui:outputText value="{!$Label.c.stgAccoutTypesWithoutContactsDelete}" class="slds-text-body--small" />
             </div>
             <div class="slds-text-body--small">
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputText value="{!$Label.hed.stgHelpAccoutsDeletedIfChildContactsDeleted}" class="slds-text-body--small" />
-                    <aura:set attribute="else">
-                        <ui:outputText value="{!$Label.c.stgHelpAccoutsDeletedIfChildContactsDeleted}" class="slds-text-body--small" />
-                    </aura:set>
-                </aura:if> 
+                <ui:outputText value="{!$Label.c.stgHelpAccoutsDeletedIfChildContactsDeleted}" class="slds-text-body--small" />
             </div>
         </div>
         <div class="slds-col slds-size--1-of-2">
@@ -232,83 +158,38 @@
 
         <div class="slds-col slds-size--1-of-2 slds-p-top--large slds-m-top--large slds-border--top slds-p-right--xx-large">
             <h2>
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputText value="{!$Label.hed.stgEthnicityRaceBackfillContacts}" class="slds-text-body--small" />
-                    <aura:set attribute="else">
-                        <ui:outputText value="{!$Label.c.stgEthnicityRaceBackfillContacts}" class="slds-text-body--small" />
-                    </aura:set>
-                </aura:if> 
+                <ui:outputText value="{!$Label.c.stgEthnicityRaceBackfillContacts}" class="slds-text-body--small" />
             </h2>
             <div class="slds-text-body--small">
 
                 <p>
-                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        <ui:outputText value="{!$Label.hed.stgHelpEthnicityRaceBackfill}" class="slds-text-body--small" />
-                        <aura:set attribute="else">
-                            <ui:outputText value="{!$Label.c.stgHelpEthnicityRaceBackfill}" class="slds-text-body--small" />
-                        </aura:set>
-                    </aura:if>
+                    <ui:outputText value="{!$Label.c.stgHelpEthnicityRaceBackfill}" class="slds-text-body--small" />
                 </p>
                 <br />
                 <h3><strong>
-                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        <ui:outputText value="{!$Label.hed.stgBeforeRunBackfill}" class="slds-text-body--small" />
-                        <aura:set attribute="else">
-                            <ui:outputText value="{!$Label.c.stgBeforeRunBackfill}" class="slds-text-body--small" />
-                        </aura:set>
-                    </aura:if>
+                        <ui:outputText value="{!$Label.c.stgBeforeRunBackfill}" class="slds-text-body--small" />
                 </strong></h3>
                 <ul class="slds-list--dotted">
                     <li>
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:outputText value="{!$Label.hed.stgAddNotHispanicOrLatinoPicklistValue}" class="slds-text-body--small" />
-                            <aura:set attribute="else">
-                                <ui:outputText value="{!$Label.c.stgAddNotHispanicOrLatinoPicklistValue}" class="slds-text-body--small" />
-                            </aura:set>
-                        </aura:if>
+                        <ui:outputText value="{!$Label.c.stgAddNotHispanicOrLatinoPicklistValue}" class="slds-text-body--small" />
                     </li>
                     <li>
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:outputText value="{!$Label.hed.stgAddHispanicOrLatinoPicklistValue}" class="slds-text-body--small" />
-                            <aura:set attribute="else">
-                                <ui:outputText value="{!$Label.c.stgAddHispanicOrLatinoPicklistValue}" class="slds-text-body--small" />
-                            </aura:set>
-                        </aura:if>
+                        <ui:outputText value="{!$Label.c.stgAddHispanicOrLatinoPicklistValue}" class="slds-text-body--small" />
                     </li>
                 </ul>
                 <br />
                 <h3><strong>
-                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        <ui:outputText value="{!$Label.hed.stgAfterRunBackfill}" class="slds-text-body--small" />
-                        <aura:set attribute="else">
-                            <ui:outputText value="{!$Label.c.stgAfterRunBackfill}" class="slds-text-body--small" />
-                        </aura:set>
-                    </aura:if>
+                        <ui:outputText value="{!$Label.c.stgAfterRunBackfill}" class="slds-text-body--small" />
                 </strong></h3>
                 <ul class="slds-list--dotted">
                     <li>
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:outputText value="{!$Label.hed.stgHelpIfCustomValuesEthnicityCopyRace}" class="slds-text-body--small" />
-                            <aura:set attribute="else">
-                                <ui:outputText value="{!$Label.c.stgHelpIfCustomValuesEthnicityCopyRace}" class="slds-text-body--small" />
-                            </aura:set>
-                        </aura:if>
+                        <ui:outputText value="{!$Label.c.stgHelpIfCustomValuesEthnicityCopyRace}" class="slds-text-body--small" />
                     </li>
                     <li>
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:outputText value="{!$Label.hed.stgHelpRemoveAllPicklistValuesEthnicityExceptHispanicOrLatino}" class="slds-text-body--small" />
-                            <aura:set attribute="else">
-                                <ui:outputText value="{!$Label.c.stgHelpRemoveAllPicklistValuesEthnicityExceptHispanicOrLatino}" class="slds-text-body--small" />
-                            </aura:set>
-                        </aura:if>
+                        <ui:outputText value="{!$Label.c.stgHelpRemoveAllPicklistValuesEthnicityExceptHispanicOrLatino}" class="slds-text-body--small" />
                     </li>
                     <li>
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:outputText value="{!$Label.hed.stgHelpUpdateReportIfDependenciesEthnicity}" class="slds-text-body--small" />
-                            <aura:set attribute="else">
-                                <ui:outputText value="{!$Label.c.stgHelpUpdateReportIfDependenciesEthnicity}" class="slds-text-body--small" />
-                            </aura:set>
-                        </aura:if>
+                        <ui:outputText value="{!$Label.c.stgHelpUpdateReportIfDependenciesEthnicity}" class="slds-text-body--small" />
                     </li>
                 </ul>
             </div>
@@ -316,12 +197,7 @@
         <div class="slds-col slds-size--1-of-2 slds-p-top--large slds-m-top--large slds-border--top">
             <lightning:button variant="brand" label="Run Backfill" iconName="utility:copy" iconPosition="left" onclick="{! c.runBackfill }" aura:id="ethnicRaceBtn" />
             <br />
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputText aura:id="ethnicRaceMsg" value="{!$Label.hed.stgBackfillQueuedEmailSent}" class="slds-text-color--weak slds-hide" />
-                    <aura:set attribute="else">
-                        <ui:outputText aura:id="ethnicRaceMsg" value="{!$Label.c.stgBackfillQueuedEmailSent}" class="slds-text-color--weak slds-hide" />
-                    </aura:set>
-            </aura:if>
+            <ui:outputText aura:id="ethnicRaceMsg" value="{!$Label.c.stgBackfillQueuedEmailSent}" class="slds-text-color--weak slds-hide" />
         </div>
         
     </div>

--- a/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp
+++ b/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp
@@ -11,42 +11,22 @@
     <div id="afflTabs" class="slds-tabs--scoped">
         <ul class="slds-tabs--scoped__nav" role="tablist">
             <li aura:id="settsTab" class="slds-tabs__item slds-text-heading--label" title="Settings" role="tab">
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        <ui:outputURL value="#" label="{!$Label.hed.stgTabSettings}" click="{!c.settsLinkClicked}" class="affl-settings-menulink" />
-                    <aura:set attribute="else">
-                        <ui:outputURL value="#" label="{!$Label.c.stgTabSettings}" click="{!c.settsLinkClicked}" class="affl-settings-menulink" />
-                    </aura:set>
-                </aura:if>
+                <ui:outputURL value="#" label="{!$Label.c.stgTabSettings}" click="{!c.settsLinkClicked}" class="affl-settings-menulink" />
             </li>
             <li aura:id="mappingsTab" class="slds-tabs__item slds-text-heading--label" title="Affiliation Mappings" role="tab">
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputURL value="#" label="{!$Label.hed.stgTabAfflMappings}" click="{!c.mappingsLinkClicked}" class="affl-mappings-menulink"/>
-                    <aura:set attribute="else">
-                        <ui:outputURL value="#" label="{!$Label.c.stgTabAfflMappings}" click="{!c.mappingsLinkClicked}" class="affl-mappings-menulink"/>
-                    </aura:set>
-                </aura:if>
+                <ui:outputURL value="#" label="{!$Label.c.stgTabAfflMappings}" click="{!c.mappingsLinkClicked}" class="affl-mappings-menulink"/>
             </li>
         </ul>
         
         <div aura:id="settsTabContent" class="slds-tabs__content" role="tabpanel">
             <div class="slds-grid slds-wrap">
                 <div class="slds-col slds-size--1-of-1">
-                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        <ui:outputText value="{!$Label.hed.AfflProgEnrollDeleted + ' '}" />
-                    <aura:set attribute="else">
-                        <ui:outputText value="{!$Label.c.AfflProgEnrollDeleted + ' '}" />
-                    </aura:set>
-                    </aura:if>
+                    <ui:outputText value="{!$Label.c.AfflProgEnrollDeleted + ' '}" />
                 </div>
                 <div class="slds-col slds-grid slds-wrap slds-size--1-of-1 slds-m-top--medium">
                     
                     <div class="slds-col slds-size--1-of-2">
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:outputText value="{!$Label.hed.stgDeleteRelatedAfflYes + ' '}" />
-                        <aura:set attribute="else">
-                            <ui:outputText value="{!$Label.c.stgDeleteRelatedAfflYes + ' '}" />
-                        </aura:set>
-                        </aura:if>                        
+                        <ui:outputText value="{!$Label.c.stgDeleteRelatedAfflYes + ' '}" />
                     </div> 
                     <div class="slds-col slds-size--1-of-2">
                          <aura:if isTrue="{!v.hierarchySettings.Affl_ProgEnroll_Del__c}">
@@ -62,12 +42,7 @@
                     <div class="slds-col slds-size--1-of-2">
                          <div class="slds-col slds-grid slds-wrap">
                             <div class="slds-col slds-size--1-of-2">
-                                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                                    <ui:outputText value="{!$Label.hed.stgDeleteRelatedAfflNo + ' '}" />
-                                <aura:set attribute="else">
-                                    <ui:outputText value="{!$Label.c.stgDeleteRelatedAfflNo + ' '}" />
-                                </aura:set>
-                                </aura:if> 
+                                <ui:outputText value="{!$Label.c.stgDeleteRelatedAfflNo + ' '}" />
                             </div>
                             <div class="slds-col slds-size--1-of-2">
                                 <aura:if isTrue="{!v.isView}">
@@ -98,64 +73,34 @@
         
         <div aura:id="mappingsTabContent" class="slds-tabs__content" role="tabpanel">
             <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputText value="{!$Label.hed.AfflMappingsDescription + ' '}" class="slds-text-body--small" />
-                <aura:set attribute="else">
-                    <ui:outputText value="{!$Label.c.AfflMappingsDescription + ' '}" class="slds-text-body--small" />
-                </aura:set>
-                </aura:if>
+                <ui:outputText value="{!$Label.c.AfflMappingsDescription + ' '}" class="slds-text-body--small" />
                 <ui:outputURL value="http://powerofus.force.com/HEDA_Affiliations" class="slds-text-body--small slds-type-focus" 
                     label="HEDA documentation." target="_blank" />
             </div>
             <div class="slds-grid slds-wrap">
                 <div class="slds-col slds-size--1-of-6">
                     <strong>
-                       <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:outputText value="{!$Label.hed.stgColAccountRecordType + ' '}" />
-                            <aura:set attribute="else">
-                                <ui:outputText value="{!$Label.c.stgColAccountRecordType + ' '}" />
-                            </aura:set>
-                        </aura:if> 
+                        <ui:outputText value="{!$Label.c.stgColAccountRecordType + ' '}" />
                     </strong>
                 </div>
                  <div class="slds-col slds-size--1-of-6">
                     <strong>
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:outputText value="{!$Label.hed.stgColContactPrimaryAfflField + ' '}" />
-                            <aura:set attribute="else">
-                                <ui:outputText value="{!$Label.c.stgColContactPrimaryAfflField + ' '}" />
-                            </aura:set>
-                        </aura:if> 
+                        <ui:outputText value="{!$Label.c.stgColContactPrimaryAfflField + ' '}" />
                     </strong>
                 </div>
                  <div class="slds-col slds-size--1-of-6">
                     <strong>
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:outputText value="{!$Label.hed.stgAutoEnrollment + ' '}" />
-                            <aura:set attribute="else">
-                                <ui:outputText value="{!$Label.c.stgAutoEnrollment + ' '}" />
-                            </aura:set>
-                        </aura:if>
+                        <ui:outputText value="{!$Label.c.stgAutoEnrollment + ' '}" />
                     </strong>
                 </div>
                  <div class="slds-col slds-size--1-of-6">
                     <strong>
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:outputText value="{!$Label.hed.stgAutoEnrollmentStatus + ' '}" />
-                            <aura:set attribute="else">
-                                <ui:outputText value="{!$Label.c.stgAutoEnrollmentStatus + ' '}" />
-                            </aura:set>
-                        </aura:if>
+                        <ui:outputText value="{!$Label.c.stgAutoEnrollmentStatus + ' '}" />
                     </strong>
                 </div>
                  <div class="slds-col slds-size--1-of-6">
                     <strong>
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:outputText value="{!$Label.hed.stgAutoEnrollmentRole + ' '}" />
-                            <aura:set attribute="else">
-                                <ui:outputText value="{!$Label.c.stgAutoEnrollmentRole + ' '}" />
-                            </aura:set>
-                        </aura:if>
+                        <ui:outputText value="{!$Label.c.stgAutoEnrollmentRole + ' '}" />
                     </strong>
                 </div>
                  <div class="slds-col slds-size--1-of-6">&nbsp;</div>
@@ -227,12 +172,7 @@
                 <div aria-labelledby="newafflmappingform">
                     <fieldset class="slds-box slds-form--compound slds-theme--default slds-container--medium">
                         <legend id="newafflmappingform" class="slds-text-heading--medium slds-p-vertical--medium">
-                            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                                <ui:outputText value="{!$Label.hed.stgNewAfflMapping}" />
-                                <aura:set attribute="else">
-                                    <ui:outputText value="{!$Label.c.stgNewAfflMapping}" />
-                                </aura:set>
-                            </aura:if>
+                            <ui:outputText value="{!$Label.c.stgNewAfflMapping}" />
                         </legend>
 
                         <div class="slds-form-element__group">
@@ -240,34 +180,19 @@
 
                             <div class="slds-form-element slds-size--1-of-6">
                                 <div class="slds-form-element__control">
-                                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                                        <ui:inputText aura:id="accRecType" class="slds-m-right--medium acc-rec-type-new slds-input" label="{!$Label.hed.stgColAccountRecordType}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newAfflMappingKeyup}"/>
-                                        <aura:set attribute="else">
-                                            <ui:inputText aura:id="accRecType" class="slds-m-right--medium acc-rec-type-new slds-input" label="{!$Label.c.stgColAccountRecordType}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newAfflMappingKeyup}"/>
-                                        </aura:set>
-                                    </aura:if>
+                                    <ui:inputText aura:id="accRecType" class="slds-m-right--medium acc-rec-type-new slds-input" label="{!$Label.c.stgColAccountRecordType}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newAfflMappingKeyup}"/>
                                 </div>
                             </div>
 
                             <div class="slds-form-element slds-size--1-of-6">
                                 <div class="slds-form-element__control">
-                                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                                        <ui:inputText aura:id="primaryField" class="slds-m-right--medium primary-affl-field-new slds-input" label="{!$Label.c.stgTabPrimaryAfflField}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newAfflMappingKeyup}"/>
-                                        <aura:set attribute="else">
-                                            <ui:inputText aura:id="primaryField" class="slds-m-right--medium primary-affl-field-new slds-input" label="{!$Label.c.stgTabPrimaryAfflField}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newAfflMappingKeyup}"/>
-                                        </aura:set>
-                                    </aura:if>                                    
+                                    <ui:inputText aura:id="primaryField" class="slds-m-right--medium primary-affl-field-new slds-input" label="{!$Label.c.stgTabPrimaryAfflField}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newAfflMappingKeyup}"/>
                                 </div>
                             </div>
 
                             <div class="slds-form-element slds-size--1-of-6">
                                 <label class="slds-form-element__label" for="autoEnroll">&nbsp;
-                                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                                        <ui:outputText value="{!$Label.hed.stgAutoEnrollment}" />
-                                        <aura:set attribute="else">
-                                            <ui:outputText value="{!$Label.c.stgAutoEnrollment}" />
-                                        </aura:set>
-                                    </aura:if>
+                                    <ui:outputText value="{!$Label.c.stgAutoEnrollment}" />
                                 </label>
                                 <br />
                                 <div class="slds-form-element__control">
@@ -281,35 +206,20 @@
 
                             <div class="slds-form-element slds-size--1-of-6">
                                 <div class="slds-form-element__control">
-                                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                                        <ui:inputText aura:id="autoEnrollStatus" class="slds-m-right--medium auto-enroll-status-new slds-input" label="{!$Label.hed.stgColStatus}" labelClass="slds-form-element__label" />
-                                        <aura:set attribute="else">
-                                            <ui:inputText aura:id="autoEnrollStatus" class="slds-m-right--medium auto-enroll-status-new slds-input" label="{!$Label.c.stgColStatus}" labelClass="slds-form-element__label" />
-                                        </aura:set>
-                                    </aura:if>                                     
+                                    <ui:inputText aura:id="autoEnrollStatus" class="slds-m-right--medium auto-enroll-status-new slds-input" label="{!$Label.c.stgColStatus}" labelClass="slds-form-element__label" />
                                 </div>
                             </div>
 
                             <div class="slds-form-element slds-size--1-of-6">
                                 <div class="slds-form-element__control">
-                                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                                        <ui:inputText aura:id="autoEnrollRole" label="{!$Label.hed.stgColRole}" labelClass="slds-form-element__label" class="auto-enroll-role-new slds-input" />
-                                        <aura:set attribute="else">
-                                            <ui:inputText aura:id="autoEnrollRole" label="{!$Label.c.stgColRole}" labelClass="slds-form-element__label" class="auto-enroll-role-new slds-input" />
-                                        </aura:set>
-                                    </aura:if>                                     
+                                    <ui:inputText aura:id="autoEnrollRole" label="{!$Label.c.stgColRole}" labelClass="slds-form-element__label" class="auto-enroll-role-new slds-input" />
                                 </div>
                             </div>
                         </div>
                         </div>
 
                         <ui:button aura:id="newAfflMappingBtn" class="slds-button slds-button--brand slds-m-top--medium affl-mapping-addnew" press="{!c.newAfflMapping}" disabled="true">
-                            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                                <ui:outputText value="{!$Label.hed.stgBtnAddMapping}" />
-                                <aura:set attribute="else">
-                                    <ui:outputText value="{!$Label.c.stgBtnAddMapping}" />
-                                </aura:set>
-                            </aura:if>
+                            <ui:outputText value="{!$Label.c.stgBtnAddMapping}" />
                         </ui:button>
                     </fieldset>
                 </div>

--- a/src/aura/STG_CMP_Base/STG_CMP_BaseHelper.js
+++ b/src/aura/STG_CMP_Base/STG_CMP_BaseHelper.js
@@ -134,19 +134,5 @@
 			}
 		}
 		return settingArrayTrim;
-	},
-
-	//Labels built dynamically will only be available if they are being referenced somewhere in the code.
-	//Note that this method isn't even called from anywhere.
-	hugeHack : function() {
-		try {
-			$A.get("$Label.hed.noAfflMappings");
-			$A.get("$Label.hed.noRecSettings");
-			$A.get("$Label.hed.noAutoCreateSettings");
-		} catch(e) {
-			$A.get("$Label.c.noAfflMappings");
-			$A.get("$Label.c.noRecSettings");
-			$A.get("$Label.c.noAutoCreateSettings");
-		}
 	}
 })

--- a/src/aura/STG_CMP_Container/STG_CMP_Container.cmp
+++ b/src/aura/STG_CMP_Container/STG_CMP_Container.cmp
@@ -8,12 +8,7 @@
 	<div class="slds-notify_container slds-hide" aura:id="notificationToast">
 		<div class="slds-notify slds-notify--toast slds-theme--error" role="alert">
 			<span class="slds-assistive-text">
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputText value="{!$Label.hed.stgToastError}" />
-                    <aura:set attribute="else">
-                        <ui:outputText value="{!$Label.c.stgToastError}" />
-                    </aura:set>
-                </aura:if>
+                <ui:outputText value="{!$Label.c.stgToastError}" />
 			</span>
 			<lightning:buttonIcon iconName="utility:close" variant="bare" onclick="{! c.hideToast }" alternativeText="Close" class="slds-icon slds-notify__close slds-button--icon-inverse" size="large" />
 			<div class="slds-notify__content slds-grid slds-align-middle">

--- a/src/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnections.cmp
+++ b/src/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnections.cmp
@@ -13,20 +13,10 @@
   <div id="relTabs" class="slds-tabs--scoped">
     <ul class="slds-tabs--scoped__nav" role="tablist">
       <li aura:id="settsTab" class="slds-tabs__item slds-text-heading--label slds-active" title="Settings" role="tab">
-        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-          <ui:outputURL value="#" label="{!$Label.hed.stgTabSettings}" class="rel-settings-menulink" click="{!c.settsLinkClicked}" />
-          <aura:set attribute="else">
-            <ui:outputURL value="#" label="{!$Label.c.stgTabSettings}" class="rel-settings-menulink" click="{!c.settsLinkClicked}" />
-          </aura:set>
-        </aura:if>
+        <ui:outputURL value="#" label="{!$Label.c.stgTabSettings}" class="rel-settings-menulink" click="{!c.settsLinkClicked}" />
       </li>
       <li aura:id="backfillTab" class="slds-tabs__item slds-text-heading--label" title="Backfill" role="tab">
-        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-          <ui:outputURL value="#" label="{!$Label.hed.stgTabBackfill}" class="rel-recip-settings-menulink"  click="{!c.backfillLinkClicked}" />
-          <aura:set attribute="else">
-            <ui:outputURL value="#" label="{!$Label.c.stgTabBackfill}" class="rel-recip-settings-menulink"  click="{!c.backfillLinkClicked}" />
-          </aura:set>
-        </aura:if>
+        <ui:outputURL value="#" label="{!$Label.c.stgTabBackfill}" class="rel-recip-settings-menulink"  click="{!c.backfillLinkClicked}" />
       </li>
     </ul>
 
@@ -38,12 +28,7 @@
             <div class="slds-notify slds-notify--alert slds-theme--error slds-theme--alert-texture" role="alert">
               <h2>
                 <lightning:icon iconName="utility:warning" size="small" class="slds-m-right--small enable-connection-error-icon" />
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                  <ui:outputText value="{!$Label.hed.stgHelpEnableCourseConnBeforeRecordTypes}" class="slds-text-body--small" />
-                  <aura:set attribute="else">
                     <ui:outputText value="{!$Label.c.stgHelpEnableCourseConnBeforeRecordTypes}" class="slds-text-body--small" />
-                  </aura:set>
-                </aura:if>
               </h2>
             </div>
           </div>
@@ -52,12 +37,7 @@
 
       <div class="slds-grid slds-wrap">
           <div class="slds-col slds-size--1-of-2">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-              {!$Label.hed.stgEnableCourseConnectionsTitle}
-            <aura:set attribute="else">
               {!$Label.c.stgEnableCourseConnectionsTitle}
-            </aura:set>
-            </aura:if>
           </div>
           <div class="slds-col slds-size--1-of-2">
             <label class="slds-checkbox">
@@ -74,21 +54,11 @@
             </label>
           </div>
           <div class="slds-col slds-size--1-of-1">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgHelpEnableCourseConnections}" class="slds-text-body--small" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgHelpEnableCourseConnections}" class="slds-text-body--small" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgHelpEnableCourseConnections}" class="slds-text-body--small" />
           </div>
           <div class="slds-col slds-grid slds-m-top--medium">
             <div class="slds-col slds-size--1-of-2">
-              <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                {!$Label.hed.stgDefaultStudentTypeTitle}
-              <aura:set attribute="else">
                 {!$Label.c.stgDefaultStudentTypeTitle}
-              </aura:set>
-              </aura:if>
             </div>
             <div class="slds-col slds-size--1-of-2">
               <c:CMP_RecTypes_Dropdown class="student-course-connection-record-type"
@@ -102,22 +72,12 @@
             </div>
           </div>
           <div class="slds-col slds-size--1-of-1">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgHelpDefaultStudentType}" class="slds-text-body--small" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgHelpDefaultStudentType}" class="slds-text-body--small" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgHelpDefaultStudentType}" class="slds-text-body--small" />
           </div>
 
           <div class="slds-col slds-grid slds-m-top--medium">
             <div class="slds-col slds-size--1-of-2">
-              <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                {!$Label.hed.stgDefaultFacultyTypeTitle}
-              <aura:set attribute="else">
                 {!$Label.c.stgDefaultFacultyTypeTitle}
-              </aura:set>
-              </aura:if>
             </div>
             <div class="slds-col slds-size--1-of-2">
               <c:CMP_RecTypes_Dropdown class="faculty-course-connection-record-type"
@@ -131,12 +91,7 @@
             </div>
           </div>
           <div class="slds-col slds-size--1-of-1">
-              <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                  <ui:outputText value="{!$Label.hed.stgHelpDefaultFacultyType}" class="slds-text-body--small" />
-              <aura:set attribute="else">
-                  <ui:outputText value="{!$Label.c.stgHelpDefaultFacultyType}" class="slds-text-body--small" />
-              </aura:set>
-              </aura:if>
+            <ui:outputText value="{!$Label.c.stgHelpDefaultFacultyType}" class="slds-text-body--small" />
           </div>
       </div>
     </div>
@@ -148,12 +103,7 @@
             <div class="slds-notify slds-notify--alert slds-theme--error slds-theme--alert-texture" role="alert">
               <h2>
                 <lightning:icon iconName="utility:warning" size="small" class="slds-m-right--small enable-connection-error-icon" />
-                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                      <ui:outputText value="{!$Label.hed.stgHelpEnableCourseConnBeforeBackfill}" class="slds-text-body--small" />
-                      <aura:set attribute="else">
-                        <ui:outputText value="{!$Label.c.stgHelpEnableCourseConnBeforeBackfill}" class="slds-text-body--small" />
-                      </aura:set>
-                    </aura:if>
+                    <ui:outputText value="{!$Label.c.stgHelpEnableCourseConnBeforeBackfill}" class="slds-text-body--small" />
               </h2>
             </div>
           </div>
@@ -161,22 +111,12 @@
       </span>
       <div class="slds-grid slds-wrap">
         <div class="slds-col slds-size--1-of-1">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-              <ui:outputText value="{!$Label.hed.stgTitleCourseConnectionBackfill}" class="slds-text-body--small" />
-              <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgTitleCourseConnectionBackfill}" class="slds-text-body--small" />
-              </aura:set>
-            </aura:if>
+          <ui:outputText value="{!$Label.c.stgTitleCourseConnectionBackfill}" class="slds-text-body--small" />
         </div>
       </div>
       <div class="slds-grid slds-wrap">
         <div class="slds-col slds-size--1-of-1">
-          <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-              <ui:outputText value="{!$Label.hed.stgHelpCourseConnBackfillDescription}" class="slds-text-body--small" />
-          <aura:set attribute="else">
-              <ui:outputText value="{!$Label.c.stgHelpCourseConnBackfillDescription}" class="slds-text-body--small" />
-          </aura:set>
-          </aura:if>
+          <ui:outputText value="{!$Label.c.stgHelpCourseConnBackfillDescription}" class="slds-text-body--small" />
         </div>
       </div>
       <div class="slds-grid slds-grid--align-center">
@@ -185,23 +125,13 @@
             <ui:inputCheckbox value="{!v.allowBackfill}" class="slds-checkbox allow-backfill-checkbox"
                               text="" disabled="{!not(v.hierarchySettings.Enable_Course_Connections__c)}"/>
             <span class="slds-checkbox--faux"></span>
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-              <ui:outputText value="{!$Label.hed.stgConfirmReadyRunBackfill}" class="slds-text-body--small" />
-              <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgConfirmReadyRunBackfill}" class="slds-text-body--small" />
-              </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgConfirmReadyRunBackfill}" class="slds-text-body--small" />
           </label>
         </div>
       </div>
       <div class="slds-grid slds-grid--align-center slds-m-top--medium">
         <div>
-          <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-            <ui:button class="slds-button slds-button--neutral settings-edit-bttn" disabled="{!or(not(v.allowBackfill), v.backfillStarted)}" label="{!$Label.hed.stgBtnRunBackfill}" press="{!c.startBackfill}"/>            
-            <aura:set attribute="else">
-              <ui:button class="slds-button slds-button--neutral settings-edit-bttn" disabled="{!or(not(v.allowBackfill), v.backfillStarted)}" label="{!$Label.c.stgBtnRunBackfill}" press="{!c.startBackfill}"/>            
-            </aura:set>
-          </aura:if>
+          <ui:button class="slds-button slds-button--neutral settings-edit-bttn" disabled="{!or(not(v.allowBackfill), v.backfillStarted)}" label="{!$Label.c.stgBtnRunBackfill}" press="{!c.startBackfill}"/>
         </div>
       </div>
       <div class="slds-grid slds-grid--align-center slds-m-top--medium">

--- a/src/aura/STG_CMP_Courses/STG_CMP_Courses.cmp
+++ b/src/aura/STG_CMP_Courses/STG_CMP_Courses.cmp
@@ -5,12 +5,7 @@
 				<div class="slds-media__body">
 					<h2>
 						<span class="slds-text-heading--small">
-							<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-				                <ui:outputText value="{!$Label.hed.stgTitleCoursesDescriptionDataMigration}" class="slds-text-body--small" />
-				                <aura:set attribute="else">
-				                    <ui:outputText value="{!$Label.c.stgTitleCoursesDescriptionDataMigration}" class="slds-text-body--small" />
-				                </aura:set>
-				            </aura:if>
+							<ui:outputText value="{!$Label.c.stgTitleCoursesDescriptionDataMigration}" class="slds-text-body--small" />
         				</span>
 					</h2>
 				</div>
@@ -18,47 +13,20 @@
 		</div>
 		<div class="slds-card__body">
 			<div class="slds-p-around--medium">
-				<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-	                <ui:outputText value="{!$Label.hed.stgHelpCoursesDataMigration}" class="slds-text-body--small" />
-	                <aura:set attribute="else">
-	                    <ui:outputText value="{!$Label.c.stgHelpCoursesDataMigration}" class="slds-text-body--small" />
-	                </aura:set>
-	            </aura:if><br />
-				<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-	                <ui:outputText value="{!$Label.hed.stgHelpCoursesDataMigrationCopiesValues}" class="slds-text-body--small" />
-	                <aura:set attribute="else">
-	                    <ui:outputText value="{!$Label.c.stgHelpCoursesDataMigrationCopiesValues}" class="slds-text-body--small" />
-	                </aura:set>
-	            </aura:if><br />
-				<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-	                <ui:outputText value="{!$Label.hed.stgHelpCoursesDataMigrationDontOverwrite}" class="slds-text-body--small" />
-	                <aura:set attribute="else">
-	                    <ui:outputText value="{!$Label.c.stgHelpCoursesDataMigrationDontOverwrite}" class="slds-text-body--small" />
-	                </aura:set>
-	            </aura:if><br /><br />
+				<ui:outputText value="{!$Label.c.stgHelpCoursesDataMigration}" class="slds-text-body--small" />
+				<br />
+				<ui:outputText value="{!$Label.c.stgHelpCoursesDataMigrationCopiesValues}" class="slds-text-body--small" />
+				<br />
+				<ui:outputText value="{!$Label.c.stgHelpCoursesDataMigrationDontOverwrite}" class="slds-text-body--small" />
+				<br /><br />
 
-				<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-	                <ui:outputText value="{!$Label.hed.stgHelpCoursesDataMigrationUpdatePageLayouts}" class="slds-text-body--small" />
-	                <aura:set attribute="else">
-	                    <ui:outputText value="{!$Label.c.stgHelpCoursesDataMigrationUpdatePageLayouts}" class="slds-text-body--small" />
-	                </aura:set>
-	            </aura:if>
+				<ui:outputText value="{!$Label.c.stgHelpCoursesDataMigrationUpdatePageLayouts}" class="slds-text-body--small" />
 			</div>
 		</div>
 		<div class="slds-card__footer">
 			<div class="slds-no-flex">
-				<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-					<ui:outputText aura:id="descCopyMsg" value="{!$Label.hed.stgHelpCopyQueuedEmailSent}" class="slds-text-color--weak slds-hide slds-m-right--medium" />
-	                <aura:set attribute="else">
-						<ui:outputText aura:id="descCopyMsg" value="{!$Label.c.stgHelpCopyQueuedEmailSent}" class="slds-text-color--weak slds-hide slds-m-right--medium" />
-	                </aura:set>
-	            </aura:if>
-				<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-	                <ui:outputText value="{!$Label.hed.stgBtnRunCopy}" class="slds-text-body--small" />
-	                <aura:set attribute="else">
-						<lightning:button variant="brand" label="{!$Label.c.stgBtnRunCopy}" iconName="utility:copy" iconPosition="left" onclick="{! c.startCourseDescriptionCopy }" aura:id="descCopyBtn" />
-	                </aura:set>
-	            </aura:if>
+				<ui:outputText aura:id="descCopyMsg" value="{!$Label.c.stgHelpCopyQueuedEmailSent}" class="slds-text-color--weak slds-hide slds-m-right--medium" />
+				<lightning:button variant="brand" label="{!$Label.c.stgBtnRunCopy}" iconName="utility:copy" iconPosition="left" onclick="{! c.startCourseDescriptionCopy }" aura:id="descCopyBtn" />
 			</div>
 		</div>
 	</div>

--- a/src/aura/STG_CMP_Header/STG_CMP_Header.cmp
+++ b/src/aura/STG_CMP_Header/STG_CMP_Header.cmp
@@ -25,20 +25,10 @@
 
                     <div class="slds-media__body">
                         <p class="slds-text-heading--label">
-                            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                                <ui:outputText value="{!$Label.hed.stgTitleHEDASettings}"/>
-                                <aura:set attribute="else">
-                                    <ui:outputText value="{!$Label.c.stgTitleHEDASettings}"/>
-                                </aura:set>
-                            </aura:if>
+                            <ui:outputText value="{!$Label.c.stgTitleHEDASettings}"/>
                         </p>
                         <h1 class="slds-text-heading--medium">
-                            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                                <ui:outputText value="{!$Label.hed.stgTitleHEDAConfig}"/>
-                                <aura:set attribute="else">
-                                    <ui:outputText value="{!$Label.c.stgTitleHEDAConfig}"/>
-                                </aura:set>
-                            </aura:if>
+                            <ui:outputText value="{!$Label.c.stgTitleHEDAConfig}"/>
                         </h1>
                     </div>
 
@@ -50,25 +40,10 @@
             <div class="slds-col slds-no-flex slds-align-middle">
                 <div class="slds-button-group" role="group">
                     <aura:if isTrue="{!v.isView}">
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:button class="slds-button slds-button--neutral settings-edit-bttn" label="{!$Label.hed.stgBtnEdit}" press="{!c.edit}"/>
-                            <aura:set attribute="else">
-                                <ui:button class="slds-button slds-button--neutral settings-edit-bttn" label="{!$Label.c.stgBtnEdit}" press="{!c.edit}"/>
-                            </aura:set>
-                        </aura:if>
+                        <ui:button class="slds-button slds-button--neutral settings-edit-bttn" label="{!$Label.c.stgBtnEdit}" press="{!c.edit}"/>
                     <aura:set attribute="else">
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:button class="slds-button slds-button--neutral settings-save-bttn" label="{!$Label.hed.stgBtnSave}" press="{!c.save}"/>
-                            <aura:set attribute="else">
-                                <ui:button class="slds-button slds-button--neutral settings-save-bttn" label="{!$Label.c.stgBtnSave}" press="{!c.save}"/>
-                            </aura:set>
-                        </aura:if>
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:button class="slds-button slds-button--neutral settings-cancel-bttn" label="{!$Label.hed.stgBtnCancel}" press="{!c.cancel}"/>
-                            <aura:set attribute="else">
-                                <ui:button class="slds-button slds-button--neutral settings-cancel-bttn" label="{!$Label.c.stgBtnCancel}" press="{!c.cancel}"/>
-                            </aura:set>
-                        </aura:if>
+                        <ui:button class="slds-button slds-button--neutral settings-save-bttn" label="{!$Label.c.stgBtnSave}" press="{!c.save}"/>
+                        <ui:button class="slds-button slds-button--neutral settings-cancel-bttn" label="{!$Label.c.stgBtnCancel}" press="{!c.cancel}"/>
                     </aura:set>
                     </aura:if>
                 </div>
@@ -77,12 +52,7 @@
         </div>
         <!-- / LAYOUT GRID -->
         <p class="slds-text-body--small slds-m-top--x-small">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgTitleAppwideSettings}"/>
-                <aura:set attribute="else">
-                    <ui:outputText value="{!$Label.c.stgTitleAppwideSettings}"/>
-                </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgTitleAppwideSettings}"/>
         </p>
     </div>
     <!-- / PAGE HEADER -->

--- a/src/aura/STG_CMP_Rel/STG_CMP_Rel.cmp
+++ b/src/aura/STG_CMP_Rel/STG_CMP_Rel.cmp
@@ -39,12 +39,7 @@
               </ui:inputSelect>
           </div>
           <div class="slds-col slds-size--1-of-1">
-	            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-	                <ui:outputText value="{!$Label.hed.stgHelpRelReciprocalMethod}" class="slds-text-body--small" />
-					    <aura:set attribute="else">
-					        <ui:outputText value="{!$Label.c.stgHelpRelReciprocalMethod}" class="slds-text-body--small" />
-				      </aura:set>
-	            </aura:if>
+		        <ui:outputText value="{!$Label.c.stgHelpRelReciprocalMethod}" class="slds-text-body--small" />
           </div>
 			    <div class="slds-col slds-grid slds-m-top--medium">
 				    <div class="slds-col slds-size--1-of-2">

--- a/src/aura/STG_CMP_Rel/STG_CMP_Rel.cmp
+++ b/src/aura/STG_CMP_Rel/STG_CMP_Rel.cmp
@@ -15,40 +15,20 @@
 	<div id="relTabs" class="slds-tabs--scoped">
 		<ul class="slds-tabs--scoped__nav" role="tablist">
 			<li aura:id="settsTab" class="slds-tabs__item slds-text-heading--label" title="Settings" role="tab">
-				<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-					<ui:outputURL value="#" label="{!$Label.hed.stgTabSettings}" class="rel-settings-menulink" click="{!c.settsLinkClicked}" />
-                    <aura:set attribute="else">
-						<ui:outputURL value="#" label="{!$Label.c.stgTabSettings}" class="rel-settings-menulink" click="{!c.settsLinkClicked}" />
-                    </aura:set>
-                </aura:if>
+				<ui:outputURL value="#" label="{!$Label.c.stgTabSettings}" class="rel-settings-menulink" click="{!c.settsLinkClicked}" />
 			</li>
 			<li aura:id="recSettsTab" class="slds-tabs__item slds-text-heading--label" title="Reciprocal Settings" role="tab">
-				<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-					<ui:outputURL value="#" label="{!$Label.hed.stgTabReciprocalSettings}" class="rel-recip-settings-menulink"  click="{!c.recSettsLinkClicked}" />
-                    <aura:set attribute="else">
-						<ui:outputURL value="#" label="{!$Label.c.stgTabReciprocalSettings}" class="rel-recip-settings-menulink"  click="{!c.recSettsLinkClicked}" />
-                    </aura:set>
-                </aura:if>
+				<ui:outputURL value="#" label="{!$Label.c.stgTabReciprocalSettings}" class="rel-recip-settings-menulink"  click="{!c.recSettsLinkClicked}" />
 			</li>
 			<li aura:id="autocTab" class="slds-tabs__item slds-text-heading--label" title="Autocreation" role="tab">
-				<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                	<ui:outputURL value="#" label="{!$Label.hed.stgTabAutocreation}" class="rel-autoc-settings-menulink" click="{!c.autocLinkClicked}" />
-                    <aura:set attribute="else">
-                		<ui:outputURL value="#" label="{!$Label.c.stgTabAutocreation}" class="rel-autoc-settings-menulink" click="{!c.autocLinkClicked}" />
-                    </aura:set>
-                </aura:if>
+				<ui:outputURL value="#" label="{!$Label.c.stgTabAutocreation}" class="rel-autoc-settings-menulink" click="{!c.autocLinkClicked}" />
 			</li>
 		</ul>
 		
 		<div aura:id="settsTabContent" class="slds-tabs__content" role="tabpanel">
 			<div class="slds-grid slds-wrap">
 			    <div class="slds-col slds-size--1-of-2">
-			    	<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        <ui:outputText value="{!$Label.hed.stgTitleReciMethod}"/>
-                        <aura:set attribute="else">
-                            <ui:outputText value="{!$Label.c.stgTitleReciMethod}"/>
-                        </aura:set>
-                    </aura:if>
+					<ui:outputText value="{!$Label.c.stgTitleReciMethod}"/>
                 </div>
 			    <div class="slds-col slds-size--1-of-2">
 			        <ui:outputText value="{!v.hierarchySettings.Reciprocal_Method__c}" class="{!(v.isView ? '':'slds-hide ') + 'reciprocal-method'}" />
@@ -67,13 +47,8 @@
 	            </aura:if>
           </div>
 			    <div class="slds-col slds-grid slds-m-top--medium">
-				    <div class="slds-col slds-size--1-of-2">			    	
-				    	<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        	<ui:outputText value="{!$Label.hed.stgTitleAllowAutocreatedDuplicateRel}"/>
-                        	<aura:set attribute="else">
-                            	<ui:outputText value="{!$Label.c.stgTitleAllowAutocreatedDuplicateRel}"/>
-                        	</aura:set>
-                    	</aura:if>
+				    <div class="slds-col slds-size--1-of-2">
+						<ui:outputText value="{!$Label.c.stgTitleAllowAutocreatedDuplicateRel}"/>
                 	</div>
 				    <div class="slds-col slds-size--1-of-2">
 				         <div class="slds-form-element">
@@ -93,74 +68,39 @@
 				    </div>
 			    </div>
 			    <div class="slds-col slds-size--1-of-1">
-                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        <ui:outputText value="{!$Label.hed.stgHelpRelAutoCreatedDup}" class="slds-text-body--small" />
-                    <aura:set attribute="else">
-                        <ui:outputText value="{!$Label.c.stgHelpRelAutoCreatedDup}" class="slds-text-body--small" />
-                    </aura:set>
-                    </aura:if>
+					<ui:outputText value="{!$Label.c.stgHelpRelAutoCreatedDup}" class="slds-text-body--small" />
                 </div>
 			</div>
 		</div>
 		
 		<div aura:id="recSettsTabContent" class="slds-tabs__content" role="tabpanel">
 		    <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputText value="{!$Label.hed.RelationshipsLookupDescription}" class="slds-text-body--small" />
-                <aura:set attribute="else">
-                    <ui:outputText value="{!$Label.c.RelationshipsLookupDescription}" class="slds-text-body--small" />
-                </aura:set>
-                </aura:if>
+				<ui:outputText value="{!$Label.c.RelationshipsLookupDescription}" class="slds-text-body--small" />
             </div>
 			<div class="slds-grid slds-wrap">
 			    <div class="slds-col slds-size--1-of-6">
-			    	<strong>			    	
-			    		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        	<ui:outputText value="{!$Label.hed.stgTabName}"/>
-	                        <aura:set attribute="else">
-	                            <ui:outputText value="{!$Label.c.stgTabName}"/>
-	                        </aura:set>
-                    	</aura:if>
+			    	<strong>
+						<ui:outputText value="{!$Label.c.stgTabName}"/>
                 	</strong>
                 </div>
 			    <div class="slds-col slds-size--1-of-6">
 			    	<strong>
-			    		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        	<ui:outputText value="{!$Label.hed.stgColFemale}"/>
-	                        <aura:set attribute="else">
-	                            <ui:outputText value="{!$Label.c.stgColFemale}"/>
-	                        </aura:set>
-                    	</aura:if>
+						<ui:outputText value="{!$Label.c.stgColFemale}"/>
                     </strong>
                 </div>
 			    <div class="slds-col slds-size--1-of-6">
 			    	<strong>
-			    		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        	<ui:outputText value="{!$Label.hed.stgColMale}"/>
-	                        <aura:set attribute="else">
-	                            <ui:outputText value="{!$Label.c.stgColMale}"/>
-	                        </aura:set>
-                    	</aura:if>
+						<ui:outputText value="{!$Label.c.stgColMale}"/>
                     </strong>
                 </div>
 			    <div class="slds-col slds-size--1-of-6">
 			    	<strong>
-			    		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        	<ui:outputText value="{!$Label.hed.stgColNeutral}"/>
-	                        <aura:set attribute="else">
-	                            <ui:outputText value="{!$Label.c.stgColNeutral}"/>
-	                        </aura:set>
-                    	</aura:if>
+						<ui:outputText value="{!$Label.c.stgColNeutral}"/>
                     </strong>
                 </div>
 			    <div class="slds-col slds-size--1-of-6">
 			    	<strong>
-			    		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        	<ui:outputText value="{!$Label.hed.stgColActive}"/>
-	                        <aura:set attribute="else">
-	                            <ui:outputText value="{!$Label.c.stgColActive}"/>
-	                        </aura:set>
-                    	</aura:if>
+						<ui:outputText value="{!$Label.c.stgColActive}"/>
                     </strong>
                 </div>
 			    <div class="slds-col slds-size--1-of-6">&nbsp;</div>
@@ -231,69 +171,40 @@
 			<div class="newrecsetting">
 			  <div aria-labelledby="newrecsettingform">
 			    <fieldset class="slds-box slds-form--compound slds-theme--default slds-container--medium">
-			      <legend id="newrecsettingform" class="slds-text-heading--medium slds-p-vertical--medium">			    		
-			      		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        	<ui:outputText value="{!$Label.hed.stgTitleNewReciSetting}"/>
-	                        <aura:set attribute="else">
-	                            <ui:outputText value="{!$Label.c.stgTitleNewReciSetting}"/>
-	                        </aura:set>
-                    	</aura:if></legend>
+			      <legend id="newrecsettingform" class="slds-text-heading--medium slds-p-vertical--medium">
+					  <ui:outputText value="{!$Label.c.stgTitleNewReciSetting}"/>
+				  </legend>
 	                <div class="slds-form-element__group">
 	                <div class="slds-form-element__row">
 
 						<div class="slds-form-element slds-size--1-of-6">
 				          	<div class="slds-form-element__control">
-      				    		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-			               			<ui:inputText aura:id="newName" class="slds-m-right--medium new-rec-settg-name slds-input" label="{!$Label.hed.stgTabName}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newReciprocalStgKeyup}"/>		
-			               			<aura:set attribute="else">
-			               				<ui:inputText aura:id="newName" class="slds-m-right--medium new-rec-settg-name slds-input" label="{!$Label.c.stgTabName}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newReciprocalStgKeyup}"/>	
-			           				</aura:set>
-	                    		</aura:if>
-				          </div>
+								<ui:inputText aura:id="newName" class="slds-m-right--medium new-rec-settg-name slds-input" label="{!$Label.c.stgTabName}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newReciprocalStgKeyup}"/>
+							</div>
 						</div>
 
 						<div class="slds-form-element slds-size--1-of-6">
-	                      	<div class="slds-form-element__control">      				    		
-	                      		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-									<ui:inputText aura:id="newFemale" class="slds-m-right--medium new-rec-settg-female slds-input" label="{!$Label.hed.stgColFemale}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newReciprocalStgKeyup}"/>			               	
-									<aura:set attribute="else">
-										<ui:inputText aura:id="newFemale" class="slds-m-right--medium new-rec-settg-female slds-input" label="{!$Label.c.stgColFemale}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newReciprocalStgKeyup}"/>  
-									</aura:set>
-	                    		</aura:if>
-	                      	</div>
+	                      	<div class="slds-form-element__control">
+								<ui:inputText aura:id="newFemale" class="slds-m-right--medium new-rec-settg-female slds-input" label="{!$Label.c.stgColFemale}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newReciprocalStgKeyup}"/>
+							</div>
 						</div>
 
 						<div class="slds-form-element slds-size--1-of-6">
-	                      	<div class="slds-form-element__control">	                      		
-	                      		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-									<ui:inputText aura:id="newMale" class="slds-m-right--medium new-rec-settg-male slds-input" label="{!$Label.hed.stgColMale}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newReciprocalStgKeyup}"/>		
-									<aura:set attribute="else">
-										<ui:inputText aura:id="newMale" class="slds-m-right--medium new-rec-settg-male slds-input" label="{!$Label.c.stgColMale}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newReciprocalStgKeyup}"/>
-									</aura:set>
-	                    		</aura:if>
+	                      	<div class="slds-form-element__control">
+								<ui:inputText aura:id="newMale" class="slds-m-right--medium new-rec-settg-male slds-input" label="{!$Label.c.stgColMale}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newReciprocalStgKeyup}"/>
 	                      </div>
 						</div>
 
 						<div class="slds-form-element slds-size--1-of-6">
 	                      	<div class="slds-form-element__control">
-	                      		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-	                          		<ui:inputText aura:id="newNeutral" class="slds-m-right--medium new-rec-settg-neutral slds-input" label="{!$Label.hed.stgColNeutral}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newReciprocalStgKeyup}"/>
-									<aura:set attribute="else">
-	                          			<ui:inputText aura:id="newNeutral" class="slds-m-right--medium new-rec-settg-neutral slds-input" label="{!$Label.c.stgColNeutral}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newReciprocalStgKeyup}"/>
-									</aura:set>
-	                    		</aura:if>	                      	
+								<ui:inputText aura:id="newNeutral" class="slds-m-right--medium new-rec-settg-neutral slds-input" label="{!$Label.c.stgColNeutral}" labelClass="slds-form-element__label" required="true" requiredIndicatorClass="slds-required" updateOn="keyup" keyup="{!c.newReciprocalStgKeyup}"/>
 	                      	</div>
 						</div>
 
 						<div class="slds-form-element slds-size--1-of-6">
-	                        <label class="slds-form-element__label" for="Active">&nbsp;			    		
-	                      		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-	                        		<ui:outputText value="{!$Label.hed.stgColActive}"/>
-		                        	<aura:set attribute="else">
-		                            	<ui:outputText value="{!$Label.c.stgColActive}"/>
-		                        	</aura:set>
-                    			</aura:if>
-                    	 	</label>
+	                        <label class="slds-form-element__label" for="Active">&nbsp;
+								<ui:outputText value="{!$Label.c.stgColActive}"/>
+							</label>
                     	 	<br />
 	                      <div class="slds-form-element__control">
 	                          <label class="slds-checkbox">
@@ -308,13 +219,8 @@
 					</div>
 			        <ui:button aura:id="newReciprocalStgBtn" class="slds-button slds-button--brand slds-m-top--medium add-rec-setting" 
 			                   press="{!c.newReciprocalStg}" disabled="true">
-			                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-	                        		<ui:outputText value="{!$Label.hed.stgBtnAddSetting}"/>
-		                        	<aura:set attribute="else">
-		                            	<ui:outputText value="{!$Label.c.stgBtnAddSetting}"/>
-		                        	</aura:set>
-                    			</aura:if>
-                    </ui:button>
+						<ui:outputText value="{!$Label.c.stgBtnAddSetting}"/>
+					</ui:button>
 			    </fieldset>
 			  </div>
             </div>
@@ -322,53 +228,28 @@
 
 		<div aura:id="autocTabContent" class="slds-tabs__content" role="tabpanel">
 		    <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputText value="{!$Label.hed.RelationshipsAutoDescription}" class="slds-text-body--small" />
-                <aura:set attribute="else">
-                    <ui:outputText value="{!$Label.c.RelationshipsAutoDescription}" class="slds-text-body--small" />
-                </aura:set>
-                </aura:if>
+				<ui:outputText value="{!$Label.c.RelationshipsAutoDescription}" class="slds-text-body--small" />
             </div>
 			<div class="slds-grid slds-wrap"> 
 			    <div class="slds-col slds-size--1-of-5">
 			    	<strong>
-			    		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    		<ui:outputText value="{!$Label.hed.stgColObject}"/>
-                        	<aura:set attribute="else">
-                            	<ui:outputText value="{!$Label.c.stgColObject}"/>
-                        	</aura:set>
-            			</aura:if>
-            		</strong>
+						<ui:outputText value="{!$Label.c.stgColObject}"/>
+					</strong>
             	</div>              
                 <div class="slds-col slds-size--1-of-5">
                 	<strong>
-                		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    		<ui:outputText value="{!$Label.hed.stgColField}"/>
-                        	<aura:set attribute="else">
-                            	<ui:outputText value="{!$Label.c.stgColField}"/>
-                        	</aura:set>
-            			</aura:if>
-            		</strong>
+						<ui:outputText value="{!$Label.c.stgColField}"/>
+					</strong>
             	</div>
                 <div class="slds-col slds-size--1-of-5">
                 	<strong>
-                		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    		<ui:outputText value="{!$Label.hed.stgColRelType}"/>
-                        	<aura:set attribute="else">
-                            	<ui:outputText value="{!$Label.c.stgColRelType}"/>
-                        	</aura:set>
-            			</aura:if>
-            		</strong>
+						<ui:outputText value="{!$Label.c.stgColRelType}"/>
+					</strong>
             	</div>
                 <div class="slds-col slds-size--1-of-5">
                 	<strong>
-                		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    		<ui:outputText value="{!$Label.hed.stgColCampTypes}"/>
-                        	<aura:set attribute="else">
-                            	<ui:outputText value="{!$Label.c.stgColCampTypes}"/>
-                        	</aura:set>
-            			</aura:if>
-            		</strong>
+						<ui:outputText value="{!$Label.c.stgColCampTypes}"/>
+					</strong>
             	</div>
                 <div class="slds-col slds-size--1-of-5">&nbsp;</div>
             
@@ -423,68 +304,38 @@
               <div aria-labelledby="newautocsettingform">
                 <fieldset class="slds-box slds-form--compound slds-theme--default slds-container--medium">
                   <legend id="newautocsettingform" class="slds-text-heading--medium slds-p-vertical--medium">
-                  		<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    		<ui:outputText value="{!$Label.hed.stgTitleNewAutocreateSetting}"/>
-                        	<aura:set attribute="else">
-                            	<ui:outputText value="{!$Label.c.stgTitleNewAutocreateSetting}"/>
-                        	</aura:set>
-            			</aura:if>
-            		</legend>
+					  <ui:outputText value="{!$Label.c.stgTitleNewAutocreateSetting}"/>
+				  </legend>
 
                     <div class="slds-form-element__group">
                     <div class="slds-form-element__row">
                         <div class="slds-form-element slds-size--1-of-6">
                           <div class="slds-form-element__control">
-                          	<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            	<ui:inputText aura:id="newObject" class="slds-input slds-m-right--medium new-autoc-settg-object" label="{!$Label.hed.stgColObject}" labelClass="slds-form-element__label" updateOn="keyup" keyup="{!c.newAutoCreateKeyup}" required="true" requiredIndicatorClass="slds-required" />                  
-	                            <aura:set attribute="else">
-	                            	<ui:inputText aura:id="newObject" class="slds-input slds-m-right--medium new-autoc-settg-object" label="{!$Label.c.stgColObject}" labelClass="slds-form-element__label" updateOn="keyup" keyup="{!c.newAutoCreateKeyup}" required="true" requiredIndicatorClass="slds-required" /> 
-	                        	</aura:set>
-            				</aura:if>
-                          </div>
+							  <ui:inputText aura:id="newObject" class="slds-input slds-m-right--medium new-autoc-settg-object" label="{!$Label.c.stgColObject}" labelClass="slds-form-element__label" updateOn="keyup" keyup="{!c.newAutoCreateKeyup}" required="true" requiredIndicatorClass="slds-required" />
+						  </div>
                         </div>
                         <div class="slds-form-element slds-size--1-of-6">
                           <div class="slds-form-element__control">
-                            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            	<ui:inputText aura:id="newField" class="slds-input slds-m-right--medium new-autoc-settg-field" label="{!$Label.hed.stgColField}" labelClass="slds-form-element__label" updateOn="keyup" keyup="{!c.newAutoCreateKeyup}" required="true" requiredIndicatorClass="slds-required" />
-	                            <aura:set attribute="else">
-                            		<ui:inputText aura:id="newField" class="slds-input slds-m-right--medium new-autoc-settg-field" label="{!$Label.c.stgColField}" labelClass="slds-form-element__label" updateOn="keyup" keyup="{!c.newAutoCreateKeyup}" required="true" requiredIndicatorClass="slds-required" />
-	                        	</aura:set>
-            				</aura:if>
-                          </div>
+							  <ui:inputText aura:id="newField" class="slds-input slds-m-right--medium new-autoc-settg-field" label="{!$Label.c.stgColField}" labelClass="slds-form-element__label" updateOn="keyup" keyup="{!c.newAutoCreateKeyup}" required="true" requiredIndicatorClass="slds-required" />
+						  </div>
                         </div>
                         <div class="slds-form-element slds-size--1-of-6">
                           <div class="slds-form-element__control">
-                            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-								<ui:inputText aura:id="newRelType" class="slds-input slds-m-right--medium new-autoc-settg-type" label="{!$Label.hed.stgColRelType}" labelClass="slds-form-element__label" updateOn="keyup" keyup="{!c.newAutoCreateKeyup}" required="true" requiredIndicatorClass="slds-required" />	         
-								<aura:set attribute="else">
-									<ui:inputText aura:id="newRelType" class="slds-input slds-m-right--medium new-autoc-settg-type" label="{!$Label.c.stgColRelType}" labelClass="slds-form-element__label" updateOn="keyup" keyup="{!c.newAutoCreateKeyup}" required="true" requiredIndicatorClass="slds-required" />	   	
-								</aura:set>
-            				</aura:if>
-                          </div>
+							  <ui:inputText aura:id="newRelType" class="slds-input slds-m-right--medium new-autoc-settg-type" label="{!$Label.c.stgColRelType}" labelClass="slds-form-element__label" updateOn="keyup" keyup="{!c.newAutoCreateKeyup}" required="true" requiredIndicatorClass="slds-required" />
+						  </div>
                         </div>
                         <div class="slds-form-element slds-size--1-of-6">
                           <div class="slds-form-element__control">
-                          	<aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-								<ui:inputTextArea aura:id="newCpgTypes" class="slds-input new-autoc-settg-campaign" label="{!$Label.hed.stgColCampTypes}" labelClass="slds-form-element__label" updateOn="keyup" keyup="{!c.newAutoCreateKeyup}" required="true" requiredIndicatorClass="slds-required" />					
-								<aura:set attribute="else">
-									<ui:inputTextArea aura:id="newCpgTypes" class="slds-input new-autoc-settg-campaign" label="{!$Label.c.stgColCampTypes}" labelClass="slds-form-element__label" updateOn="keyup" keyup="{!c.newAutoCreateKeyup}" required="true" requiredIndicatorClass="slds-required" />				
-								</aura:set>
-            				</aura:if>
-                          </div>
+							  <ui:inputTextArea aura:id="newCpgTypes" class="slds-input new-autoc-settg-campaign" label="{!$Label.c.stgColCampTypes}" labelClass="slds-form-element__label" updateOn="keyup" keyup="{!c.newAutoCreateKeyup}" required="true" requiredIndicatorClass="slds-required" />
+						  </div>
                         </div>
 
                     </div>
                     </div>
                     <ui:button aura:id="newAutoCreateStgBtn" class="slds-button slds-button--brand slds-m-top--medium new-autoc-sttg-bttn" 
                                press="{!c.newAutoCreateStg}" disabled="true">
-                       <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:outputText value="{!$Label.hed.stgBtnAddSetting}"/>
-                            <aura:set attribute="else">
-                                <ui:outputText value="{!$Label.c.stgBtnAddSetting}"/>
-                            </aura:set>
-                        </aura:if>
-                    </ui:button>
+						<ui:outputText value="{!$Label.c.stgBtnAddSetting}"/>
+					</ui:button>
                 </fieldset>
               </div>
             </div>

--- a/src/aura/STG_CMP_System/STG_CMP_System.cmp
+++ b/src/aura/STG_CMP_System/STG_CMP_System.cmp
@@ -107,32 +107,17 @@
                 </div>
 
                 <div class="slds-hide slds-form-element slds-size--1-of-3" aura:id="errNoticeUserId" >
-                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        <c:autocomplete aura:id="autocomplete"
-                                    label="{!$Label.hed.stgAutoCompleteSelectUser}"
-                                    placeholder="{!$Label.hed.stgAutoCompleteEnterUserName}"
-                                    searchContext="">
+                    <c:autocomplete aura:id="autocomplete"
+                                        label="{!$Label.c.stgAutoCompleteSelectUser}"
+                                        placeholder="{!$Label.c.stgAutoCompleteEnterUserName}"
+                                        searchContext="">
                         <aura:set attribute="dataProvider">
                             <c:autocompleteDataProvider sObjectType="User" />
                         </aura:set>
                         <aura:set attribute="itemTemplate">
                             <c:autocompleteOption value="{!item}" displayValue="{!item.label}" iconSprite="standard" iconName="user"/>
                         </aura:set>
-                        </c:autocomplete>                     
-                        <aura:set attribute="else">
-                            <c:autocomplete aura:id="autocomplete"
-                                        label="{!$Label.c.stgAutoCompleteSelectUser}"
-                                        placeholder="{!$Label.c.stgAutoCompleteEnterUserName}"
-                                        searchContext="">
-                                <aura:set attribute="dataProvider">
-                                    <c:autocompleteDataProvider sObjectType="User" />
-                                </aura:set>
-                                <aura:set attribute="itemTemplate">
-                                    <c:autocompleteOption value="{!item}" displayValue="{!item.label}" iconSprite="standard" iconName="user"/>
-                                </aura:set>
-                            </c:autocomplete>                 
-                        </aura:set>
-                    </aura:if> 
+                    </c:autocomplete> 
                 </div>
 
                 <div class="slds-hide slds-form-element slds-size--1-of-3" aura:id="errNoticeChatter">

--- a/src/aura/STG_CMP_System/STG_CMP_System.cmp
+++ b/src/aura/STG_CMP_System/STG_CMP_System.cmp
@@ -16,12 +16,7 @@
 
         <div class="slds-grid slds-wrap">
         <div class="slds-col slds-size--1-of-2">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgAccModelTitle}" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgAccModelTitle}" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgAccModelTitle}" />
         </div>
 
         <div class="slds-col slds-size--1-of-2">
@@ -35,21 +30,11 @@
         </div>
 
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgHelpAccountModel}" class="slds-text-body--small" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgHelpAccountModel}" class="slds-text-body--small" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgHelpAccountModel}" class="slds-text-body--small" />
         </div>
 
         <div class="slds-col slds-size--1-of-2">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgStoreErrorsTitle}" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgStoreErrorsTitle}" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgStoreErrorsTitle}" />
         </div>
         <div class="slds-col slds-size--1-of-2">
             <div class="slds-form-element">
@@ -69,21 +54,11 @@
             </div>
         </div>
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgHelpStoreErrorsOn}" class="slds-text-body--small" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgHelpStoreErrorsOn}" class="slds-text-body--small" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgHelpStoreErrorsOn}" class="slds-text-body--small" />
         </div>
 
         <div class="slds-col slds-size--1-of-2">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgSendErrorsTitle}" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgSendErrorsTitle}" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgSendErrorsTitle}" />
         </div>
         <div class="slds-col slds-size--1-of-2">
             <div class="slds-form-element">
@@ -102,21 +77,11 @@
             </div>
         </div>
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgHelpErrorNotifyOn}" class="slds-text-body--small" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgHelpErrorNotifyOn}" class="slds-text-body--small" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgHelpErrorNotifyOn}" class="slds-text-body--small" />
         </div>
 
         <div class="slds-col slds-size--1-of-2">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgErrorNotifRecipientsTitle}" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgErrorNotifRecipientsTitle}" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgErrorNotifRecipientsTitle}" />
         </div>
         <div class="slds-col slds-size--1-of-2">
             <aura:if isTrue="{!v.isView}">
@@ -125,38 +90,20 @@
             <aura:set attribute="else">
 
                 <div class="slds-form-element slds-size--1-of-3">
-                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        <lightning:select value="{!v.errorNotificationType}" name="error_to_type" label="{!$Label.hed.stgSelectReciType}" onchange="{!c.errorToSelect}">
-                            <option value="">
-                                <ui:outputText value="{!$Label.hed.stgOptSelect}" />
-                            </option>
-                            <option value="All Sys Admins">
-                                <ui:outputText value="{!$Label.hed.stgOptAllSysAdmins}" />
-                            </option>
-                            <option value="Chatter Group">                                
-                                <ui:outputText value="{!$Label.hed.stgOptChatterGroup}" />
-                            </option>
-                            <option value="User">                                
-                                <ui:outputText value="{!$Label.hed.stgOptUser}" />
-                            </option>
-                        </lightning:select>                     
-                    <aura:set attribute="else">
-                        <lightning:select value="{!v.errorNotificationType}" name="error_to_type" label="{!$Label.c.stgSelectReciType}" onchange="{!c.errorToSelect}">
-                            <option value="">
-                                <ui:outputText value="{!$Label.c.stgOptSelect}" />
-                            </option>
-                            <option value="All Sys Admins">                                
-                                <ui:outputText value="{!$Label.c.stgOptAllSysAdmins}" />
-                            </option>
-                            <option value="Chatter Group">                                
-                                <ui:outputText value="{!$Label.c.stgOptChatterGroup}" />
-                            </option>
-                            <option value="User">                                
-                                <ui:outputText value="{!$Label.c.stgOptUser}" />
-                            </option>
-                        </lightning:select>                     
-                    </aura:set>
-                    </aura:if> 
+                    <lightning:select value="{!v.errorNotificationType}" name="error_to_type" label="{!$Label.c.stgSelectReciType}" onchange="{!c.errorToSelect}">
+                        <option value="">
+                            <ui:outputText value="{!$Label.c.stgOptSelect}" />
+                        </option>
+                        <option value="All Sys Admins">
+                            <ui:outputText value="{!$Label.c.stgOptAllSysAdmins}" />
+                        </option>
+                        <option value="Chatter Group">
+                            <ui:outputText value="{!$Label.c.stgOptChatterGroup}" />
+                        </option>
+                        <option value="User">
+                            <ui:outputText value="{!$Label.c.stgOptUser}" />
+                        </option>
+                    </lightning:select>
                 </div>
 
                 <div class="slds-hide slds-form-element slds-size--1-of-3" aura:id="errNoticeUserId" >
@@ -189,10 +136,9 @@
                 </div>
 
                 <div class="slds-hide slds-form-element slds-size--1-of-3" aura:id="errNoticeChatter">
-                    <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                        <c:autocomplete aura:id="autocomplete"
-                                    label="{!$Label.hed.stgAutoCompleteSelectChatterGroup}"
-                                    placeholder="{!$Label.hed.stgAutoCompleteEnterChatterGroupName}"
+                    <c:autocomplete aura:id="autocomplete"
+                                    label="{!$Label.c.stgAutoCompleteSelectChatterGroup}"
+                                    placeholder="{!$Label.c.stgAutoCompleteEnterChatterGroupName}"
                                     searchContext="">
                         <aura:set attribute="dataProvider">
                             <c:autocompleteDataProvider sObjectType="CollaborationGroup" />
@@ -200,33 +146,13 @@
                         <aura:set attribute="itemTemplate">
                             <c:autocompleteOption value="{!item}" displayValue="{!item.label}" iconSprite="standard" iconName="groups"/>
                         </aura:set>
-                        </c:autocomplete>                    
-                        <aura:set attribute="else">
-                            <c:autocomplete aura:id="autocomplete"
-                                    label="{!$Label.c.stgAutoCompleteSelectChatterGroup}"
-                                    placeholder="{!$Label.c.stgAutoCompleteEnterChatterGroupName}"
-                                    searchContext="">
-                            <aura:set attribute="dataProvider">
-                                <c:autocompleteDataProvider sObjectType="CollaborationGroup" />
-                            </aura:set>
-                            <aura:set attribute="itemTemplate">
-                                <c:autocompleteOption value="{!item}" displayValue="{!item.label}" iconSprite="standard" iconName="groups"/>
-                            </aura:set>
-                            </c:autocomplete>                  
-                        </aura:set>
-                    </aura:if> 
+                    </c:autocomplete>
                 </div>
 
                 <div class="slds-form-element slds-size--1-of-3 slds-m-top--small">
                     <div class="slds-form-element__control">
-                        <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                            <ui:inputText value="{!v.hierarchySettings.Error_Notifications_To__c}" 
-                                class="errors-recepient slds-input" label="{!$Label.hed.stgErrorNotiTo}" labelClass="slds-form-element__label" disabled="true" />                            
-                            <aura:set attribute="else">
-                                <ui:inputText value="{!v.hierarchySettings.Error_Notifications_To__c}" 
-                                class="errors-recepient slds-input" label="{!$Label.c.stgErrorNotiTo}" labelClass="slds-form-element__label" disabled="true" />                            
-                            </aura:set>
-                        </aura:if>
+                        <ui:inputText value="{!v.hierarchySettings.Error_Notifications_To__c}"
+                                      class="errors-recepient slds-input" label="{!$Label.c.stgErrorNotiTo}" labelClass="slds-form-element__label" disabled="true" />
                     </div>
                 </div>
 
@@ -235,21 +161,11 @@
 
         </div>
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgHelpErrorNotifyTo}" class="slds-text-body--small" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgHelpErrorNotifyTo}" class="slds-text-body--small" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgHelpErrorNotifyTo}" class="slds-text-body--small" />
         </div>
 
         <div class="slds-col slds-size--1-of-2">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgDisableErrorHandlingTitle}" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgDisableErrorHandlingTitle}" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgDisableErrorHandlingTitle}" />
         </div>
         <div class="slds-col slds-size--1-of-2">
             <div class="slds-form-element">
@@ -268,20 +184,10 @@
             </div>
         </div>
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.stgHelpErrorDisable}" class="slds-text-body--small" />
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.stgHelpErrorDisable}" class="slds-text-body--small" />
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.stgHelpErrorDisable}" class="slds-text-body--small" />
         </div>
         <div class="slds-col slds-size--1-of-2">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.automaticHHNaming}" />
-                <aura:set attribute="else">
-                    <ui:outputText value="{!$Label.c.automaticHHNaming}" />
-                </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.automaticHHNaming}" />
         </div>
         <div class="slds-col slds-size--1-of-2">
             <div class="slds-form-element">
@@ -301,21 +207,11 @@
             </div>
         </div>
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.automaticHHNamingHelpText}" class="slds-text-body--small" />
-                <aura:set attribute="else">
-                    <ui:outputText value="{!$Label.c.automaticHHNamingHelpText}" class="slds-text-body--small" />
-                </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.automaticHHNamingHelpText}" class="slds-text-body--small" />
         </div>
 
         <div class="slds-col slds-size--1-of-2">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.adminAccNameFormat}"/>
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.adminAccNameFormat}"/>
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.adminAccNameFormat}"/>
         </div>
         
         <div class="slds-col slds-size--1-of-2" >
@@ -329,21 +225,11 @@
             />
         </div>
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.adminAccNameFormatHelpText}" class="slds-text-body--small" />
-                <aura:set attribute="else">
-                    <ui:outputText value="{!$Label.c.adminAccNameFormatHelpText}" class="slds-text-body--small" />
-                </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.adminAccNameFormatHelpText}" class="slds-text-body--small" />
         </div>
 
         <div class="slds-col slds-size--1-of-2">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.hhAccNameFormat}"/>
-            <aura:set attribute="else">
-                <ui:outputText value="{!$Label.c.hhAccNameFormat}"/>
-            </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.hhAccNameFormat}"/>
         </div>
         
         <div class="slds-col slds-size--1-of-2">
@@ -357,12 +243,7 @@
             />
         </div>
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-            <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                <ui:outputText value="{!$Label.hed.hhAccNameFormatHelpText}" class="slds-text-body--small" />
-                <aura:set attribute="else">
-                    <ui:outputText value="{!$Label.c.hhAccNameFormatHelpText}" class="slds-text-body--small" />
-                </aura:set>
-            </aura:if>
+            <ui:outputText value="{!$Label.c.hhAccNameFormatHelpText}" class="slds-text-body--small" />
         </div>
     </div>
 </aura:component>

--- a/src/aura/STG_CMP_Tabs/STG_CMP_Tabs.cmp
+++ b/src/aura/STG_CMP_Tabs/STG_CMP_Tabs.cmp
@@ -31,50 +31,25 @@
     <div aura:id="tabs" id="tabs" class="slds-tabs--default">
         <ul class="slds-tabs--default__nav" role="tablist">
             <li aura:id="afflTab" id="afflTab" class="slds-tabs__item slds-text-heading--label" tile="Affiliations" role="tab">
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputURL aura:id="afflTabBtn" value="#" label="{!$Label.hed.stgTabAffl}" click="{!c.tabNavigationClick}" class="afflTab affls-menu-item" />
-                    <aura:set attribute="else">
-                        <ui:outputURL aura:id="afflTabBtn" value="#" label="{!$Label.c.stgTabAffl}" click="{!c.tabNavigationClick}" class="afflTab affls-menu-item" />
-                    </aura:set>
-                </aura:if>
+                <ui:outputURL aura:id="afflTabBtn" value="#" label="{!$Label.c.stgTabAffl}" click="{!c.tabNavigationClick}" class="afflTab affls-menu-item" />
             </li>
             <li aura:id="relTab" id="relTab" class="slds-tabs__item slds-text-heading--label" title="Relationships" role="tab">
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputURL aura:id="relTabBtn" value="#" label="{!$Label.hed.stgTabRel}" click="{!c.tabNavigationClick}" class="relTab rels-menu-item" />
-                    <aura:set attribute="else">
-                        <ui:outputURL aura:id="relTabBtn" value="#" label="{!$Label.c.stgTabRel}" click="{!c.tabNavigationClick}" class="relTab rels-menu-item" />
-                    </aura:set>
-                </aura:if>
+                <ui:outputURL aura:id="relTabBtn" value="#" label="{!$Label.c.stgTabRel}" click="{!c.tabNavigationClick}" class="relTab rels-menu-item" />
             </li>
             <li aura:id="coursesTab" id="coursesTab" class="slds-tabs__item slds-text-heading--label" title="Courses" role="tab">
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputURL aura:id="coursesTabBtn" value="#" label="{!$Label.hed.stgTabCourse}" click="{!c.tabNavigationClick}" class="coursesTab course-con-menu-item" />
-                    <aura:set attribute="else">
-                        <ui:outputURL aura:id="coursesTabBtn" value="#" label="{!$Label.c.stgTabCourse}" click="{!c.tabNavigationClick}" class="coursesTab course-con-menu-item" />
-                    </aura:set>
-                </aura:if>
+                <ui:outputURL aura:id="coursesTabBtn" value="#" label="{!$Label.c.stgTabCourse}" click="{!c.tabNavigationClick}" class="coursesTab course-con-menu-item" />
             </li>
             <li aura:id="courseConTab" id="courseConTab" class="slds-tabs__item slds-text-heading--label" title="Course Connections" role="tab">
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputURL aura:id="courseConTabBtn" value="#" label="{!$Label.hed.stgTabCourseConn}" click="{!c.tabNavigationClick}" class="courseConTab course-con-menu-item" />                    
-                    <aura:set attribute="else">
-                        <ui:outputURL aura:id="courseConTabBtn" value="#" label="{!$Label.c.stgTabCourseConn}" click="{!c.tabNavigationClick}" class="courseConTab course-con-menu-item" />                    
-                    </aura:set>
-                </aura:if>
+                <ui:outputURL aura:id="courseConTabBtn" value="#" label="{!$Label.c.stgTabCourseConn}" click="{!c.tabNavigationClick}" class="courseConTab course-con-menu-item" />
             </li>
             <li aura:id="addrTab" id="addrTab" class="slds-tabs__item slds-text-heading--label" title="Accounts and Contacts" role="tab">
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputURL aura:id="addrTabBtn" value="#" label="{!$Label.hed.stgTabAccCont}" click="{!c.tabNavigationClick}" class="addrTab accs-cons-menu-item" />
-                    <aura:set attribute="else">
-                        <ui:outputURL aura:id="addrTabBtn" value="#" label="{!$Label.c.stgTabAccCont}" click="{!c.tabNavigationClick}" class="addrTab accs-cons-menu-item" />
-                    </aura:set>
-                </aura:if>
+                <ui:outputURL aura:id="addrTabBtn" value="#" label="{!$Label.c.stgTabAccCont}" click="{!c.tabNavigationClick}" class="addrTab accs-cons-menu-item" />
             </li>
             <li aura:id="systemTab" id="systemTab" class="slds-tabs__item slds-text-heading--label" title="System" role="tab">
                 <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputURL aura:id="systemTabBtn" value="#" label="{!$Label.hed.stgTabSystem}" click="{!c.tabNavigationClick}" class="systemTab system-menu-item" />                    
+                    <ui:outputURL aura:id="systemTabBtn" value="#" label="{!$Label.hed.stgTabSystem}" click="{!c.tabNavigationClick}" class="systemTab system-menu-item" />
                     <aura:set attribute="else">
-                    <ui:outputURL aura:id="systemTabBtn" value="#" label="{!$Label.c.stgTabSystem}" click="{!c.tabNavigationClick}" class="systemTab system-menu-item" />                    
+                    <ui:outputURL aura:id="systemTabBtn" value="#" label="{!$Label.c.stgTabSystem}" click="{!c.tabNavigationClick}" class="systemTab system-menu-item" />
                     </aura:set>
                 </aura:if>
             </li>

--- a/src/aura/STG_CMP_Tabs/STG_CMP_Tabs.cmp
+++ b/src/aura/STG_CMP_Tabs/STG_CMP_Tabs.cmp
@@ -46,12 +46,7 @@
                 <ui:outputURL aura:id="addrTabBtn" value="#" label="{!$Label.c.stgTabAccCont}" click="{!c.tabNavigationClick}" class="addrTab accs-cons-menu-item" />
             </li>
             <li aura:id="systemTab" id="systemTab" class="slds-tabs__item slds-text-heading--label" title="System" role="tab">
-                <aura:if isTrue="{!v.namespacePrefix == 'hed__'}">
-                    <ui:outputURL aura:id="systemTabBtn" value="#" label="{!$Label.hed.stgTabSystem}" click="{!c.tabNavigationClick}" class="systemTab system-menu-item" />
-                    <aura:set attribute="else">
-                    <ui:outputURL aura:id="systemTabBtn" value="#" label="{!$Label.c.stgTabSystem}" click="{!c.tabNavigationClick}" class="systemTab system-menu-item" />
-                    </aura:set>
-                </aura:if>
+                <ui:outputURL aura:id="systemTabBtn" value="#" label="{!$Label.c.stgTabSystem}" click="{!c.tabNavigationClick}" class="systemTab system-menu-item" />
             </li>
         </ul>
 

--- a/src/aura/STG_CMP_Tabs/STG_CMP_TabsHelper.js
+++ b/src/aura/STG_CMP_Tabs/STG_CMP_TabsHelper.js
@@ -204,11 +204,7 @@
 	getOtherDisplay : function(component, value) {
 		var prefix = component.get("v.namespacePrefix");
 		var label = '';
-		if(prefix === 'hed__') {
-            label = $A.get("$Label.hed.acctNamingOther");
-        }else{
-            label = $A.get("$Label.c.acctNamingOther");
-        } 
+        label = $A.get("$Label.c.acctNamingOther");
         if (value === label) {
         	return true;
         }else{


### PR DESCRIPTION
# Critical Changes

# Changes

- We've changed the custom label references on the HEDA Settings page to access custom labels directly. Specifically, we've replaced all $Label.hed.(LabelName) with $Label.c.(LabelName). This has the added benefit of cleaning up our code base and ensuring consistency and maintainability.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
1.  Set up a new dev org#1
2. Create a dummy package
3. Add all heda components to the dummy package
4. Set up another new dev org#2
5. Install the dummy package in dev org#2 
6. Make sure everything in HEDA setting page still working as before