### PR TITLE
Renaming labels in custom objects.

### DIFF
--- a/src/objects/Address__c.object
+++ b/src/objects/Address__c.object
@@ -677,7 +677,7 @@ MailingCity__c &amp; IF(LEN(MailingCity__c) &gt; 0, &quot;, &quot;, &quot;&quot;
         <type>Number</type>
         <unique>false</unique>
     </fields>
-    <label>Address</label>
+    <label>HEDA Address</label>
     <listViews>
         <fullName>All</fullName>
         <filterScope>Everything</filterScope>
@@ -689,7 +689,7 @@ MailingCity__c &amp; IF(LEN(MailingCity__c) &gt; 0, &quot;, &quot;, &quot;&quot;
         <trackFeedHistory>false</trackFeedHistory>
         <type>AutoNumber</type>
     </nameField>
-    <pluralLabel>Addresses</pluralLabel>
+    <pluralLabel>HEDA Addresses</pluralLabel>
     <searchLayouts>
         <lookupDialogsAdditionalFields>Formula_MailingAddress__c</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>Parent_Account__c</lookupDialogsAdditionalFields>

--- a/src/objects/Affiliation__c.object
+++ b/src/objects/Affiliation__c.object
@@ -193,7 +193,7 @@
         <trackTrending>false</trackTrending>
         <type>Picklist</type>
     </fields>
-    <label>Affiliation</label>
+    <label>HEDA Affiliation</label>
     <listViews>
         <fullName>All</fullName>
         <filterScope>Everything</filterScope>
@@ -205,7 +205,7 @@
         <trackHistory>false</trackHistory>
         <type>AutoNumber</type>
     </nameField>
-    <pluralLabel>Affiliations</pluralLabel>
+    <pluralLabel>HEDA Affiliations</pluralLabel>
     <searchLayouts/>
     <sharingModel>ReadWrite</sharingModel>
 </CustomObject>

--- a/src/objects/Affl_Mappings__c.object
+++ b/src/objects/Affl_Mappings__c.object
@@ -56,6 +56,6 @@
         <type>Text</type>
         <unique>false</unique>
     </fields>
-    <label>Affl Mappings</label>
+    <label>HEDA Affl Mappings</label>
     <visibility>Public</visibility>
 </CustomObject>

--- a/src/objects/Course_Enrollment__c.object
+++ b/src/objects/Course_Enrollment__c.object
@@ -198,7 +198,7 @@
         <trackTrending>false</trackTrending>
         <type>Picklist</type>
     </fields>
-    <label>Course Connection</label>
+    <label>HEDA Course Connection</label>
     <listViews>
         <fullName>All</fullName>
         <filterScope>Everything</filterScope>
@@ -209,7 +209,7 @@
         <label>Course Connection ID</label>
         <type>AutoNumber</type>
     </nameField>
-    <pluralLabel>Course Connections</pluralLabel>
+    <pluralLabel>HEDA Course Connections</pluralLabel>
     <searchLayouts/>
     <sharingModel>ReadWrite</sharingModel>
 </CustomObject>

--- a/src/objects/Course_Offering__c.object
+++ b/src/objects/Course_Offering__c.object
@@ -140,7 +140,7 @@
         <type>MasterDetail</type>
         <writeRequiresMasterRead>false</writeRequiresMasterRead>
     </fields>
-    <label>Course Offering</label>
+    <label>HEDA Course Offering</label>
     <listViews>
         <fullName>All</fullName>
         <filterScope>Everything</filterScope>
@@ -150,7 +150,7 @@
         <label>Course Offering ID</label>
         <type>Text</type>
     </nameField>
-    <pluralLabel>Course Offerings</pluralLabel>
+    <pluralLabel>HEDA Course Offerings</pluralLabel>
     <searchLayouts/>
     <sharingModel>ControlledByParent</sharingModel>
 </CustomObject>

--- a/src/objects/Course__c.object
+++ b/src/objects/Course__c.object
@@ -116,7 +116,7 @@
         <type>LongTextArea</type>
         <visibleLines>5</visibleLines>
     </fields>
-    <label>Course</label>
+    <label>HEDA Course</label>
     <listViews>
         <fullName>All</fullName>
         <filterScope>Everything</filterScope>
@@ -126,7 +126,7 @@
         <label>Course Name</label>
         <type>Text</type>
     </nameField>
-    <pluralLabel>Courses</pluralLabel>
+    <pluralLabel>HEDA Courses</pluralLabel>
     <searchLayouts/>
     <sharingModel>ControlledByParent</sharingModel>
 </CustomObject>

--- a/src/objects/Error__c.object
+++ b/src/objects/Error__c.object
@@ -149,13 +149,13 @@
         <type>LongTextArea</type>
         <visibleLines>10</visibleLines>
     </fields>
-    <label>Error</label>
+    <label>HEDA Error</label>
     <nameField>
         <displayFormat>{000000}</displayFormat>
         <label>Error Number</label>
         <type>AutoNumber</type>
     </nameField>
-    <pluralLabel>Errors</pluralLabel>
+    <pluralLabel>HEDA Errors</pluralLabel>
     <searchLayouts>
         <customTabListAdditionalFields>Datetime__c</customTabListAdditionalFields>
         <customTabListAdditionalFields>Error_Type__c</customTabListAdditionalFields>

--- a/src/objects/Hierarchy_Settings__c.object
+++ b/src/objects/Hierarchy_Settings__c.object
@@ -312,6 +312,6 @@
         <type>Text</type>
         <unique>false</unique>
     </fields>
-    <label>Hierarchy Settings</label>
+    <label>HEDA Hierarchy Settings</label>
     <visibility>Public</visibility>
 </CustomObject>

--- a/src/objects/Plan_Requirement__c.object
+++ b/src/objects/Plan_Requirement__c.object
@@ -163,7 +163,7 @@
         <type>Number</type>
         <unique>false</unique>
     </fields>
-    <label>Plan Requirement</label>
+    <label>HEDA Plan Requirement</label>
     <listViews>
         <fullName>All</fullName>
         <filterScope>Everything</filterScope>
@@ -173,7 +173,7 @@
         <label>Plan Requirement Name</label>
         <type>Text</type>
     </nameField>
-    <pluralLabel>Plan Requirements</pluralLabel>
+    <pluralLabel>HEDA Plan Requirements</pluralLabel>
     <searchLayouts/>
     <sharingModel>ReadWrite</sharingModel>
 </CustomObject>

--- a/src/objects/Program_Enrollment__c.object
+++ b/src/objects/Program_Enrollment__c.object
@@ -255,7 +255,7 @@
         <trackTrending>false</trackTrending>
         <type>Date</type>
     </fields>
-    <label>Program Enrollment</label>
+    <label>HEDA Program Enrollment</label>
     <listViews>
         <fullName>All</fullName>
         <filterScope>Everything</filterScope>
@@ -266,7 +266,7 @@
         <label>Program Enrollment ID</label>
         <type>AutoNumber</type>
     </nameField>
-    <pluralLabel>Program Enrollments</pluralLabel>
+    <pluralLabel>HEDA Program Enrollments</pluralLabel>
     <searchLayouts/>
     <sharingModel>ReadWrite</sharingModel>
 </CustomObject>

--- a/src/objects/Program_Plan__c.object
+++ b/src/objects/Program_Plan__c.object
@@ -150,7 +150,7 @@
         <type>Text</type>
         <unique>false</unique>
     </fields>
-    <label>Program Plan</label>
+    <label>HEDA Program Plan</label>
     <listViews>
         <fullName>All</fullName>
         <filterScope>Everything</filterScope>
@@ -176,7 +176,7 @@
         <label>Program Plan Name</label>
         <type>Text</type>
     </nameField>
-    <pluralLabel>Program Plans</pluralLabel>
+    <pluralLabel>HEDA Program Plans</pluralLabel>
     <searchLayouts>
         <searchResultsAdditionalFields>Account__c</searchResultsAdditionalFields>
         <searchResultsAdditionalFields>Start_Date__c</searchResultsAdditionalFields>

--- a/src/objects/Relationship_Auto_Create__c.object
+++ b/src/objects/Relationship_Auto_Create__c.object
@@ -49,6 +49,6 @@
         <type>Text</type>
         <unique>false</unique>
     </fields>
-    <label>Relationship Auto-Create</label>
+    <label>HEDA Relationship Auto-Create</label>
     <visibility>Public</visibility>
 </CustomObject>

--- a/src/objects/Relationship_Lookup__c.object
+++ b/src/objects/Relationship_Lookup__c.object
@@ -50,6 +50,6 @@
         <type>Text</type>
         <unique>false</unique>
     </fields>
-    <label>Relationship Lookup</label>
+    <label>HEDA Relationship Lookup</label>
     <visibility>Public</visibility>
 </CustomObject>

--- a/src/objects/Relationship__c.object
+++ b/src/objects/Relationship__c.object
@@ -286,7 +286,7 @@ TEXT(Contact__r.Salutation) + &quot; &quot; + Contact__r.FirstName + &quot; &quo
         <trackTrending>false</trackTrending>
         <type>Picklist</type>
     </fields>
-    <label>Relationship</label>
+    <label>HEDA Relationship</label>
     <listViews>
         <fullName>All</fullName>
         <filterScope>Everything</filterScope>
@@ -298,7 +298,7 @@ TEXT(Contact__r.Salutation) + &quot; &quot; + Contact__r.FirstName + &quot; &quo
         <trackHistory>false</trackHistory>
         <type>AutoNumber</type>
     </nameField>
-    <pluralLabel>Relationships</pluralLabel>
+    <pluralLabel>HEDA Relationships</pluralLabel>
     <searchLayouts/>
     <sharingModel>ReadWrite</sharingModel>
     <validationRules>

--- a/src/objects/Term__c.object
+++ b/src/objects/Term__c.object
@@ -93,7 +93,7 @@
         <trackTrending>false</trackTrending>
         <type>Date</type>
     </fields>
-    <label>Term</label>
+    <label>HEDA Term</label>
     <listViews>
         <fullName>All</fullName>
         <filterScope>Everything</filterScope>
@@ -103,7 +103,7 @@
         <label>Term Name</label>
         <type>Text</type>
     </nameField>
-    <pluralLabel>Terms</pluralLabel>
+    <pluralLabel>HEDA Terms</pluralLabel>
     <searchLayouts/>
     <sharingModel>ControlledByParent</sharingModel>
 </CustomObject>

--- a/src/objects/Trigger_Handler__c.object
+++ b/src/objects/Trigger_Handler__c.object
@@ -210,7 +210,7 @@
         <trackTrending>false</trackTrending>
         <type>TextArea</type>
     </fields>
-    <label>Trigger Handler</label>
+    <label>HEDA Trigger Handler</label>
     <listViews>
         <fullName>All</fullName>
         <filterScope>Everything</filterScope>
@@ -232,7 +232,7 @@
         <label>Trigger Handler Name</label>
         <type>Text</type>
     </nameField>
-    <pluralLabel>Trigger Handlers</pluralLabel>
+    <pluralLabel>HEDA Trigger Handlers</pluralLabel>
     <searchLayouts/>
     <sharingModel>ReadWrite</sharingModel>
 </CustomObject>


### PR DESCRIPTION
# Critical Changes

# Changes
- Updating custom objects labels to include "HEDA" in the name, so they are easy to infer their origin in the setup menu.

# Issues Closed
Fixes #654.

# New Metadata

# Deleted Metadata

# Testing Notes
Verify all objects in HEDA now include HEDA in their name in the setup menu.