### PR TITLE
Adding Global Util class for exposing portions of the Custom Setting

### DIFF
--- a/src/classes/ADDR_Contact_TEST.cls
+++ b/src/classes/ADDR_Contact_TEST.cls
@@ -41,7 +41,7 @@ public with sharing class ADDR_Contact_TEST {
     private static void configSettings() {
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c(Contacts_Addresses_Enabled__c = true,
                                                Simple_Address_Change_Treated_as_Update__c = true);
-        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        UTIL_CustomSettings_API.getSettingsForTests(hs);
     }
     
     public static void turnOnAllAddrTriggers() {
@@ -63,7 +63,7 @@ public with sharing class ADDR_Contact_TEST {
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Contacts_Addresses_Enabled__c = true,
             Simple_Address_Change_Treated_as_Update__c = true);
-        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        UTIL_CustomSettings_API.getSettingsForTests(hs);
         
         Contact contact = new Contact(LastName = 'Testerson', MailingStreet = '123 Main St', 
         MailingCity = 'Austin', MailingState = 'Texas', MailingPostalcode = '78701', MailingCountry = 'United States');
@@ -102,7 +102,7 @@ public with sharing class ADDR_Contact_TEST {
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Contacts_Addresses_Enabled__c = true,
             Simple_Address_Change_Treated_as_Update__c = true);
-        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        UTIL_CustomSettings_API.getSettingsForTests(hs);
         
         Contact contact1 = new Contact(LastName = 'Testerson');
         insert contact1;
@@ -152,7 +152,7 @@ public with sharing class ADDR_Contact_TEST {
     **********************************************************************************************************/            
     @isTest
     public static void newRecordsWithAddrInfo() {            
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Contacts_Addresses_Enabled__c = true));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Contacts_Addresses_Enabled__c = true));
  
         Integer contactCount = 3;
         List<Contact> contacts = UTIL_UnitTestData_API.getMultipleTestContacts(contactCount);
@@ -835,7 +835,7 @@ public with sharing class ADDR_Contact_TEST {
     **********************************************************************************************************/            
     @isTest
     public static void insertMultilineStreetAddress() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Contacts_Addresses_Enabled__c = true));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Contacts_Addresses_Enabled__c = true));
     
         List<Contact> contacts = UTIL_UnitTestData_API.getMultipleTestContacts(2);
         for (Contact contact : contacts) {
@@ -959,7 +959,7 @@ public with sharing class ADDR_Contact_TEST {
     **********************************************************************************************************/            
     @isTest
     public static void updateRecordsWithAddrInfo() {         
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Contacts_Addresses_Enabled__c = true));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Contacts_Addresses_Enabled__c = true));
  
         // create Contacts without addresses
         Integer contactCount = 3;
@@ -1006,7 +1006,7 @@ public with sharing class ADDR_Contact_TEST {
     **********************************************************************************************************/            
     @isTest
     public static void newAddrForContacts() {           
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Contacts_Addresses_Enabled__c = true));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Contacts_Addresses_Enabled__c = true));
  
         // create Contacts without addresses
         List<Contact> contacts = UTIL_UnitTestData_API.getMultipleTestContacts(3);
@@ -1052,7 +1052,7 @@ public with sharing class ADDR_Contact_TEST {
     **********************************************************************************************************/            
     @isTest
     public static void testDisabledAddr() {        
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Contacts_Addresses_Enabled__c = false));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Contacts_Addresses_Enabled__c = false));
 
         List<Contact> contacts = UTIL_UnitTestData_API.getMultipleTestContacts(2);
         for (Contact contact : contacts) {
@@ -1081,7 +1081,7 @@ public with sharing class ADDR_Contact_TEST {
         no new Address created
     **********************************************************************************************************/            
     static testMethod void clearAddrExisting() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Contacts_Addresses_Enabled__c = true));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Contacts_Addresses_Enabled__c = true));
                 
         // this creates a default Address for each Contact
         UTIL_UnitTestData_TEST.ContactsWithAddrs contactsAddrs = UTIL_UnitTestData_TEST.createTestContactsAddrs(4);

