### PR TITLE
Feature/jbrandolini/update program plan trigger context

### DIFF
--- a/src/classes/PPlan_Primary_TDTM.cls
+++ b/src/classes/PPlan_Primary_TDTM.cls
@@ -101,7 +101,7 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
     * @param new PPlan new value of Program_Plan__c record
     * @return Boolean true if newly marked primary, or if currently primary and related Account__c was changed, false otherwise
     ********************************************************************************************************/
-    private static boolean isNewlyPrimaryOrPrimaryAndAccountChanged(Program_Plan__c oldPPlan, Program_Plan__c newPPlan) {
+    @testVisible private static boolean isNewlyPrimaryOrPrimaryAndAccountChanged(Program_Plan__c oldPPlan, Program_Plan__c newPPlan) {
         boolean wasPrimary = ((oldPPlan != null) && (oldPPlan.Is_Primary__c));
         boolean isPrimary = ((newPPlan != null) && (newPPlan.Is_Primary__c));  
         Id oldAcctId = (oldPPlan != null) ? oldPPlan.Account__c : null;
@@ -118,7 +118,8 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
                                             Is_Primary__c
                                     From Program_Plan__c
                                     WHERE Account__c IN :accountIdsNeedNonPrimary
-                                        AND Id NOT IN :primaryProgramIds]) {
+                                        AND Id NOT IN :primaryProgramIds
+                                        AND IS_Primary__c = true]) {
             pPlan.Is_Primary__c = false;
             pPlansNeedNonPrimary.add(pPlan);
         }

--- a/src/classes/PPlan_Primary_TDTM.cls
+++ b/src/classes/PPlan_Primary_TDTM.cls
@@ -50,8 +50,10 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
         Set<Id> acccountIdsNeedNonPrimarycount = new Set<Id>();
         Set<Id> primaryProgramIds = new Set<Id>();
         
+        boolean afterInsertRecursionFlag = TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_After_Insert);
+
         // AFTER INSERT
