### PR TITLE
Update record types

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -168,14 +168,14 @@ flows:
                     managed: True
                     namespaced_org: True
                     record_types:
-                        - record_type: "Account.{namespaced_org}Administrative"
+                        - record_type: "Account.Administrative"
                           default: true
-                        - record_type: "Account.{namespaced_org}Academic_Program"
-                        - record_type: "Account.{namespaced_org}Business_Organization"
-                        - record_type: "Account.{namespaced_org}Educational_Institution"
-                        - record_type: "Account.{namespaced_org}HH_Account"
-                        - record_type: "Account.{namespaced_org}Sports_Organization"
-                        - record_type: "Account.{namespaced_org}University_Department"
+                        - record_type: "Account.Academic_Program"
+                        - record_type: "Account.Business_Organization"
+                        - record_type: "Account.Educational_Institution"
+                        - record_type: "Account.HH_Account"
+                        - record_type: "Account.Sports_Organization"
+                        - record_type: "Account.University_Department"
 
     config_qa:
         steps:


### PR DESCRIPTION
# Critical Changes

# Changes
When run against the packaging org, the `update_admin_profile` task retrieves a `package.xml` that doesn't include the package namespaces. This causes the task to fail with:

    Record Type Account.{namespaced_org}Administrative not found in retrieved Admin.profile
    
This PR removes the namespace token from the `config_packaging` configuration. 
# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
