### PR TITLE
Auto populate primary program plan on program enrollment

### DIFF
--- a/src/classes/PREN_ProgramPlan_TDTM.cls
+++ b/src/classes/PREN_ProgramPlan_TDTM.cls
@@ -48,14 +48,20 @@ public with sharing class PREN_ProgramPlan_TDTM extends TDTM_Runnable{
             TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
 
         DmlWrapper dmlWrapper = new DmlWrapper();
-
+                
         //Before Insert
-        if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
+        if (newlist != null
+            	&& newlist.size() > 0
+            	&& triggerAction == TDTM_Runnable.Action.BeforeInsert 
+            	&& !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PREN_ProgramPlan_TDTM_Before_Insert)) {
             if(newlist != null && newlist.size() > 0) {
                 populatePrimaryProgramPlan(newlist);
             }
         }
-
+                
+		if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.PREN_ProgramPlan_TDTM_Before_Insert, false);
+        }
         return dmlWrapper;
     }
 

--- a/src/classes/PREN_ProgramPlan_TDTM.cls
+++ b/src/classes/PREN_ProgramPlan_TDTM.cls
@@ -36,6 +36,9 @@
 */
 public with sharing class PREN_ProgramPlan_TDTM extends TDTM_Runnable{
 
+    //Variables for Process Control
+    static boolean beforeInsertRecursionFlag = TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PREN_ProgramPlan_TDTM_Before_Insert);
+
     /*******************************************************************************************************
     * @description Handles Program Plan management for Program Enrollment.
     * @param listNew the list of Program Enrollments from trigger new.
@@ -53,7 +56,7 @@ public with sharing class PREN_ProgramPlan_TDTM extends TDTM_Runnable{
         if (newlist != null
             	&& newlist.size() > 0
             	&& triggerAction == TDTM_Runnable.Action.BeforeInsert 
-            	&& !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PREN_ProgramPlan_TDTM_Before_Insert)) {
+            	&& !beforeInsertRecursionFlag) {
             if(newlist != null && newlist.size() > 0) {
                 populatePrimaryProgramPlan(newlist);
             }
@@ -92,7 +95,7 @@ public with sharing class PREN_ProgramPlan_TDTM extends TDTM_Runnable{
 
         //Loop through program enrollment again and populate primary program plan
         for (SObject so : newlist) {
-            Program_Enrollment__c newPe = (Program_Enrollment__c) so;
+            Program_Enrollment__c newPe = (Program_Enrollment__c)so;
             if (mapAcademicProgramIdToPrimaryPPId.containsKey(newPe.Account__c)
                     && mapAcademicProgramIdToPrimaryPPId.get(newPe.Account__c) != null) {
                 newPe.Program_Plan__c = mapAcademicProgramIdToPrimaryPPId.get(newPe.Account__c);

--- a/src/classes/PREN_ProgramPlan_TDTM.cls
+++ b/src/classes/PREN_ProgramPlan_TDTM.cls
@@ -1,0 +1,97 @@
+/*
+    Copyright (c) 2018, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2018
+* @group Program Enrollment
+* @group-content ../../ApexDocContent/ProgramEnrollments.htm
+* @description Handles Program Enrollment and Program Plan.
+*/
+public with sharing class PREN_ProgramPlan_TDTM extends TDTM_Runnable{
+
+    /*******************************************************************************************************
+    * @description Handles Program Plan management for Program Enrollment.
+    * @param listNew the list of Program Enrollments from trigger new.
+    * @param listOld the list of Program Enrollments from trigger old.
+    * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.).
+    * @param objResult the describe for Program Enrollment.
+    * @return dmlWrapper.
+    ********************************************************************************************************/
+    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist,
+            TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
+
+        DmlWrapper dmlWrapper = new DmlWrapper();
+
+        //Before Insert
+        if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
+            if(newlist != null && newlist.size() > 0) {
+                populatePrimaryProgramPlan(newlist);
+            }
+        }
+
+        return dmlWrapper;
+    }
+
+    /*******************************************************************************************************
+    * @description Populate primary program plan when a program enrollment is created
+    * @param List<SObject> newList the Contact
+    * @return void
+    */
+    private void populatePrimaryProgramPlan(List<SObject> newlist) {
+        Set<Id> setAcademicProgramIds = new Set<Id>();
+        Map<Id, Id> mapAcademicProgramIdToPrimaryPPId = new Map<Id, Id>();
+        for (SObject so : newlist) {
+            Program_Enrollment__c newPe = (Program_Enrollment__c)so;
+            //Build a set of academic program ids
+            setAcademicProgramIds.add(newPe.Account__c);
+        }
+
+        //Query academic program and build a map of
+        //Academic Program id and Primary Program Plan id
+        for (Program_Plan__c pp : [SELECT Id, Account__c
+                                    FROM Program_Plan__c
+                                    WHERE Account__c in :setAcademicProgramIds
+                                        AND Is_Primary__c = TRUE]) {
+            if (pp.Account__c != null) {
+                mapAcademicProgramIdToPrimaryPPId.put(pp.Account__c, pp.Id);
+            }
+        }
+
+        //Loop through program enrollment again and populate primary program plan
+        for (SObject so : newlist) {
+            Program_Enrollment__c newPe = (Program_Enrollment__c) so;
+            if (mapAcademicProgramIdToPrimaryPPId.containsKey(newPe.Account__c)
+                    && mapAcademicProgramIdToPrimaryPPId.get(newPe.Account__c) != null) {
+                newPe.Program_Plan__c = mapAcademicProgramIdToPrimaryPPId.get(newPe.Account__c);
+            }
+        }
+    }
+
+}