-        if ( newlist != null && triggerAction == TDTM_Runnable.Action.AfterInsert && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_After_Insert)) {    
+        if ( newlist != null && triggerAction == TDTM_Runnable.Action.AfterInsert && !afterInsertRecursionFlag) {    
             for (integer i = 0; i < newlist.size(); i++) {
                 Program_Plan__c newPPlan = (Program_Plan__c)newlist[i];
                 if (isNewlyPrimaryOrPrimaryAndAccountChanged(null, newPPlan)) {
@@ -65,8 +67,10 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
             }
         }
 
+        boolean afterUpdateRecursionFlag = TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_After_Update);
+    
         // AFTER UPDATE
-        if ( newlist != null && triggerAction == TDTM_Runnable.Action.AfterUpdate && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_After_Update)) {                
+        if ( newlist != null && triggerAction == TDTM_Runnable.Action.AfterUpdate && !afterUpdateRecursionFlag) {                
              for (integer i = 0; i < newlist.size(); i++) {
                 Program_Plan__c newPPlan = (Program_Plan__c)newlist[i];
                 Program_Plan__c oldPPlan = (Program_Plan__c)oldlist[i];

--- a/src/classes/PPlan_Primary_TDTM.cls
+++ b/src/classes/PPlan_Primary_TDTM.cls
@@ -49,11 +49,12 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
 
         Set<Id> acccountIdsNeedNonPrimarycount = new Set<Id>();
         Set<Id> primaryProgramIds = new Set<Id>();
-        // BEFORE INSERT
-        if ( newlist != null && triggerAction == TDTM_Runnable.Action.BeforeInsert && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_Before_Insert)) {
-            for (integer i=0; i<newlist.size(); i++) {
+        
+        // AFTER INSERT
+        if ( newlist != null && triggerAction == TDTM_Runnable.Action.AfterInsert && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_After_Insert)) {    
+            for (integer i = 0; i < newlist.size(); i++) {
                 Program_Plan__c newPPlan = (Program_Plan__c)newlist[i];
-                if (newPPlan.Is_Primary__c == true) {
+                if (isNewlyPrimaryOrPrimaryAndAccountChanged(null, newPPlan)) {
                     //if multiple program plans under one single account are set as primary in same transation
                     //Use the first program plan as the primary
                     if (!acccountIdsNeedNonPrimarycount.contains(newPPlan.Account__c)) {
@@ -63,14 +64,13 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
                 }
             }
         }
-        // BEFORE UPDATE
-        if ( newlist != null && triggerAction == TDTM_Runnable.Action.BeforeUpdate && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_Before_Update)) {
-            for (integer i=0; i<newlist.size(); i++) {
+
+        // AFTER UPDATE
+        if ( newlist != null && triggerAction == TDTM_Runnable.Action.AfterUpdate && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_After_Update)) {                
+             for (integer i = 0; i < newlist.size(); i++) {
                 Program_Plan__c newPPlan = (Program_Plan__c)newlist[i];
                 Program_Plan__c oldPPlan = (Program_Plan__c)oldlist[i];
-                if (newPPlan.Is_Primary__c == true
-                    && (newPPlan.Is_Primary__c != oldPPlan.Is_Primary__c
-                        || newPPlan.Account__c != oldPPlan.Account__c)) {
+                if (isNewlyPrimaryOrPrimaryAndAccountChanged(oldPPlan, newPPlan)) {
                     //if multiple program plans under one single account are set as primary in same transation
                     //Use the first program plan as the primary
                     if (!acccountIdsNeedNonPrimarycount.contains(newPPlan.Account__c)) {
@@ -80,15 +80,36 @@ public with sharing class PPlan_Primary_TDTM extends TDTM_Runnable {
                 }
             }
         }
-        if (acccountIdsNeedNonPrimarycount.size()>0) {
+
+        if (acccountIdsNeedNonPrimarycount.size() > 0) {
             dmlWrapper.objectsToUpdate.addAll(makeOtherPPlanNotPrimary(acccountIdsNeedNonPrimarycount, primaryProgramIds));
         }
-        if (triggerAction == TDTM_Runnable.Action.BeforeUpdate) {
-            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_Before_Update, false);
-        }else if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
-            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_Before_Insert, false);
+        
+        if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_After_Update, false);
+        } else if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.PPlan_Primary_TDTM_After_Insert, false);
         }
+        
         return dmlWrapper;
+    }
+
+    /*******************************************************************************************************
+    * @description Compares oldPPlan (if present), and newPPlan to see if newly Primary, or if Account was changed.
+    * Requires Is_Primary__c and Account__c fields to be populated.
+    * @param oldPPlan old value of Program_Plan__c record (or null if new record) 
+    * @param new PPlan new value of Program_Plan__c record
+    * @return Boolean true if newly marked primary, or if currently primary and related Account__c was changed, false otherwise
+    ********************************************************************************************************/
+    private static boolean isNewlyPrimaryOrPrimaryAndAccountChanged(Program_Plan__c oldPPlan, Program_Plan__c newPPlan) {
+        boolean wasPrimary = ((oldPPlan != null) && (oldPPlan.Is_Primary__c));
+        boolean isPrimary = ((newPPlan != null) && (newPPlan.Is_Primary__c));  
+        Id oldAcctId = (oldPPlan != null) ? oldPPlan.Account__c : null;
+        Id newAcctId = (newPPlan != null) ? newPPlan.Account__c : null;
+
+        boolean acctChange = ((oldPPlan != null) && (oldAcctId != newAcctId));
+
+        return (isPrimary) && ((!wasPrimary) || (acctChange));
     }
 
     private List<Program_Plan__c> makeOtherPPlanNotPrimary(Set<Id> accountIdsNeedNonPrimary, Set<Id> primaryProgramIds) {

--- a/src/classes/PPlan_Primary_TEST.cls
+++ b/src/classes/PPlan_Primary_TEST.cls
@@ -142,4 +142,66 @@ private class PPlan_Primary_TEST {
             }
         }
     }
+
+    /*********************************************************************************************************
+     * @description Confirm various scenarios with isNewlyPrimaryOrPrimaryAccountChanged method
+     *
+     */
+    @IsTest
+    static void isNewlyPrimaryOrPrimaryAndAccountChanged() {
+         List<Account> accts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(2, UTIL_Describe.getAdminAccRecTypeID());
+        insert accts[0];
+
+        List<Program_Plan__c> pPlans = UTIL_UnitTestData_TEST.getMultipleTestProgramPlans(1);
+        for (Program_Plan__c pPlan : pPlans) {
+            pPlan.Account__c = accts[0].Id;
+        }
+        insert pPlans;
+        
+        Program_Plan__c oldPPlan = pPlans[0].clone(true, true, true, true);
+        Program_Plan__c newPPlan = pPlans[0].clone(true, true, true, true); 
+                
+        System.assertEquals (false, PPlan_Primary_TDTM.isNewlyPrimaryOrPrimaryAndAccountChanged(null, newPPlan), 'Test #1 - New Plan, Not Primary');
+        
+        newPPlan.IS_Primary__c = true;
+        System.assertEquals (true, PPlan_Primary_TDTM.isNewlyPrimaryOrPrimaryAndAccountChanged(null, newPPlan), 'Test #2 - New Plan, Primary');
+
+        oldPPlan.IS_Primary__c = false;
+        newPPlan.IS_Primary__c = false;
+
+        System.assertEquals (false, PPlan_Primary_TDTM.isNewlyPrimaryOrPrimaryAndAccountChanged(oldPPlan, newPPlan), 'Test #3 - Plan Update, neither are primary');
+
+        oldPPlan.Is_Primary__c = false;
+        newPPlan.Is_Primary__c = true;
+        System.assertEquals (true, PPlan_Primary_TDTM.isNewlyPrimaryOrPrimaryAndAccountChanged(oldPPlan, newPPlan), 'Test #4 - Plan Update, Old Plan Not Primary, New Plan Primary');
+
+        newPPlan.Is_Primary__c = true;
+        oldPPlan.Is_Primary__c = true;
+        System.assertEquals (false, PPlan_Primary_TDTM.isNewlyPrimaryOrPrimaryAndAccountChanged(oldPPlan, newPPlan), 'Test #5 - Plan Update, Old Plan Primary, New Plan Primary');
+
+        oldPPlan.Is_Primary__c = true;
+        newPPlan.Is_Primary__c = false;
+        System.assertEquals (false, PPlan_Primary_TDTM.isNewlyPrimaryOrPrimaryAndAccountChanged(oldPPlan, newPPlan), 'Test #6 - Plan Update, Old Plan Primary, New Plan Not Primary');
+
+        oldPPlan.Is_Primary__c = true;
+        newPPlan.Is_Primary__c = true;
+        newPPlan.Account__c = accts[1].Id;
+        System.assertEquals (true, PPlan_Primary_TDTM.isNewlyPrimaryOrPrimaryAndAccountChanged(oldPPlan, newPPlan), 'Test #7 - Plan Update, Old Plan Primary, New Plan Primary, New Plan Account Changed');
+
+        oldPPlan.Is_Primary__c = false;
+        newPPlan.Is_Primary__c = false;
+        newPPlan.Account__c = accts[1].Id;
+        System.assertEquals (false, PPlan_Primary_TDTM.isNewlyPrimaryOrPrimaryAndAccountChanged(oldPPlan, newPPlan), 'Test #7 - Plan Update, Old Plan Not Primary, New Plan Not Primary, New Plan Account Changed');
+
+        oldPPlan.Is_Primary__c = false;
+        newPPlan.Is_Primary__c = true;
+        newPPlan.Account__c = accts[1].Id;
+        System.assertEquals (true, PPlan_Primary_TDTM.isNewlyPrimaryOrPrimaryAndAccountChanged(oldPPlan, newPPlan), 'Test #8 - Plan Update, Old Plan Not Primary, New Plan Primary, New Plan Account Changed');
+
+        oldPPlan.Is_Primary__c = true;
+        newPPlan.Is_Primary__c = false;
+        newPPlan.Account__c = accts[1].Id;
+        System.assertEquals (false, PPlan_Primary_TDTM.isNewlyPrimaryOrPrimaryAndAccountChanged(oldPPlan, newPPlan), 'Test #9 - Plan Update, Old Plan Primary, New Plan Not Primary, New Plan Account Changed');
+
+    }
 }

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -164,7 +164,7 @@ public without sharing class TDTM_DefaultConfig {
         // Set other Program Plan as non-primary when one Plan is marked as Primary
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
                 Class__c = 'PPlan_Primary_TDTM', Load_Order__c = 1, Object__c = 'Program_Plan__c',
-                Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'BeforeInsert;BeforeUpdate'));
+                Owned_by_Namespace__c = 'hed' ,Trigger_Action__c = 'AfterInsert;AfterUpdate'));
 
         // Stops a Program Plan from being deleted if it has any Plan Requirement
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,

