### PR TITLE
Turn off custom setting for unit tests by default

### DIFF
--- a/src/classes/AFFL_AccChange_TDTM.cls
+++ b/src/classes/AFFL_AccChange_TDTM.cls
@@ -83,7 +83,7 @@ public with sharing class AFFL_AccChange_TDTM extends TDTM_Runnable {
                    		lookupFieldNameOld = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabelOld);
                		}
 
-               		if (isAfflTypeEnforced) {
+               		if (isAfflTypeEnforced == true) {
                        ERR_ExceptionHandler.handleAfflNullRecordTypeException(affl, afflMapper.validAccRecordTypesInMappings);
                		}
 

--- a/src/classes/AFFL_ContactChange_TDTM.cls
+++ b/src/classes/AFFL_ContactChange_TDTM.cls
@@ -85,7 +85,7 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 	               	String lookupFieldLabel = AFFL_MultiRecordType_TDTM.afflMapper.mapAccRecTypeToContactLabel.get(affl.Affiliation_Type__c);
 	               	String lookupFieldName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabel);
 
-					if (isAfflTypeEnforced) {
+					if (isAfflTypeEnforced == true) {
 						ERR_ExceptionHandler.handleAfflNullRecordTypeException(affl, afflMapper.validAccRecordTypesInMappings);
 					}
 

--- a/src/classes/AFFL_MultiRecordType_TDTM.cls
+++ b/src/classes/AFFL_MultiRecordType_TDTM.cls
@@ -77,7 +77,7 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 					String lookupFieldLabel = afflMapper.mapAccRecTypeToContactLabel.get(affl.Affiliation_Type__c);
 					String lookupFieldName = afflMapper.contactLabelNames.get(lookupFieldLabel);
 
-					if (isAfflTypeEnforced) {
+					if (isAfflTypeEnforced == true) {
 						ERR_ExceptionHandler.handleAfflNullRecordTypeException(affl, afflMapper.validAccRecordTypesInMappings);
 					}
 

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -106,7 +106,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         hs.Admin_Account_Naming_Format__c = '{!LastName} Administrative Account';
         hs.Household_Account_Naming_Format__c = '{!LastName} Household';
         hs.Automatic_Household_Naming__c = false;
-        hs.Affiliation_Record_Type_Enforced__c = true;
+        hs.Affiliation_Record_Type_Enforced__c = false;
     }
 
     /*******************************************************************************************************


### PR DESCRIPTION
# Critical Changes

# Changes
- We've made a change so that the Affiliation_Record_Type_Enforced__c field will be set false by default. There should be no change for your existing HEDA org settings.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
Make sure unit tests pass,
Check the Affiliation_Record_Type_Enforced__c field and that it is set to false by default.
Also make sure this ticket still works- W-023536
Notes- Turn off Affiliation_Record_Type_Enforced__c field for default settings(in both UTIL_CustomSettingsFacade.configSettings() and in Hierarchy_Settings__c the Affiliation_Record_Type_Enforced__c field is being set to 'true' by default). This is so the SAL's team unit tests can run again. 