--- a/src/classes/PREN_ProgramPlan_TDTM.cls-meta.xml
+++ b/src/classes/PREN_ProgramPlan_TDTM.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>44.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/PREN_ProgramPlan_TEST.cls
+++ b/src/classes/PREN_ProgramPlan_TEST.cls
@@ -1,0 +1,89 @@
+/*
+    Copyright (c) 2018, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2018
+* @group Program Plan
+* @group-content ../../ApexDocContent/ProgramEnrollments.htm
+* @description Testing for handling program enrollment with program plan.
+*/
+
+@IsTest
+private class PREN_ProgramPlan_TEST {
+
+    @IsTest
+    static void createProgramEnrollmentPrimaryProgramPlanExist() {
+        //Set up test data
+        List<Account> testAccts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getAcademicAccRecTypeID());
+        insert testAccts;
+
+        List<Program_Plan__c> testPPs = UTIL_UnitTestData_TEST.getMultipleTestProgramPlans(2);
+        for (Program_Plan__c testPP : testPPs) {
+            testPP.Account__c = testAccts[0].Id;
+        }
+        testPPs[0].Is_Primary__c = true;
+        insert testPPs;
+
+        //Run the test
+        Test.startTest();
+        Program_Enrollment__c testPe = UTIL_UnitTestData_TEST.getProgramEnrollment(testAccts[0].Id);
+        insert testPe;
+        Test.stopTest();
+
+        //Assert the test
+        List<Program_Enrollment__c> resultPes = [SELECT Id, Program_Plan__c
+                                                    FROM Program_Enrollment__c];
+        //Make sure there is only one program enrollment created
+        System.assertEquals(1, resultPes);
+        //Make sure the program plan is automatically populated for new program enrollment
+        System.assertEquals(testPPs[0].Id, resultPes[0].Program_Plan__c);
+    }
+
+    @IsTest
+    static void createProgramEnrollmentPrimaryProgramPlanNotExist() {
+        //Set up test data
+        List<Account> testAccts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getAcademicAccRecTypeID());
+        insert testAccts;
+
+        //Run the test
+        Test.startTest();
+        Program_Enrollment__c testPe = UTIL_UnitTestData_TEST.getProgramEnrollment(testAccts[0].Id);
+        insert testPe;
+        Test.stopTest();
+
+        //Assert the test
+        List<Program_Enrollment__c> resultPes = [SELECT Id, Program_Plan__c
+        FROM Program_Enrollment__c];
+        //Make sure there is only one program enrollment created
+        System.assertEquals(1, resultPes);
+        //Make sure the program plan is empty for new program enrollment
+        System.assertEquals(null, resultPes[0].Program_Plan__c);
+    }
+}

--- a/src/classes/PREN_ProgramPlan_TEST.cls
+++ b/src/classes/PREN_ProgramPlan_TEST.cls
@@ -80,7 +80,7 @@ private class PREN_ProgramPlan_TEST {
 
         //Assert the test
         List<Program_Enrollment__c> resultPes = [SELECT Id, Program_Plan__c
-        FROM Program_Enrollment__c];
+                                                    FROM Program_Enrollment__c];
         //Make sure there is only one program enrollment created
         System.assertEquals(1, resultPes.size());
         //Make sure the program plan is empty for new program enrollment

