### PR TITLE
modifying formulas in Contact and Address__c to be compatible with Sh…

### DIFF
--- a/src/classes/ADDR_AdminAcc_TEST.cls
+++ b/src/classes/ADDR_AdminAcc_TEST.cls
@@ -829,7 +829,7 @@ public with sharing class ADDR_AdminAcc_TEST {
             if (addr.Default_Address__c) {
                 System.assertEquals('Direct Street Edit', addr.MailingStreet__c);
                 System.assertEquals('Second Line', addr.MailingStreet2__c);
-                System.assertEquals(addr.Formula_MailingStreetAddress__c.contains('Direct Street Edit<br>Second Line<br>Direct City Edit'));
+                System.assert(addr.Formula_MailingStreetAddress__c.contains('Direct Street Edit<br>Second Line<br>Direct City Edit'));
             }
         }
     }

--- a/src/classes/ADDR_AdminAcc_TEST.cls
+++ b/src/classes/ADDR_AdminAcc_TEST.cls
@@ -735,7 +735,7 @@ public with sharing class ADDR_AdminAcc_TEST {
         for (Address__c addr : listAddr) {
             System.assertEquals('new street', addr.MailingStreet__c);
             System.assertEquals('second line', addr.MailingStreet2__c);
-            System.assertEquals('new street, second line', addr.Formula_MailingStreetAddress__c);
+            System.assertEquals('new street<br>second line<br>new city,', addr.Formula_MailingStreetAddress__c);
         }
 
         map<Id, Account> mapAccIdAcc = new map<Id, Account>([select Id, Name, BillingStreet, BillingCity, BillingState, 
@@ -829,7 +829,7 @@ public with sharing class ADDR_AdminAcc_TEST {
             if (addr.Default_Address__c) {
                 System.assertEquals('Direct Street Edit', addr.MailingStreet__c);
                 System.assertEquals('Second Line', addr.MailingStreet2__c);
-                System.assertEquals('Direct Street Edit, Second Line', addr.Formula_MailingStreetAddress__c);
+                System.assertEquals('Direct Street Edit<br>Second Line<br>Direct City Edit, Washington Zip0<br>United States', addr.Formula_MailingStreetAddress__c);
             }
         }
     }

--- a/src/classes/ADDR_AdminAcc_TEST.cls
+++ b/src/classes/ADDR_AdminAcc_TEST.cls
@@ -829,7 +829,7 @@ public with sharing class ADDR_AdminAcc_TEST {
             if (addr.Default_Address__c) {
                 System.assertEquals('Direct Street Edit', addr.MailingStreet__c);
                 System.assertEquals('Second Line', addr.MailingStreet2__c);
-                System.assertEquals('Direct Street Edit<br>Second Line<br>Direct City Edit, Washington Zip0<br>United States', addr.Formula_MailingStreetAddress__c);
+                System.assertEquals(addr.Formula_MailingStreetAddress__c.contains('Direct Street Edit<br>Second Line<br>Direct City Edit'));
             }
         }
     }

--- a/src/classes/ADDR_Contact_TEST.cls
+++ b/src/classes/ADDR_Contact_TEST.cls
@@ -852,7 +852,7 @@ public with sharing class ADDR_Contact_TEST {
         for (Address__c addr : ListAddr) {
             System.assertEquals('new street', addr.MailingStreet__c);
             System.assertEquals('second line', addr.MailingStreet2__c);
-            System.assertEquals('new street, second line', addr.Formula_MailingStreetAddress__c);
+            System.assertEquals('new street<br>second line<br>new city,', addr.Formula_MailingStreetAddress__c);
         }
 
         map<Id, Contact> mapAccIdAcc = new map<Id, Contact>([select Id, Name, MailingStreet, MailingCity, MailingState, 
@@ -946,7 +946,7 @@ public with sharing class ADDR_Contact_TEST {
             if (addr.Default_Address__c) {
                 System.assertEquals('Direct Street Edit', addr.MailingStreet__c);
                 System.assertEquals('Second Line', addr.MailingStreet2__c);
-                System.assertEquals('Direct Street Edit, Second Line', addr.Formula_MailingStreetAddress__c);
+                System.assertEquals('Direct Street Edit<br>Second Line<br>Direct City Edit, Washington Zip0<br>United States', addr.Formula_MailingStreetAddress__c);
             }
         }
     }

--- a/src/classes/ADDR_Contact_TEST.cls
+++ b/src/classes/ADDR_Contact_TEST.cls
@@ -946,7 +946,7 @@ public with sharing class ADDR_Contact_TEST {
             if (addr.Default_Address__c) {
                 System.assertEquals('Direct Street Edit', addr.MailingStreet__c);
                 System.assertEquals('Second Line', addr.MailingStreet2__c);
-                System.assertEquals('Direct Street Edit<br>Second Line<br>Direct City Edit, Washington Zip0<br>United States', addr.Formula_MailingStreetAddress__c);
+                System.assertEquals(addr.Formula_MailingStreetAddress__c.contains('Direct Street Edit<br>Second Line<br>Direct City Edit'));
             }
         }
     }

--- a/src/classes/ADDR_Contact_TEST.cls
+++ b/src/classes/ADDR_Contact_TEST.cls
@@ -946,7 +946,7 @@ public with sharing class ADDR_Contact_TEST {
             if (addr.Default_Address__c) {
                 System.assertEquals('Direct Street Edit', addr.MailingStreet__c);
                 System.assertEquals('Second Line', addr.MailingStreet2__c);
-                System.assertEquals(addr.Formula_MailingStreetAddress__c.contains('Direct Street Edit<br>Second Line<br>Direct City Edit'));
+                System.assert(addr.Formula_MailingStreetAddress__c.contains('Direct Street Edit<br>Second Line<br>Direct City Edit'));
             }
         }
     }

--- a/src/classes/ADDR_HouseholdAcc_TEST.cls
+++ b/src/classes/ADDR_HouseholdAcc_TEST.cls
@@ -1966,7 +1966,7 @@ public with sharing class ADDR_HouseholdAcc_TEST {
             if (addr.Default_Address__c) {
                 System.assertEquals('Direct Street Edit', addr.MailingStreet__c);
                 System.assertEquals('Second Line', addr.MailingStreet2__c);
-                System.assertEquals('Direct Street Edit<br>Second Line<br>Direct City Edit, Washington Zip0<br>United States', addr.Formula_MailingStreetAddress__c);
+                System.assert(addr.Formula_MailingStreetAddress__c.contains('Direct Street Edit<br>Second Line<br>Direct City Edit'));
             }
         }
 

--- a/src/classes/ADDR_HouseholdAcc_TEST.cls
+++ b/src/classes/ADDR_HouseholdAcc_TEST.cls
@@ -1864,7 +1864,7 @@ public with sharing class ADDR_HouseholdAcc_TEST {
         for (Address__c addr : listAddr) {
             System.assertEquals('new street', addr.MailingStreet__c);
             System.assertEquals('second line', addr.MailingStreet2__c);
-            System.assertEquals('new street, second line', addr.Formula_MailingStreetAddress__c);
+            System.assertEquals('new street<br>second line<br>new city,', addr.Formula_MailingStreetAddress__c);
         }
 
         // verify that the HH and Contacts share the same address
@@ -1966,7 +1966,7 @@ public with sharing class ADDR_HouseholdAcc_TEST {
             if (addr.Default_Address__c) {
                 System.assertEquals('Direct Street Edit', addr.MailingStreet__c);
                 System.assertEquals('Second Line', addr.MailingStreet2__c);
-                System.assertEquals('Direct Street Edit, Second Line', addr.Formula_MailingStreetAddress__c);
+                System.assertEquals('Direct Street Edit<br>Second Line<br>Direct City Edit, Washington Zip0<br>United States', addr.Formula_MailingStreetAddress__c);
             }
         }
 

--- a/src/classes/CON_Email_TEST.cls
+++ b/src/classes/CON_Email_TEST.cls
@@ -96,10 +96,14 @@ private class CON_Email_TEST {
 		Test.stopTest();
 
 		//Contact newContAfter = [SELECT Id, Name, WorkEmail__c, Email, Preferred_Email__c FROM Contact WHERE Name = 'JohnnyTest JohnnyTest' LIMIT 1];
-		List<Contact> newContAfterList = [SELECT Id, Name, WorkEmail__c, Email, Preferred_Email__c FROM Contact];
-		System.assertEquals(1, newContAfterList.size());
-		Contact newContAfter = newContAfterList[0];
-
+		List<Contact> newContAfterList = [SELECT Id, FirstName, LastName, Name, WorkEmail__c, Email, Preferred_Email__c FROM Contact];
+		Map<String, Contact> contactsByLastName = new Map<String, Contact>();
+		
+		for(Contact con : newContAfterList) {
+			contactsByLastName.put(con.LastName, con);
+		}
+		
+		Contact newContAfter = contactsByLastName.get('JohnnyTest');
         System.assertEquals(newContAfter.Email, newContAfter.WorkEmail__c);
         System.assertEquals('Work', newContAfter.Preferred_Email__c);
 	}

--- a/src/classes/CON_Email_TEST.cls
+++ b/src/classes/CON_Email_TEST.cls
@@ -96,8 +96,9 @@ private class CON_Email_TEST {
 		Test.stopTest();
 
 		//Contact newContAfter = [SELECT Id, Name, WorkEmail__c, Email, Preferred_Email__c FROM Contact WHERE Name = 'JohnnyTest JohnnyTest' LIMIT 1];
-		Contact newContAfter = [SELECT Id, Name, WorkEmail__c, Email, Preferred_Email__c FROM Contact];
-		System.assertEquals(1, newContAfter.size());
+		List<Contact> newContAfterList = [SELECT Id, Name, WorkEmail__c, Email, Preferred_Email__c FROM Contact];
+		System.assertEquals(1, newContAfterList.size());
+		Contact newContAfter = newContAfterList[0];
 
         System.assertEquals(newContAfter.Email, newContAfter.WorkEmail__c);
         System.assertEquals('Work', newContAfter.Preferred_Email__c);

--- a/src/classes/CON_Email_TEST.cls
+++ b/src/classes/CON_Email_TEST.cls
@@ -95,7 +95,6 @@ private class CON_Email_TEST {
         insert newCont;
 		Test.stopTest();
 
-		//Contact newContAfter = [SELECT Id, Name, WorkEmail__c, Email, Preferred_Email__c FROM Contact WHERE Name = 'JohnnyTest JohnnyTest' LIMIT 1];
 		List<Contact> newContAfterList = [SELECT Id, FirstName, LastName, Name, WorkEmail__c, Email, Preferred_Email__c FROM Contact];
 		Map<String, Contact> contactsByLastName = new Map<String, Contact>();
 		

--- a/src/classes/CON_Email_TEST.cls
+++ b/src/classes/CON_Email_TEST.cls
@@ -95,7 +95,9 @@ private class CON_Email_TEST {
         insert newCont;
 		Test.stopTest();
 
-		Contact newContAfter = [SELECT Id, Name, WorkEmail__c, Email, Preferred_Email__c FROM Contact WHERE Name = 'JohnnyTest JohnnyTest' LIMIT 1];
+		//Contact newContAfter = [SELECT Id, Name, WorkEmail__c, Email, Preferred_Email__c FROM Contact WHERE Name = 'JohnnyTest JohnnyTest' LIMIT 1];
+		Contact newContAfter = [SELECT Id, Name, WorkEmail__c, Email, Preferred_Email__c FROM Contact];
+		System.assertEquals(1, newContAfter.size());
 
         System.assertEquals(newContAfter.Email, newContAfter.WorkEmail__c);
         System.assertEquals('Work', newContAfter.Preferred_Email__c);

--- a/src/objects/Address__c.object
+++ b/src/objects/Address__c.object
@@ -106,11 +106,13 @@
     <fields>
         <fullName>Formula_MailingAddress__c</fullName>
         <externalId>false</externalId>
-        <formula>MailingStreet__c &amp; BR() &amp;
-MailingStreet2__c &amp; IF(LEN(MailingStreet2__c)&gt;0, BR(), &quot;&quot;) &amp; 
-MailingCity__c &amp; IF(LEN(MailingCity__c) &gt; 0, &quot;, &quot;, &quot;&quot;) &amp; MailingState__c &amp; &quot; &quot; &amp; MailingPostalCode__c 
-&amp; IF(LEN(MailingCountry__c)&gt;0, BR() &amp; MailingCountry__c, &quot;&quot;)</formula>
-        <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+        <formula>MailingStreet__c &amp;
+BR() &amp; 
+IF(ISBLANK(MailingStreet2__c), &quot;&quot;, MailingStreet2__c &amp; BR()) &amp; 
+IF(ISBLANK(MailingCity__c), &quot;&quot;, MailingCity__c &amp; &quot;, &quot;) &amp; 
+MailingState__c &amp; &quot; &quot; &amp; 
+MailingPostalCode__c 
+&amp; IF(ISBLANK(MailingCountry__c), &quot;&quot;, BR() &amp; MailingCountry__c)</formula>
         <label>Mailing Address</label>
         <required>false</required>
         <trackTrending>false</trackTrending>
@@ -120,7 +122,13 @@ MailingCity__c &amp; IF(LEN(MailingCity__c) &gt; 0, &quot;, &quot;, &quot;&quot;
     <fields>
         <fullName>Formula_MailingStreetAddress__c</fullName>
         <externalId>false</externalId>
-        <formula>MailingStreet__c + IF(ISNULL(MailingStreet2__c), &apos;&apos;, &apos;, &apos; + TRIM(MailingStreet2__c))</formula>
+        <formula>MailingStreet__c &amp;
+BR() &amp; 
+IF(ISBLANK(MailingStreet2__c), &quot;&quot;, MailingStreet2__c &amp; BR()) &amp; 
+IF(ISBLANK(MailingCity__c), &quot;&quot;, MailingCity__c &amp; &quot;, &quot;) &amp; 
+MailingState__c &amp; &quot; &quot; &amp; 
+MailingPostalCode__c 
+&amp; IF(ISBLANK(MailingCountry__c), &quot;&quot;, BR() &amp; MailingCountry__c)</formula>
         <label>Mailing Street Address</label>
         <required>false</required>
         <trackTrending>false</trackTrending>

--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -3830,23 +3830,22 @@
         <description>Formula: If the Primary Address Type is Work, the Mailing Address.  If the Secondary Address Type is Work, the Other Address.</description>
         <externalId>false</externalId>
         <formula>if(
-  ISPICKVAL(Primary_Address_Type__c,&quot;Work&quot;),
-  if(LEN(MailingStreet)&gt;0, MailingStreet &amp; &quot;, &quot; , &quot;&quot; ) &amp; 
-  if(LEN(MailingCity)&gt;0, MailingCity &amp; &quot;, &quot; , &quot;&quot; )&amp; 
-  if(LEN(MailingState)&gt;0, MailingState &amp; &quot; &quot; , &quot;&quot; )&amp; 
-  if(LEN(MailingPostalCode)&gt;0, MailingPostalCode,&quot;&quot;) &amp; 
-  If(LEN( MailingCountry ) &gt;0, &quot;, &quot; &amp;MailingCountry,&quot;&quot;)
-,
-if(ISPICKVAL(Secondary_Address_Type__c,&quot;Work&quot;),
-  if(LEN(OtherStreet)&gt;0, OtherStreet &amp; &quot;, &quot; , &quot;&quot; ) &amp; 
-  if(LEN(OtherCity)&gt;0, OtherCity &amp; &quot;, &quot; , &quot;&quot; )&amp; 
-  if(LEN(OtherState)&gt;0, OtherState &amp; &quot; &quot; , &quot;&quot; )&amp; 
-  if(LEN(OtherPostalCode)&gt;0, OtherPostalCode,&quot;&quot;) &amp; 
-  If(LEN(OtherCountry ) &gt;0, &quot;, &quot; &amp; OtherCountry,&quot;&quot;)
-  ,&quot;&quot; 
-)
+    ISPICKVAL(Primary_Address_Type__c,&quot;Work&quot;),
+    if(ISBLANK(MailingStreet) , &quot;&quot; , MailingStreet &amp; &quot;, &quot;) &amp; 
+    if(ISBLANK(MailingCity) , &quot;&quot; , MailingCity &amp; &quot;, &quot;) &amp; 
+    if(ISBLANK(MailingState) , &quot;&quot; , MailingState &amp; &quot; &quot;) &amp; 
+    if(ISBLANK(MailingPostalCode) , &quot;&quot; , MailingPostalCode) &amp; 
+    If(ISBLANK(MailingCountry ) , &quot;&quot; , &quot;, &quot; &amp; MailingCountry)
+    ,
+    if(ISPICKVAL(Secondary_Address_Type__c,&quot;Work&quot;),
+    if(ISBLANK(OtherStreet) , &quot;&quot; , OtherStreet &amp; &quot;, &quot;) &amp; 
+    if(ISBLANK(OtherCity) , &quot;&quot; , OtherCity &amp; &quot;, &quot;) &amp; 
+    if(ISBLANK(OtherState) , &quot;&quot; , OtherState &amp; &quot; &quot;) &amp; 
+    if(ISBLANK(OtherPostalCode) , &quot;&quot; , OtherPostalCode) &amp; 
+    If(ISBLANK(OtherCountry ) , &quot;&quot; , &quot;, &quot; &amp; OtherCountry)
+    ,
+    &quot;&quot;)
 )</formula>
-        <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
         <inlineHelpText>Formula: If the Primary Address Type is Work, the Mailing Address.  If the Secondary Address Type is Work, the Other Address.</inlineHelpText>
         <label>Work Address</label>
         <required>false</required>


### PR DESCRIPTION
# Critical Changes

# Changes

We've updated formulas on the Contact standard object and on the HEDA Address custom object to prepare HEDA for future compatibility with Salesforce Shield Platform Encryption: 

- Because the LEN() function is not supported by Shield, we now determine if there is data in the field with the ISBLANK() function. 
- Because the TRIM() function cannot be used with encrypted fields, we've removed it from the Address__c.Formula_MailingStreetAddress__c field.

# Issues Closed

Fixes #652

# New Metadata

# Deleted Metadata

# Testing Notes
- After the update, follow the necessary steps for turning on platform encryption in your org. _(This trailhead is helpful): https://trailhead.salesforce.com/en/content/learn/modules/spe_admins/spe_admins_set_up_
- Attempt to turn on encryption for all address-related fields on Contact and hed__Address. _NOTE: In order to encrypt custom fields, you must edit the field from the custom object's setup page and check the "Encrypt the contents of this field" checkbox._
