### PR TITLE
Makes Program Plan Status Current if Is Primary is Checked

### DIFF
--- a/src/classes/PPlan_Primary_TDTM.cls
+++ b/src/classes/PPlan_Primary_TDTM.cls
@@ -50,7 +50,7 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
     * @param objResult the describe for Accounts
     * @return dmlWrapper.
     ********************************************************************************************************/
-        public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist,
+    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist,
     TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
         DmlWrapper dmlWrapper = new DmlWrapper();
 

--- a/src/classes/PPlan_Primary_TDTM.cls
+++ b/src/classes/PPlan_Primary_TDTM.cls
@@ -35,6 +35,13 @@
 * @description Handles primary program plans under accounts
 */
 public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
+   
+    /*******************************************************************************************************
+    * @description The Plan status value of Current.
+    */
+    @testVisible private static final String STATUS_CURRENT_VAL = 'Current';
+	@testVisible private static final String STATUS_ARCHIVED_VAL = 'Archived';
+   
     /*******************************************************************************************************
     * @description Handles primary program plans.
     * @param listNew the list of Accounts from trigger new.
@@ -43,7 +50,7 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
     * @param objResult the describe for Accounts
     * @return dmlWrapper.
     ********************************************************************************************************/
-    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist,
+        public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist,
     TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
         DmlWrapper dmlWrapper = new DmlWrapper();
 
@@ -54,24 +61,47 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
             for (integer i=0; i<newlist.size(); i++) {
                 Program_Plan__c newPPlan = (Program_Plan__c)newlist[i];
                 if (newPPlan.Is_Primary__c == true) {
+                    // Make Plan "Current" if "Is Primary" is checked.
+					newPPlan.Status__c = STATUS_CURRENT_VAL;
+                }
+            }
+        }
+        // AFTER INSERT
+        if ( newlist != null && triggerAction == TDTM_Runnable.Action.AfterInsert && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_After_Insert)) {
+            for (integer i=0; i<newlist.size(); i++) {
+                Program_Plan__c newPPlan = (Program_Plan__c)newlist[i];
+                if (newPPlan.Is_Primary__c == true) {
                     //if multiple program plans under one single account are set as primary in same transation
                     //Use the first program plan as the primary
-                    if (!acccountIdsNeedNonPrimarycount.contains(newPPlan.Account__c)) {
+					if (!acccountIdsNeedNonPrimarycount.contains(newPPlan.Account__c)) {
                         primaryProgramIds.add(newPPlan.Id);
                     }
                     acccountIdsNeedNonPrimarycount.add(newPPlan.Account__c);
                 }
             }
         }
-        // BEFORE UPDATE
+ 		// BEFORE UPDATE
         if ( newlist != null && triggerAction == TDTM_Runnable.Action.BeforeUpdate && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_Before_Update)) {
+           for (integer i=0; i<newlist.size(); i++) {
+                Program_Plan__c newPPlan = (Program_Plan__c)newlist[i];
+                Program_Plan__c oldPPlan = (Program_Plan__c)oldlist[i];
+                if (newPPlan.Is_Primary__c == true&& newPPlan.Is_Primary__c != oldPPlan.Is_Primary__c) {
+					// Make Plan "Current" if "Is Primary" is checked.
+					newPPlan.Status__c = STATUS_CURRENT_VAL;
+                }
+            }
+
+        }
+		System.debug('Groucho');
+        // AFTER UPDATE
+        if ( newlist != null && triggerAction == TDTM_Runnable.Action.AfterUpdate && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_After_Update)) {
             for (integer i=0; i<newlist.size(); i++) {
                 Program_Plan__c newPPlan = (Program_Plan__c)newlist[i];
                 Program_Plan__c oldPPlan = (Program_Plan__c)oldlist[i];
                 if (newPPlan.Is_Primary__c == true
                     && (newPPlan.Is_Primary__c != oldPPlan.Is_Primary__c
                         || newPPlan.Account__c != oldPPlan.Account__c)) {
-                    //if multiple program plans under one single account are set as primary in same transation
+					//if multiple program plans under one single account are set as primary in same transation
                     //Use the first program plan as the primary
                     if (!acccountIdsNeedNonPrimarycount.contains(newPPlan.Account__c)) {
                         primaryProgramIds.add(newPPlan.Id);
@@ -80,13 +110,19 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
                 }
             }
         }
+        
         if (acccountIdsNeedNonPrimarycount.size()>0) {
             dmlWrapper.objectsToUpdate.addAll(makeOtherPPlanNotPrimary(acccountIdsNeedNonPrimarycount, primaryProgramIds));
         }
+		
         if (triggerAction == TDTM_Runnable.Action.BeforeUpdate) {
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_Before_Update, false);
         }else if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_Before_Insert, false);