--- a/src/classes/PREN_ProgramPlan_TEST.cls
+++ b/src/classes/PREN_ProgramPlan_TEST.cls
@@ -61,7 +61,7 @@ private class PREN_ProgramPlan_TEST {
         List<Program_Enrollment__c> resultPes = [SELECT Id, Program_Plan__c
                                                     FROM Program_Enrollment__c];
         //Make sure there is only one program enrollment created
-        System.assertEquals(1, resultPes);
+        System.assertEquals(1, resultPes.size());
         //Make sure the program plan is automatically populated for new program enrollment
         System.assertEquals(testPPs[0].Id, resultPes[0].Program_Plan__c);
     }
@@ -82,7 +82,7 @@ private class PREN_ProgramPlan_TEST {
         List<Program_Enrollment__c> resultPes = [SELECT Id, Program_Plan__c
         FROM Program_Enrollment__c];
         //Make sure there is only one program enrollment created
-        System.assertEquals(1, resultPes);
+        System.assertEquals(1, resultPes.size());
         //Make sure the program plan is empty for new program enrollment
         System.assertEquals(null, resultPes[0].Program_Plan__c);
     }

--- a/src/classes/PREN_ProgramPlan_TEST.cls-meta.xml
+++ b/src/classes/PREN_ProgramPlan_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>44.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -176,5 +176,11 @@ public without sharing class TDTM_DefaultConfig {
                 Class__c = 'PReq_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Plan_Requirement__c',
                 Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'BeforeDelete'));
         return handlers;
+
+        // Handles Program Enrollment and Program Plan
+        handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
+                Class__c = 'PREN_ProgramPlan_TDTM', Load_Order__c = 1, Object__c = 'Program_Enrollment__c',
+                Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'BeforeInsert'));
+        return handlers;
     }
 }

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -175,7 +175,6 @@ public without sharing class TDTM_DefaultConfig {
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
                 Class__c = 'PReq_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Plan_Requirement__c',
                 Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'BeforeDelete'));
-        return handlers;
 
         // Handles Program Enrollment and Program Plan
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,

--- a/src/classes/TDTM_ProcessControl.cls
+++ b/src/classes/TDTM_ProcessControl.cls
@@ -63,7 +63,8 @@ public class TDTM_ProcessControl {
         AFFL_MultiRecordType_TDTM_afflMadePrimary,
         CON_PrimaryAffls_TDTM_keyAfflLookupUpdated,
         PPlan_Primary_TDTM_Before_Insert,
-        PPlan_Primary_TDTM_Before_Update
+        PPlan_Primary_TDTM_Before_Update,
+        PREN_ProgramPlan_TDTM_Before_Insert
     }
 
     /*******************************************************************************************************

--- a/src/package.xml
+++ b/src/package.xml
@@ -69,10 +69,10 @@
         <members>PPlan_CannotDelete_TEST</members>
         <members>PPlan_Primary_TDTM</members>
         <members>PPlan_Primary_TEST</members>
-        <members>PREN_ProgramPlan_TDTM</members>
-        <members>PREN_ProgramPlan_TEST</members>
         <members>PREN_Affiliation_TDTM</members>
         <members>PREN_Affiliation_TEST</members>
+        <members>PREN_ProgramPlan_TDTM</members>
+        <members>PREN_ProgramPlan_TEST</members>
         <members>PReq_CannotDelete_TDTM</members>
         <members>PReq_CannotDelete_TEST</members>
         <members>REL_Relationships_Cm_TDTM</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -69,6 +69,8 @@
         <members>PPlan_CannotDelete_TEST</members>
         <members>PPlan_Primary_TDTM</members>
         <members>PPlan_Primary_TEST</members>
+        <members>PREN_ProgramPlan_TDTM</members>
+        <members>PREN_ProgramPlan_TEST</members>
         <members>PREN_Affiliation_TDTM</members>
         <members>PREN_Affiliation_TEST</members>
         <members>PReq_CannotDelete_TDTM</members>


### PR DESCRIPTION
# Critical Changes

# Changes
- We've introduced a new TDTM class, PREN_ProgramPlan_TDTM, that automatically populates the Program Plan field on a Program Enrollment. Now, when you create a Program Enrollment and leave the Program Plan field blank, we set it to the one that's specified as Primary for the Academic Program. If you haven't specified a Primary Program Plan, we don't fill in a value.

# Issues Closed
Fixes #662
# New Metadata

# Deleted Metadata

# Testing Notes
1. Create a academic program
2. Create a program plan, mark it as primary and assign it to the academic program
3. Create a contact
4. Create a program enrollment and set the account as the academic program
5. Make sure the program plan on program enrollment is populated with the primary program plan