### PR TITLE
Enable reporting for program plan and plan requirement

### DIFF
--- a/src/objects/Plan_Requirement__c.object
+++ b/src/objects/Plan_Requirement__c.object
@@ -59,7 +59,7 @@
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>false</enableFeeds>
     <enableHistory>false</enableHistory>
-    <enableReports>false</enableReports>
+    <enableReports>true</enableReports>
     <enableSearch>true</enableSearch>
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>

--- a/src/objects/Program_Plan__c.object
+++ b/src/objects/Program_Plan__c.object
@@ -59,7 +59,7 @@
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>false</enableFeeds>
     <enableHistory>false</enableHistory>
-    <enableReports>false</enableReports>
+    <enableReports>true</enableReports>
     <enableSearch>true</enableSearch>
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>


### PR DESCRIPTION
# Critical Changes

# Changes

- In response to an issue that prevented users from creating reports for the Program Plan and Plan Requirement objects introduced with [HEDA Release 1.57](https://github.com/SalesforceFoundation/HEDAP/releases/tag/rel%2F1.57), we've enabled reporting for those objects. 
     - If you've already enabled reporting for Program Plans and Plan Requirements in your org(s), you will experience no change. 
    - For all new HEDA orgs, reporting for Program Plans and Plan Requirements is enabled by default.

# Issues Closed
Fixes #617
# New Metadata

# Deleted Metadata

# Testing Notes
Go to report and make sure we can create reports for program plan and plan requirement.
From the App Launcher search for "reports"
Click on the Report link that comes up in the Search results
Click on New Report (you will see the Choose Report Type box appear)
Enter "Plan" into the Search Report Types field
Make sure reports related to Program Plan and Plan Requirements show.