+        }else if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_After_Update, false);
+        }else if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_After_Insert, false);
         }
         return dmlWrapper;
     }

--- a/src/classes/PPlan_Primary_TDTM.cls
+++ b/src/classes/PPlan_Primary_TDTM.cls
@@ -40,7 +40,10 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
     * @description The Plan status value of Current.
     */
     @testVisible private static final String STATUS_CURRENT_VAL = 'Current';
-	@testVisible private static final String STATUS_ARCHIVED_VAL = 'Archived';
+    /*******************************************************************************************************
+    * @description The Plan status value of Archived.
+    */
+    @testVisible private static final String STATUS_ARCHIVED_VAL = 'Archived';
    
     /*******************************************************************************************************
     * @description Handles primary program plans.
@@ -62,7 +65,7 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
                 Program_Plan__c newPPlan = (Program_Plan__c)newlist[i];
                 if (newPPlan.Is_Primary__c == true) {
                     // Make Plan "Current" if "Is Primary" is checked.
-					newPPlan.Status__c = STATUS_CURRENT_VAL;
+                    newPPlan.Status__c = STATUS_CURRENT_VAL;
                 }
             }
         }
@@ -73,26 +76,25 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
                 if (newPPlan.Is_Primary__c == true) {
                     //if multiple program plans under one single account are set as primary in same transation
                     //Use the first program plan as the primary
-					if (!acccountIdsNeedNonPrimarycount.contains(newPPlan.Account__c)) {
+                    if (!acccountIdsNeedNonPrimarycount.contains(newPPlan.Account__c)) {
                         primaryProgramIds.add(newPPlan.Id);
                     }
                     acccountIdsNeedNonPrimarycount.add(newPPlan.Account__c);
                 }
             }
         }
- 		// BEFORE UPDATE
+        // BEFORE UPDATE
         if ( newlist != null && triggerAction == TDTM_Runnable.Action.BeforeUpdate && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_Before_Update)) {
            for (integer i=0; i<newlist.size(); i++) {
                 Program_Plan__c newPPlan = (Program_Plan__c)newlist[i];
                 Program_Plan__c oldPPlan = (Program_Plan__c)oldlist[i];
-                if (newPPlan.Is_Primary__c == true&& newPPlan.Is_Primary__c != oldPPlan.Is_Primary__c) {
-					// Make Plan "Current" if "Is Primary" is checked.
-					newPPlan.Status__c = STATUS_CURRENT_VAL;
+                if (newPPlan.Is_Primary__c == true && newPPlan.Is_Primary__c != oldPPlan.Is_Primary__c) {
+                    // Make Plan "Current" if "Is Primary" is checked.
+                    newPPlan.Status__c = STATUS_CURRENT_VAL;
                 }
             }
 
         }
-		System.debug('Groucho');
         // AFTER UPDATE
         if ( newlist != null && triggerAction == TDTM_Runnable.Action.AfterUpdate && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_After_Update)) {
             for (integer i=0; i<newlist.size(); i++) {
@@ -101,7 +103,7 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
                 if (newPPlan.Is_Primary__c == true
                     && (newPPlan.Is_Primary__c != oldPPlan.Is_Primary__c
                         || newPPlan.Account__c != oldPPlan.Account__c)) {
-					//if multiple program plans under one single account are set as primary in same transation
+                    //if multiple program plans under one single account are set as primary in same transation
                     //Use the first program plan as the primary
                     if (!acccountIdsNeedNonPrimarycount.contains(newPPlan.Account__c)) {
                         primaryProgramIds.add(newPPlan.Id);
@@ -114,7 +116,7 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
         if (acccountIdsNeedNonPrimarycount.size()>0) {
             dmlWrapper.objectsToUpdate.addAll(makeOtherPPlanNotPrimary(acccountIdsNeedNonPrimarycount, primaryProgramIds));
         }
-		
+        
         if (triggerAction == TDTM_Runnable.Action.BeforeUpdate) {
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_Before_Update, false);
         }else if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {

--- a/src/classes/PPlan_Primary_TEST.cls
+++ b/src/classes/PPlan_Primary_TEST.cls
@@ -142,77 +142,77 @@ private class PPlan_Primary_TEST {
             }
         }
     }
-	
-	/*********************************************************************************************************
+    
+    /*********************************************************************************************************
      * @description Confirm Program Plan Status is set to "Current"
      * if program plan is set as Primary on insert
      */
     @IsTest