--- a/src/classes/ADDR_HouseholdAcc_TEST.cls
+++ b/src/classes/ADDR_HouseholdAcc_TEST.cls
@@ -42,7 +42,7 @@ public with sharing class ADDR_HouseholdAcc_TEST {
     private static ID householdRecTypeID = UTIL_Describe_API.getHhAccRecTypeID();
     
     private static void configSettings() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(
             Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
             Household_Addresses_RecType__c = UTIL_Describe_API.getHhAccRecTypeID(),
             Contacts_Addresses_Enabled__c = true,
@@ -1974,7 +1974,7 @@ public with sharing class ADDR_HouseholdAcc_TEST {
     **********************************************************************************************************/            
     @isTest
     public static void testDisabledHHAccountAddr() {        
-        Hierarchy_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getSettingsForTests(
+        Hierarchy_Settings__c contactSettingsForTests = UTIL_CustomSettings_API.getSettingsForTests(
             new Hierarchy_Settings__c (Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(), 
                                        Household_Addresses_RecType__c = null));
 

--- a/src/classes/ADDR_OtherAcc_TEST.cls
+++ b/src/classes/ADDR_OtherAcc_TEST.cls
@@ -47,7 +47,7 @@ public with sharing class ADDR_OtherAcc_TEST {
     **********************************************************************************************************/            
     @isTest
     public static void newRecordsWithAddrInfo() {            
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Accounts_Addresses_Enabled__c = 
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Accounts_Addresses_Enabled__c = 
                                                                       UTIL_Describe_API.getBizAccRecTypeID() + ';'));
  
         Integer cAcc = 3;
@@ -85,7 +85,7 @@ public with sharing class ADDR_OtherAcc_TEST {
     **********************************************************************************************************/            
     @isTest
     public static void updateRecordsWithAddrInfo() {         
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Accounts_Addresses_Enabled__c = 
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Accounts_Addresses_Enabled__c = 
                                                                             UTIL_Describe_API.getBizAccRecTypeID() + ';'));
  
         // create accounts without addresses
@@ -133,7 +133,7 @@ public with sharing class ADDR_OtherAcc_TEST {
     **********************************************************************************************************/            
     @isTest
     public static void newAddrForAccounts() {           
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Accounts_Addresses_Enabled__c = 
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Accounts_Addresses_Enabled__c = 
                                                                       UTIL_Describe_API.getBizAccRecTypeID() + ';'));
  
         // create accounts without addresses
@@ -180,7 +180,7 @@ public with sharing class ADDR_OtherAcc_TEST {
     **********************************************************************************************************/            
     @isTest
     public static void testDisabledAddr() {        
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Accounts_Addresses_Enabled__c = null));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Accounts_Addresses_Enabled__c = null));
 
         List<Account> accs = UTIL_UnitTestData_API.getMultipleTestAccounts(2, UTIL_Describe_API.getAdminAccRecTypeID());
         for (Account acc : accs) {

--- a/src/classes/ADDR_Seasonal_TEST.cls
+++ b/src/classes/ADDR_Seasonal_TEST.cls
@@ -612,7 +612,7 @@ private with sharing class ADDR_Seasonal_TEST {
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Contacts_Addresses_Enabled__c = true,
             Simple_Address_Change_Treated_as_Update__c = true);
-        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        UTIL_CustomSettings_API.getSettingsForTests(hs);
 
         // this creates a default Address for each Account
         UTIL_UnitTestData_TEST.AccsWithAddrs accsAddrs = UTIL_UnitTestData_TEST.createTestAccsAddrs(2, UTIL_Describe_API.getAdminAccRecTypeID());
@@ -733,7 +733,7 @@ private with sharing class ADDR_Seasonal_TEST {
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Contacts_Addresses_Enabled__c = true,
             Simple_Address_Change_Treated_as_Update__c = true);
-        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        UTIL_CustomSettings_API.getSettingsForTests(hs);
 
         // this creates a default Address for each Account
         UTIL_UnitTestData_TEST.AccsWithAddrs accsAddrs = UTIL_UnitTestData_TEST.createTestAccsAddrs(2, UTIL_Describe_API.getAdminAccRecTypeID());
@@ -848,7 +848,7 @@ private with sharing class ADDR_Seasonal_TEST {
 
     @isTest
     public static void testSeasonalStartEndYearCurrent() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(
             Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID(),
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Simple_Address_Change_Treated_as_Update__c = true));
@@ -884,7 +884,7 @@ private with sharing class ADDR_Seasonal_TEST {
 
     @isTest
     public static void testSeasonalStartEndYearFromAcc() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(
             Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID(),
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Simple_Address_Change_Treated_as_Update__c = true));
@@ -939,7 +939,7 @@ private with sharing class ADDR_Seasonal_TEST {
 
     @isTest
     public static void testSeasonalStartEndYearUpdateInfo() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(
             Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID(),
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Simple_Address_Change_Treated_as_Update__c = true));
@@ -981,7 +981,7 @@ private with sharing class ADDR_Seasonal_TEST {
 
     @isTest
     public static void testSeasonalStartEndYearUpdateDates() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(
             Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID(),
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Simple_Address_Change_Treated_as_Update__c = true));
@@ -1021,7 +1021,7 @@ private with sharing class ADDR_Seasonal_TEST {
 
     @isTest
     public static void testSeasonalStartEndYearDelete() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(
             Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID(),
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Simple_Address_Change_Treated_as_Update__c = true));
@@ -1060,7 +1060,7 @@ private with sharing class ADDR_Seasonal_TEST {
 
     @isTest
     public static void newSeasonalAddrForContact() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(
             Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID(),
             Contacts_Addresses_Enabled__c = true,
             Simple_Address_Change_Treated_as_Update__c = true));
@@ -1105,7 +1105,7 @@ private with sharing class ADDR_Seasonal_TEST {
 
     @isTest
     public static void secondSeasonalAddrForContact() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(
             Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID(),
             Contacts_Addresses_Enabled__c = true,
             Simple_Address_Change_Treated_as_Update__c = true));

--- a/src/classes/AFFL_AccRecordType_TEST.cls
+++ b/src/classes/AFFL_AccRecordType_TEST.cls
@@ -42,7 +42,7 @@ public with sharing class AFFL_AccRecordType_TEST {
     private static ID householdRecTypeID;
     
     public static void setup() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
 
         STG_InstallScript.insertMappings();
         

--- a/src/classes/AFFL_ContactAccChange_TEST.cls
+++ b/src/classes/AFFL_ContactAccChange_TEST.cls
@@ -42,7 +42,7 @@ public with sharing class AFFL_ContactAccChange_TEST {
 
     private static void dataSetup() {
 
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
 
         orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
         householdRecTypeID = UTIL_Describe_API.getHhAccRecTypeID();

--- a/src/classes/AFFL_MultiRecordType_TEST.cls
+++ b/src/classes/AFFL_MultiRecordType_TEST.cls
@@ -41,7 +41,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 	private static ID householdRecTypeID;
     
 	public static void setup() {
-		UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
+		UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
         		
 		List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
     	mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = 'Primary Business Organization'));	
@@ -392,7 +392,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
 	@isTest
 	public static void incorrectAfflMappingsAfflTypeEnforced() {
-		UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Affiliation_Record_Type_Enforced__c = true));
+		UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Affiliation_Record_Type_Enforced__c = true));
 
 		List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
 		mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organizations', Primary_Affl_Field__c = 'Primary Business Organization'));

--- a/src/classes/CCON_Faculty_TEST.cls
+++ b/src/classes/CCON_Faculty_TEST.cls
@@ -87,7 +87,7 @@ public with sharing class CCON_Faculty_TEST {
     }
 
     private static void enableCourseConnections() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(
+        UTIL_CustomSettings_API.getSettingsForTests(
             new Hierarchy_Settings__c(
                 Enable_Course_Connections__c = true,
                 Faculty_RecType__c = UTIL_Describe_API.getFacultyConnectionRecType()

--- a/src/classes/CON_PrimaryAffls_TEST.cls
+++ b/src/classes/CON_PrimaryAffls_TEST.cls
@@ -41,7 +41,7 @@ public with sharing class CON_PrimaryAffls_TEST {
     private static ID householdRecTypeID;
 
     public static void setup() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
 
         List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
         mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = 'Primary Business Organization'));
@@ -202,7 +202,7 @@ public with sharing class CON_PrimaryAffls_TEST {
 
     @isTest
     public static void invalidFieldName() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
 
         List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
         mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization',

--- a/src/classes/ERR_Handler_TEST.cls
+++ b/src/classes/ERR_Handler_TEST.cls
@@ -51,11 +51,11 @@ public with sharing class ERR_Handler_TEST {
 	    	chatterGroup.put('CollaborationType', 'Private');
 	    	insert chatterGroup;
 	    	chatterGroupId = chatterGroup.Id;
-	    	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Error_Notifications_On__c = true, 
+	    	UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Error_Notifications_On__c = true, 
 	    	  Error_Notifications_To__c = chatterGroup.Id, Store_Errors_On__c = true, 
 	    	  Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
     	} else {
-    		UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Error_Notifications_On__c = true, 
+    		UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Error_Notifications_On__c = true, 
     		  Error_Notifications_To__c = null, Store_Errors_On__c = true, 
     		  Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
     	}
@@ -65,7 +65,7 @@ public with sharing class ERR_Handler_TEST {
         // all these tests are about testing our error handling, so we can't let the assert interfere       
         
         User user = UTIL_UnitTestData_API.CreateNewUserForTests(System.now().getTime() + '@testerson.com');
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Error_Notifications_On__c = true, 
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Error_Notifications_On__c = true, 
             Error_Notifications_To__c = user.Id, Store_Errors_On__c = true, 
             Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
     }

--- a/src/classes/PREN_Affiliation_TEST.cls
+++ b/src/classes/PREN_Affiliation_TEST.cls
@@ -77,7 +77,7 @@ public with sharing class PREN_Affiliation_TEST {
     public static void deletePEnrollDelAfflYes() {
         STG_InstallScript.insertMappings();
 
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Affl_ProgEnroll_Del__c = true));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Affl_ProgEnroll_Del__c = true));
         
         Contact contact = UTIL_UnitTestData_TEST.getContact();
         insert contact;
@@ -118,7 +118,7 @@ public with sharing class PREN_Affiliation_TEST {
         STG_InstallScript.insertMappings();
 
         String afflStatus = 'Former';
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Affl_ProgEnroll_Del__c = false, 
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Affl_ProgEnroll_Del__c = false, 
         Affl_ProgEnroll_Del_Status__c = afflStatus));
 
         Contact contact = UTIL_UnitTestData_TEST.getContact();

--- a/src/classes/STG_InstallScript_TEST.cls
+++ b/src/classes/STG_InstallScript_TEST.cls
@@ -248,7 +248,7 @@ public with sharing class STG_InstallScript_TEST {
     @isTest
     public static void createAdminAccountForContactOnInstall() {
 
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID()));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID()));
 
         Contact cont = new Contact(
                 FirstName = 'Test',

--- a/src/classes/TDTM_DMLgt200_TEST.cls
+++ b/src/classes/TDTM_DMLgt200_TEST.cls
@@ -66,7 +66,7 @@ private class TDTM_DMLgt200_TEST {
     public static void insertUpdateContact() {
         if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
 
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID()));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID()));
 
         String newContactMailingStreet = '123 Elm St';
 