--- a/src/classes/TDTM_ProcessControl.cls
+++ b/src/classes/TDTM_ProcessControl.cls
@@ -63,7 +63,9 @@ public class TDTM_ProcessControl {
         AFFL_MultiRecordType_TDTM_afflMadePrimary,
         CON_PrimaryAffls_TDTM_keyAfflLookupUpdated,
         PPlan_Primary_TDTM_Before_Insert,
-        PPlan_Primary_TDTM_Before_Update
+        PPlan_Primary_TDTM_Before_Update,
+        PPlan_Primary_TDTM_After_Insert,
+        PPlan_Primary_TDTM_After_Update
     }
 
     /*******************************************************************************************************


### PR DESCRIPTION
# Critical Changes

# Changes

Moves Primary Program Plan Before Insert/Before Update Trigger functionality to After Insert/After Update to follow best practices for triggers

# Issues Closed

Fixes #660  

# New Metadata
None

# Deleted Metadata
None

# Testing Notes

This should be retested with the same criteria/test plans used to originally test unchecking "Is Primary" from other Program Plans associated with the same Account.

Testing scenarios should include:

1) New Program Plans marked "Is Primary" should uncheck "Is Primary" on other "Program Plans" associated with the same account
2) Program Plans newly updated to "Is Primary" should uncheck "Is Primary" on other "Program Plans" associated with the same account
3) Program Plans already marked as "Is Primary" whose account is updated will uncheck "Is Primary" from the other Program Plans associated with the same (newly changed) account
4) If two program plans are newly marked as "Is Primary" for the same account, only the first one encountered in the batch will win (meaning the other[s] will become not "Is Primary")

Out of scope:
Merging two accounts together will NOT re-evaluate the "Is Primary" selection.  This is not covered in the existing implementation, either.