-	static void setProgramPlanStatusToCurrentIfPrimary_Insert() {
-		List<Account> accts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getAdminAccRecTypeID());
+    static void setProgramPlanStatusToCurrentIfPrimary_Insert() {
+        List<Account> accts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getAdminAccRecTypeID());
         insert accts[0];
 
         List<Program_Plan__c> pPlans = UTIL_UnitTestData_TEST.getMultipleTestProgramPlans(3);
         for (Program_Plan__c pPlan : pPlans) {
             pPlan.Account__c = accts[0].Id;
-			pplan.Status__c = PPlan_Primary_TDTM.STATUS_ARCHIVED_VAL;
+            pplan.Status__c = PPlan_Primary_TDTM.STATUS_ARCHIVED_VAL;
         }
-		
-		pplans[0].Is_Primary__c = true;
+        
+        pplans[0].Is_Primary__c = true;
 
         insert pPlans;
-		
-		List<Program_Plan__c> assertProgramPlans = [SELECT Is_Primary__c, Status__c FROM Program_Plan__c where Account__c = :accts[0].Id];
+        
+        List<Program_Plan__c> assertProgramPlans = [SELECT Is_Primary__c, Status__c FROM Program_Plan__c where Account__c = :accts[0].Id];
         Integer cntPrimary = 0;
-		for (Program_Plan__c pPlan : assertProgramPlans) {
+        for (Program_Plan__c pPlan : assertProgramPlans) {
             if (pPlan.Is_Primary__c) {
                 System.assertEquals(PPlan_Primary_TDTM.STATUS_CURRENT_VAL, pPlan.Status__c);
-				cntPrimary++;
+                cntPrimary++;
             }else {
                 system.assertEquals(PPlan_Primary_TDTM.STATUS_ARCHIVED_VAL, pPlan.Status__c);
             }
         }
-		System.assertEquals (1, cntPrimary, 'One and only one primary program plan expected');
-	}
-	
-	/*********************************************************************************************************
+        System.assertEquals (1, cntPrimary, 'One and only one primary program plan expected');
+    }
+    
+    /*********************************************************************************************************
      * @description Confirm Program Plan Status is set to "Current"
      * if program plan is set as Primary on Update
      */
     @IsTest
-	static void setProgramPlanStatusToCurrentIfPrimary_Update() {
-		List<Account> accts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getAdminAccRecTypeID());
+    static void setProgramPlanStatusToCurrentIfPrimary_Update() {
+        List<Account> accts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getAdminAccRecTypeID());
         insert accts[0];
 
         List<Program_Plan__c> pPlans = UTIL_UnitTestData_TEST.getMultipleTestProgramPlans(3);
         for (Program_Plan__c pPlan : pPlans) {
             pPlan.Account__c = accts[0].Id;
-			pplan.Status__c = PPlan_Primary_TDTM.STATUS_ARCHIVED_VAL;
+            pplan.Status__c = PPlan_Primary_TDTM.STATUS_ARCHIVED_VAL;
         }
-		
+        
         insert pPlans;
 
-		List<Program_Plan__c> assertProgramPlans = [SELECT Is_Primary__c, Status__c FROM Program_Plan__c where Account__c = :accts[0].Id];
+        List<Program_Plan__c> assertProgramPlans = [SELECT Is_Primary__c, Status__c FROM Program_Plan__c where Account__c = :accts[0].Id];
         