@@ -117,7 +117,7 @@ private class TDTM_DMLgt200_TEST {
      public static void deleteContactNoOpps() {
          if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
 
-         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(
+         UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(
                     Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID(),
                     Accounts_to_Delete__c = UTIL_Describe_API.getAdminAccRecTypeID()));
 
@@ -157,7 +157,7 @@ private class TDTM_DMLgt200_TEST {
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Simple_Address_Change_Treated_as_Update__c = true);
-        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        UTIL_CustomSettings_API.getSettingsForTests(hs);
         
         // this creates a default Address for each Account
         UTIL_UnitTestData_TEST.AccsWithAddrs accsAddrs = UTIL_UnitTestData_TEST.createTestAccsAddrs(inputSize, UTIL_Describe_API.getAdminAccRecTypeID());
@@ -195,7 +195,7 @@ private class TDTM_DMLgt200_TEST {
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Simple_Address_Change_Treated_as_Update__c = true);
-        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        UTIL_CustomSettings_API.getSettingsForTests(hs);
 
         // this creates a default Address for each Account
         UTIL_UnitTestData_TEST.AccsWithAddrs accsAddrs = UTIL_UnitTestData_TEST.createTestAccsAddrs(inputSize, UTIL_Describe_API.getAdminAccRecTypeID());
@@ -227,7 +227,7 @@ private class TDTM_DMLgt200_TEST {
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Simple_Address_Change_Treated_as_Update__c = true);
-        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        UTIL_CustomSettings_API.getSettingsForTests(hs);
         
         UTIL_UnitTestData_TEST.AccsWithAddrs accsAddrs = UTIL_UnitTestData_TEST.createTestAccsAddrs(inputSize, UTIL_Describe_API.getAdminAccRecTypeID());
         List<Address__c> addrs = accsAddrs.addrs;
@@ -280,7 +280,7 @@ private class TDTM_DMLgt200_TEST {
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Simple_Address_Change_Treated_as_Update__c = true);
-        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        UTIL_CustomSettings_API.getSettingsForTests(hs);
         
         // this creates a default Address for each Account
         UTIL_UnitTestData_TEST.AccsWithAddrs accsAddrs = UTIL_UnitTestData_TEST.createTestAccsAddrs(inputSize, UTIL_Describe_API.getAdminAccRecTypeID());
@@ -320,7 +320,7 @@ private class TDTM_DMLgt200_TEST {
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Simple_Address_Change_Treated_as_Update__c = true);
-        UTIL_CustomSettingsFacade.getSettingsForTests(hs);          
+        UTIL_CustomSettings_API.getSettingsForTests(hs);          
         // this creates a default Address for each Account
         UTIL_UnitTestData_TEST.AccsWithAddrs accsAddrs = UTIL_UnitTestData_TEST.createTestAccsAddrs(inputSize, UTIL_Describe_API.getAdminAccRecTypeID());
         List<Address__c> addrs = accsAddrs.addrs;
@@ -375,7 +375,7 @@ private class TDTM_DMLgt200_TEST {
             Accounts_Addresses_Enabled__c = UTIL_Describe_API.getAdminAccRecTypeID() + ';',
             Contacts_Addresses_Enabled__c = true,
             Simple_Address_Change_Treated_as_Update__c = true);
-        UTIL_CustomSettingsFacade.getSettingsForTests(hs);
+        UTIL_CustomSettings_API.getSettingsForTests(hs);
         
         List<Contact> testContacts = new List<Contact>();
         for (Integer i = 0; i < inputSize; i++){
@@ -430,7 +430,7 @@ private class TDTM_DMLgt200_TEST {
     public static void changeContact() {
         if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
       
-    	  UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
+    	  UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
 
         Id orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
         Id householdRecTypeID = UTIL_Describe_API.getHhAccRecTypeID();
@@ -477,7 +477,7 @@ private class TDTM_DMLgt200_TEST {
     public static void createContactsWithOrg() {
         if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
 
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
 
         List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
         mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = 'Primary Business Organization'));

--- a/src/classes/TDTM_Manager_TEST.cls
+++ b/src/classes/TDTM_Manager_TEST.cls
@@ -398,7 +398,7 @@ private class TDTM_Manager_TEST {
 	//Test to make sure trigger handler is skipped if usernames_to_excluded contains current username
 	@isTest
 	public static void excludeUsernamesSingleUser() {
-		UTIL_CustomSettingsFacade.getSettingsForTests(
+		UTIL_CustomSettings_API.getSettingsForTests(
 				new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID()));
 
 		//Get current user's username
@@ -424,7 +424,7 @@ private class TDTM_Manager_TEST {
 	//Test to make sure trigger handler is skipped if usernames_to_excluded contains multiple certain usernames
 	@isTest
 	public static void excludeUsernamesMultipleUser() {
-		UTIL_CustomSettingsFacade.getSettingsForTests(
+		UTIL_CustomSettings_API.getSettingsForTests(
 				new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID()));
 
 		//Get current user's username

--- a/src/classes/UTIL_CustomSettingsFacade.cls-meta.xml
+++ b/src/classes/UTIL_CustomSettingsFacade.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>35.0</apiVersion>
+    <apiVersion>43.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_CustomSettingsFacade_TEST.cls
+++ b/src/classes/UTIL_CustomSettingsFacade_TEST.cls
@@ -87,7 +87,7 @@ public with sharing class UTIL_CustomSettingsFacade_TEST {
 
     @isTest
     public static void getOrgSettings() {
-        Hierarchy_Settings__c hs = UTIL_CustomSettingsFacade.getOrgSettings();
+        Hierarchy_Settings__c hs = UTIL_CustomSettings_API.getOrgSettings();
 
         System.assertEquals(false, hs.Error_Notifications_On__c);
     }

--- a/src/classes/UTIL_CustomSettings_API.cls
+++ b/src/classes/UTIL_CustomSettings_API.cls
@@ -1,0 +1,68 @@
+/*
+    Copyright (c) 2018 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2018
+* @group API
+* @group-content ../../ApexDocContent/API.htm
+* @description API class that exposes the Custom Setting Facade Utility methods.
+*/
+global class UTIL_CustomSettings_API {
+
+    /*******************************************************************************************************
+    * @description Returns the default settings.
+    * @return Hierarchy_Settings__c custom settings record.
+    * At the org level, if no user level settings are defined. The ID field should be checked to determine if
+    * the returned record already exists or doesn't exist in the database.
+    */
+    global static Hierarchy_Settings__c getSettings() {
+        return UTIL_CustomSettingsFacade.getSettings();
+    }
+
+    /*******************************************************************************************************
+    * @description Returns the org-level settings. Default org-level settings will be created
+    * if none exist. Meant to be called only from settings page and install script.
+    * @return Hierarchy_Settings__c org-level settings.
+    */
+    global static Hierarchy_Settings__c getOrgSettings() {
+        return UTIL_CustomSettingsFacade.getOrgSettings();
+    }
+
+    /*******************************************************************************************************
+    * @description Creates instance of settings to use in tests. It does not insert it, but all other methods will see these settings
+    * as the configured settings.
+    * @param mySettings Settings instance with the values to set.
+    * @return Hierarchy_Settings__c The configured settings.
+    **/
+    global static Hierarchy_Settings__c getSettingsForTests(Hierarchy_Settings__c mySettings) {
+        return UTIL_CustomSettingsFacade.getSettingsForTests(mySettings);
+    }
+
+}

--- a/src/classes/UTIL_CustomSettings_API.cls-meta.xml
+++ b/src/classes/UTIL_CustomSettings_API.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/UTIL_CustomSettings_API.cls-meta.xml
+++ b/src/classes/UTIL_CustomSettings_API.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>38.0</apiVersion>
+    <apiVersion>43.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/package.xml
+++ b/src/package.xml
@@ -105,6 +105,7 @@
         <members>THAN_ClearCache_TEST</members>
         <members>THAN_Filter_TDTM</members>
         <members>THAN_Filter_TEST</members>
+        <members>UTIL_CustomSettings_API</members>
         <members>UTIL_CustomSettingsFacade</members>
         <members>UTIL_CustomSettingsFacade_TEST</members>
         <members>UTIL_Debug</members>


### PR DESCRIPTION
# Critical Changes

# Changes

- In this release we've added a Custom Settings API (the UTIL_CustomSettings_API class), which makes it easier for customers and partners to view and update HEDA Custom Settings through Apex methods.

# Issues Closed

Fixes #648 

# New Metadata

- UTIL_CustomSettings_API.cls

# Deleted Metadata

# Testing Notes

- Call the following functions in UTIL_CustomSettings_API using the Developer console and ensure that they work correctly:
  - getSettings()
  - getOrgSettings()
  - getSettingsForTests(Hierarchy_Settings__c mySettings)
