### PR TITLE
Feature/rheadley/self referential terms

### DIFF
--- a/src/objects/Term__c.object
+++ b/src/objects/Term__c.object
@@ -132,7 +132,7 @@
     </fields>
     <fields>
         <fullName>Type__c</fullName>
-        <description>The type of term being configured. K12 terms can be quarters that roll up into semesters which roll up into a school year. (NOTE: this may make more sense as record types later, we shall see).</description>
+        <description>The type of term being configured.</description>
         <externalId>false</externalId>
         <label>Type</label>
         <required>false</required>

--- a/src/objects/Term__c.object
+++ b/src/objects/Term__c.object
@@ -150,6 +150,10 @@
                 <fullName>School Year</fullName>
                 <default>false</default>
             </picklistValues>
+            <picklistValues>
+                <fullName>Part of Term</fullName>
+                <default>false</default>
+            </picklistValues>
         </picklist>
         <type>Picklist</type>
     </fields>

--- a/src/objects/Term__c.object
+++ b/src/objects/Term__c.object
@@ -93,6 +93,66 @@
         <trackTrending>false</trackTrending>
         <type>Date</type>
     </fields>
+    <fields>
+        <fullName>Grading_Period_Sequence__c</fullName>
+        <description>Such as 1 for the first six week, 2 for the second six weeks, etc.</description>
+        <externalId>false</externalId>
+        <label>Grading Period Sequence</label>
+        <precision>18</precision>
+        <required>false</required>
+        <scale>0</scale>
+        <trackTrending>false</trackTrending>
+        <type>Number</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Instructional_Days__c</fullName>
+        <description>The total number of instructional days in this term</description>
+        <externalId>false</externalId>
+        <label>Instructional Days</label>
+        <precision>16</precision>
+        <required>false</required>
+        <scale>2</scale>
+        <trackTrending>false</trackTrending>
+        <type>Number</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Parent_Term__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
+        <description>Used to group terms together, such as 1st Quarter of 1st Semester of School Year.</description>
+        <externalId>false</externalId>
+        <label>Parent Term</label>
+        <referenceTo>Term__c</referenceTo>
+        <relationshipLabel>Terms</relationshipLabel>
+        <relationshipName>Terms</relationshipName>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Lookup</type>
+    </fields>
+    <fields>
+        <fullName>Type__c</fullName>
+        <description>The type of term being configured. K12 terms can be quarters that roll up into semesters which roll up into a school year. (NOTE: this may make more sense as record types later, we shall see).</description>
+        <externalId>false</externalId>
+        <label>Type</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <picklist>
+            <picklistValues>
+                <fullName>Quarter</fullName>
+                <default>false</default>
+            </picklistValues>
+            <picklistValues>
+                <fullName>Semester</fullName>
+                <default>false</default>
+            </picklistValues>
+            <picklistValues>
+                <fullName>School Year</fullName>
+                <default>false</default>
+            </picklistValues>
+        </picklist>
+        <type>Picklist</type>
+    </fields>
     <label>Term</label>
     <listViews>
         <fullName>All</fullName>

--- a/src/package.xml
+++ b/src/package.xml
@@ -107,9 +107,9 @@
         <members>THAN_ClearCache_TEST</members>
         <members>THAN_Filter_TDTM</members>
         <members>THAN_Filter_TEST</members>
-        <members>UTIL_CustomSettings_API</members>
         <members>UTIL_CustomSettingsFacade</members>
         <members>UTIL_CustomSettingsFacade_TEST</members>
+        <members>UTIL_CustomSettings_API</members>
         <members>UTIL_Debug</members>
         <members>UTIL_Describe</members>
         <members>UTIL_Describe_API</members>
@@ -370,7 +370,11 @@
         <members>Relationship__c.Type__c</members>
         <members>Term__c.Account__c</members>
         <members>Term__c.End_Date__c</members>
+        <members>Term__c.Grading_Period_Sequence__c</members>
+        <members>Term__c.Instructional_Days__c</members>
+        <members>Term__c.Parent_Term__c</members>
         <members>Term__c.Start_Date__c</members>
+        <members>Term__c.Type__c</members>
         <members>Trigger_Handler__c.Active__c</members>
         <members>Trigger_Handler__c.Asynchronous__c</members>
         <members>Trigger_Handler__c.Class__c</members>