-		for (Program_Plan__c pPlan : assertProgramPlans) {
-			System.assertEquals (PPlan_Primary_TDTM.STATUS_ARCHIVED_VAL, pPlan.Status__c);
-		}
-		
-		pPlans[0].Is_Primary__c = true;
-		update pPlans;
-		
-		assertProgramPlans = [SELECT Is_Primary__c, Status__c FROM Program_Plan__c where Account__c = :accts[0].Id];
+        for (Program_Plan__c pPlan : assertProgramPlans) {
+            System.assertEquals (PPlan_Primary_TDTM.STATUS_ARCHIVED_VAL, pPlan.Status__c);
+        }
+        
+        pPlans[0].Is_Primary__c = true;
+        update pPlans;
+        
+        assertProgramPlans = [SELECT Is_Primary__c, Status__c FROM Program_Plan__c where Account__c = :accts[0].Id];
         Integer cntPrimary = 0;
-		for (Program_Plan__c pPlan : assertProgramPlans) {
+        for (Program_Plan__c pPlan : assertProgramPlans) {
             if (pPlan.Is_Primary__c) {
                 System.assertEquals(pPlans[0].Id, pPlan.Id);
-				System.assertEquals(PPlan_Primary_TDTM.STATUS_CURRENT_VAL, pPlan.Status__c);
-				cntPrimary++;
+                System.assertEquals(PPlan_Primary_TDTM.STATUS_CURRENT_VAL, pPlan.Status__c);
+                cntPrimary++;
             }else {
                 system.assertEquals(PPlan_Primary_TDTM.STATUS_ARCHIVED_VAL, pPlan.Status__c);
             }
         }
-		System.assertEquals (1, cntPrimary, 'One and only one primary program plan expected');
-	}
+        System.assertEquals (1, cntPrimary, 'One and only one primary program plan expected');
+    }
     
 }

--- a/src/classes/PPlan_Primary_TEST.cls
+++ b/src/classes/PPlan_Primary_TEST.cls
@@ -142,4 +142,77 @@ private class PPlan_Primary_TEST {
             }
         }
     }
+	
+	/*********************************************************************************************************
+     * @description Confirm Program Plan Status is set to "Current"
+     * if program plan is set as Primary on insert
+     */
+    @IsTest
+	static void setProgramPlanStatusToCurrentIfPrimary_Insert() {
+		List<Account> accts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getAdminAccRecTypeID());
+        insert accts[0];
+
+        List<Program_Plan__c> pPlans = UTIL_UnitTestData_TEST.getMultipleTestProgramPlans(3);
+        for (Program_Plan__c pPlan : pPlans) {
+            pPlan.Account__c = accts[0].Id;
+			pplan.Status__c = PPlan_Primary_TDTM.STATUS_ARCHIVED_VAL;
+        }
+		
+		pplans[0].Is_Primary__c = true;
+
+        insert pPlans;
+		
+		List<Program_Plan__c> assertProgramPlans = [SELECT Is_Primary__c, Status__c FROM Program_Plan__c where Account__c = :accts[0].Id];
+        Integer cntPrimary = 0;
+		for (Program_Plan__c pPlan : assertProgramPlans) {
+            if (pPlan.Is_Primary__c) {
+                System.assertEquals(PPlan_Primary_TDTM.STATUS_CURRENT_VAL, pPlan.Status__c);
+				cntPrimary++;
+            }else {
+                system.assertEquals(PPlan_Primary_TDTM.STATUS_ARCHIVED_VAL, pPlan.Status__c);
+            }
+        }
+		System.assertEquals (1, cntPrimary, 'One and only one primary program plan expected');
+	}
+	
+	/*********************************************************************************************************
+     * @description Confirm Program Plan Status is set to "Current"
+     * if program plan is set as Primary on Update
+     */
+    @IsTest
+	static void setProgramPlanStatusToCurrentIfPrimary_Update() {
+		List<Account> accts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getAdminAccRecTypeID());
+        insert accts[0];
+
+        List<Program_Plan__c> pPlans = UTIL_UnitTestData_TEST.getMultipleTestProgramPlans(3);
+        for (Program_Plan__c pPlan : pPlans) {
+            pPlan.Account__c = accts[0].Id;
+			pplan.Status__c = PPlan_Primary_TDTM.STATUS_ARCHIVED_VAL;
+        }
+		
+        insert pPlans;
+
+		List<Program_Plan__c> assertProgramPlans = [SELECT Is_Primary__c, Status__c FROM Program_Plan__c where Account__c = :accts[0].Id];
+        
+		for (Program_Plan__c pPlan : assertProgramPlans) {
+			System.assertEquals (PPlan_Primary_TDTM.STATUS_ARCHIVED_VAL, pPlan.Status__c);
+		}
+		
+		pPlans[0].Is_Primary__c = true;
+		update pPlans;
+		
+		assertProgramPlans = [SELECT Is_Primary__c, Status__c FROM Program_Plan__c where Account__c = :accts[0].Id];
+        Integer cntPrimary = 0;
+		for (Program_Plan__c pPlan : assertProgramPlans) {
+            if (pPlan.Is_Primary__c) {
+                System.assertEquals(pPlans[0].Id, pPlan.Id);
+				System.assertEquals(PPlan_Primary_TDTM.STATUS_CURRENT_VAL, pPlan.Status__c);
+				cntPrimary++;
+            }else {
+                system.assertEquals(PPlan_Primary_TDTM.STATUS_ARCHIVED_VAL, pPlan.Status__c);
+            }
+        }
+		System.assertEquals (1, cntPrimary, 'One and only one primary program plan expected');
+	}
+    
 }

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -161,7 +161,7 @@ public without sharing class TDTM_DefaultConfig {
               Class__c = 'CCON_Faculty_TDTM', Load_Order__c = 1, Object__c = 'Course_Enrollment__c',
               Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'BeforeInsert;AfterInsert;AfterUpdate;AfterDelete'));
 
