### PR TITLE
test was fixed, but order by was left on by accident

### DIFF
--- a/src/classes/TERM_CourseOff_TEST.cls
+++ b/src/classes/TERM_CourseOff_TEST.cls
@@ -91,7 +91,10 @@ public with sharing class TERM_CourseOff_TEST {
         update term1;
         Test.stopTest();
         
-        coffs = [SELECT Start_Date__c, End_Date__c, Section_ID__c FROM Course_Offering__c WHERE ID IN :coffs order by Section_ID__c];
+        //To avoid using potentially encryptable fields to ensure a specific order in our testing
+        //we will create a map based on the above inserted test data to ensure we have the correct 
+        //record to test against rather than relying on order.
+        coffs = [SELECT Start_Date__c, End_Date__c, Section_ID__c FROM Course_Offering__c WHERE ID IN :coffs];
         Map<String, Course_Offering__c> courseOfferingsBySection = new Map<String, Course_Offering__c>();
         for(Course_Offering__c co : coffs) {
           courseOfferingsBySection.put(co.Section_ID__c, co);


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes

- Run the unit test from TERM_CourseOff_Test.cls and ensure it still passes.
- Turn on platform encryption and attempt to encrypt the Section_ID__c field on the Course Offering custom object. 