@@ -417,20 +421,22 @@
         <members>afflAccountNoRecordType</members>
         <members>afflAccoutMappingError</members>
         <members>afflNullPointerError</members>
-        <members>duplicateFieldInFilter</members>
-        <members>duplicateWithHEDAField</members>
         <members>afflTypeEnforced</members>
         <members>afflTypeEnforcedDescription</members>
         <members>automaticHHNaming</members>
         <members>automaticHHNamingHelpText</members>
         <members>defaultNamingConnector</members>
+        <members>duplicateFieldInFilter</members>
+        <members>duplicateWithHEDAField</members>
         <members>exceptionRequiredField</members>
         <members>exceptionValidationRule</members>
+        <members>fieldWithHEDANamespace</members>
         <members>firstNameLastNameAdminACC</members>
         <members>firstNameLastNameFamily</members>
         <members>firstNameLastNameHH</members>
         <members>giftProcessingConfigException</members>
         <members>hhAccNameFormat</members>
+        <members>hhAccNameFormatHelpText</members>
         <members>hhFamily</members>
         <members>lastNameAdminAcc</members>
         <members>lastNameFamily</members>
@@ -438,8 +444,6 @@
         <members>lastNameFirstNameFamily</members>
         <members>lastNameFirstNameHH</members>
         <members>lastNameHH</members>
-        <members>fieldWithHEDANamespace</members>
-        <members>hhAccNameFormatHelpText</members>
         <members>noAccRecType</members>
         <members>noAfflMappings</members>
         <members>noAutoCreateSettings</members>
@@ -606,10 +610,6 @@
         <members>Contact-ca</members>
         <members>Contact-es</members>
         <members>Contact-fr</members>
-        <members>Course__c-ca</members>
-        <members>Course__c-en_US</members>
-        <members>Course__c-es</members>
-        <members>Course__c-fr</members>
         <members>Course_Enrollment__c-ca</members>
         <members>Course_Enrollment__c-en_US</members>
         <members>Course_Enrollment__c-es</members>
@@ -618,6 +618,10 @@
         <members>Course_Offering__c-en_US</members>
         <members>Course_Offering__c-es</members>
         <members>Course_Offering__c-fr</members>
+        <members>Course__c-ca</members>
+        <members>Course__c-en_US</members>
+        <members>Course__c-es</members>
+        <members>Course__c-fr</members>
         <members>Error__c-ca</members>
         <members>Error__c-en_US</members>
         <members>Error__c-es</members>
@@ -634,10 +638,6 @@
         <members>Program_Enrollment__c-en_US</members>
         <members>Program_Enrollment__c-es</members>
         <members>Program_Enrollment__c-fr</members>
-        <members>Relationship__c-ca</members>
-        <members>Relationship__c-en_US</members>
-        <members>Relationship__c-es</members>
-        <members>Relationship__c-fr</members>
         <members>Program_Plan__c-ca</members>
         <members>Program_Plan__c-en_US</members>
         <members>Program_Plan__c-es</members>
@@ -650,6 +650,10 @@
         <members>Relationship_Lookup__c-en_US</members>
         <members>Relationship_Lookup__c-es</members>
         <members>Relationship_Lookup__c-fr</members>
+        <members>Relationship__c-ca</members>
+        <members>Relationship__c-en_US</members>
+        <members>Relationship__c-es</members>
+        <members>Relationship__c-fr</members>
         <members>Term__c-ca</members>
         <members>Term__c-en_US</members>
         <members>Term__c-es</members>


### PR DESCRIPTION
# Critical Changes

# Changes

- Adding the ability for a Term to have child terms. This allows customers to create the concept of School Years that have Semesters that have Quarters, etc.

# Issues Closed

# New Metadata

- 4 new fields:
    - Grading_Period_Sequence__c (Number), Instructional_Days__c (Number), Parent_Term__c (Lookup), Type__c (Picklist)

# Deleted Metadata

# Testing Notes
- Add Terms related list to Term page layout
- Create a term, eg. '2018-2019 School Year'
    - Create two child terms from the School Year term, eg. First Semester, Second Semester
        - From each semester's Term related list, create 2 quarters, e.g. First Quarter, Second Quarter (from the First Semester record & Third Quarter, Fourth Quarter from the Second Semester record)