-        // Set other Program Plan as non-primary when one Plan is marked as Primary
+        // Set other Program Plan as non-primary when one Plan is marked as Primary, and to set Status to Current (if record marked as "Primary")
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
                 Class__c = 'PPlan_Primary_TDTM', Load_Order__c = 1, Object__c = 'Program_Plan__c',
                 Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'BeforeInsert;BeforeUpdate;AfterInsert;AfterUpdate'));

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -164,7 +164,7 @@ public without sharing class TDTM_DefaultConfig {
         // Set other Program Plan as non-primary when one Plan is marked as Primary
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
                 Class__c = 'PPlan_Primary_TDTM', Load_Order__c = 1, Object__c = 'Program_Plan__c',
-                Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'BeforeInsert;BeforeUpdate'));
+                Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'BeforeInsert;BeforeUpdate;AfterInsert;AfterUpdate'));
 
         // Stops a Program Plan from being deleted if it has any Plan Requirement
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,

--- a/src/classes/TDTM_ProcessControl.cls
+++ b/src/classes/TDTM_ProcessControl.cls
@@ -63,7 +63,9 @@ public class TDTM_ProcessControl {
         AFFL_MultiRecordType_TDTM_afflMadePrimary,
         CON_PrimaryAffls_TDTM_keyAfflLookupUpdated,
         PPlan_Primary_TDTM_Before_Insert,
-        PPlan_Primary_TDTM_Before_Update
+        PPlan_Primary_TDTM_Before_Update,
+        PPlan_Primary_TDTM_After_Insert,
+        PPlan_Primary_TDTM_After_Update
     }
 
     /*******************************************************************************************************


### PR DESCRIPTION
# Critical Changes

# Changes
* Moves logic to mark other plan records associated with same account non primary from Before Insert / Before Update to After Insert / After Update.  Best practice is to update same records in Before Insert/Update trigger contect, and other records in After Insert/Update context
* Adds Before Insert / Before Update logic to set status to Current for records marked as "Primary" (Is Primary checked)
* Updated Trigger Default Config to reflect existence of After Update, After Insert for PPlan_Primary_TDTM trigger
* Defined Register Trigger values for the new trigger combinations (PPlan_Primary_TTDM_AfterInsert, AfterUpdate)
* Added additional tests to cover the logic to make Status Current for new "Primary" Program Plans, as well as Primary Program Plan records newly updated to "Primary"

# Issues Closed
Addresses #604 
# New Metadata

# Deleted Metadata

# Testing Notes
* Confirmed new and existing tests all ran successfully, unit tested as well for New and Updates, as well as existing trigger functionality