### PR TITLE
Fix for parallel test error in ADV test run.

### DIFF
--- a/src/classes/AFFL_ContactAccChange_TEST.cls
+++ b/src/classes/AFFL_ContactAccChange_TEST.cls
@@ -40,8 +40,7 @@ public with sharing class AFFL_ContactAccChange_TEST {
     private static ID orgRecTypeID;
     private static ID householdRecTypeID;
 
-    @testSetup 
-    static void dataSetup() {
+    private static void dataSetup() {
 
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
 
@@ -71,7 +70,7 @@ public with sharing class AFFL_ContactAccChange_TEST {
     
     @isTest
     public static void changeContact() {
-
+        dataSetup();
         Account bizOrg1 = [SELECT Id FROM Account WHERE Name = 'Acme'];
         
         //Confirm Primary Business Organization field has been populated in contact
@@ -102,6 +101,7 @@ public with sharing class AFFL_ContactAccChange_TEST {
     
     @isTest
     public static void clearContact() {
+        dataSetup();
         Contact contact = [Select Primary_Organization__c from Contact WHERE FirstName = 'Test' AND Lastname = 'Testerson'];
         Account bizOrg1 = [SELECT Id FROM Account WHERE Name = 'Acme'];
         Affiliation__c bizAffl1 = [SELECT Account__c FROM Affiliation__c WHERE Contact__c =: contact.ID AND Account__c =: bizOrg1.ID];
@@ -119,6 +119,7 @@ public with sharing class AFFL_ContactAccChange_TEST {
     
     @isTest
     public static void changeAccountSameType() {
+        dataSetup();
         Contact contact = [Select Primary_Organization__c from Contact WHERE FirstName = 'Test' AND Lastname = 'Testerson'];
         Account bizOrg1 = [SELECT Id FROM Account WHERE Name = 'Acme'];
         Account bizOrg2 = [SELECT Id FROM Account WHERE Name = 'Acme2'];
@@ -138,7 +139,7 @@ public with sharing class AFFL_ContactAccChange_TEST {
     
     @isTest
     public static void changeAccountDifferentType() {
-
+        dataSetup();
         Contact contact = [Select Primary_Organization__c from Contact WHERE FirstName = 'Test' AND Lastname = 'Testerson'];
 
         Account bizOrg1 = [SELECT Id FROM Account WHERE Name = 'Acme'];
@@ -161,7 +162,7 @@ public with sharing class AFFL_ContactAccChange_TEST {
     
     @isTest
     public static void clearAccount() {
-
+        dataSetup();
         Contact contact = [Select Primary_Organization__c from Contact WHERE FirstName = 'Test' AND Lastname = 'Testerson'];
         Account bizOrg1 = [SELECT Id FROM Account WHERE Name = 'Acme'];
         Affiliation__c bizAffl1 = [SELECT Account__c FROM Affiliation__c WHERE Contact__c =: contact.ID AND Account__c =: bizOrg1.ID];

--- a/src/package.xml
+++ b/src/package.xml
@@ -113,6 +113,8 @@
         <members>UTIL_Describe_TEST</members>
         <members>UTIL_Namespace</members>
         <members>UTIL_Namespace_TEST</members>
+        <members>UTIL_Profile</members>
+        <members>UTIL_Profile_TEST</members>
         <members>UTIL_UnitTestData_API</members>
         <members>UTIL_UnitTestData_TEST</members>
         <name>ApexClass</name>


### PR DESCRIPTION
# Critical Changes

# Changes

- Updating test methods to fix errors when they are run in parallel.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes

- Make sure tests methods in AFFL_ContactAccChange_TEST pass when run all at once.
- Once packaged, make sure the ADV ci_feature build can be run without HEDA Test errors. If "UNABLE_TO_LOCK_ROW" shows up in errors, this still isn't resolved.
