### PR TITLE
Fixed wrong class name and id for record type validation checkbox

### DIFF
--- a/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp
+++ b/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp
@@ -82,8 +82,8 @@
                                         <aura:if isTrue="{!v.isView}">
                                             <ui:outputCheckbox value="{!v.hierarchySettings.Affiliation_Record_Type_Enforced__c}" class="store-errors" />
                                             <aura:set attribute="else">
-                                                <ui:inputCheckbox aura:id="storeErrors" value="{!v.hierarchySettings.Affiliation_Record_Type_Enforced__c}"
-                                                                  class="store-errors" />
+                                                <ui:inputCheckbox aura:id="afflRecordTypeEnforced" value="{!v.hierarchySettings.Affiliation_Record_Type_Enforced__c}"
+                                                                  class="affl-record-type-enforced" />
                                                 <span class="slds-checkbox--faux"></span>
                                                 <span class="slds-form-element__label"></span>
                                             </aura:set>

--- a/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp
+++ b/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp
@@ -80,7 +80,7 @@
                                 <div class="slds-form-element__control">
                                     <label class="slds-checkbox">
                                         <aura:if isTrue="{!v.isView}">
-                                            <ui:outputCheckbox value="{!v.hierarchySettings.Affiliation_Record_Type_Enforced__c}" class="store-errors" />
+                                            <ui:outputCheckbox value="{!v.hierarchySettings.Affiliation_Record_Type_Enforced__c}" class="affl-record-type-enforced" />
                                             <aura:set attribute="else">
                                                 <ui:inputCheckbox aura:id="afflRecordTypeEnforced" value="{!v.hierarchySettings.Affiliation_Record_Type_Enforced__c}"
                                                                   class="affl-record-type-enforced" />


### PR DESCRIPTION
# Critical Changes

# Changes
Fixed wrong class name/id for "enable record type validation" checkbox on HEDA setting page.
# Issues Closed
Fixes #684
# New Metadata

# Deleted Metadata

# Testing Notes
Make sure "Enable record type validation" checkbox is still working and displayed properly on HEDA setting page.