### PR TITLE
Feature/jstvz/reparentable course offerings

### DIFF
--- a/src/objects/Course_Offering__c.object
+++ b/src/objects/Course_Offering__c.object
@@ -84,7 +84,7 @@
         <relationshipLabel>Course Offerings</relationshipLabel>
         <relationshipName>Course_Offerings</relationshipName>
         <relationshipOrder>0</relationshipOrder>
-        <reparentableMasterDetail>false</reparentableMasterDetail>
+        <reparentableMasterDetail>true</reparentableMasterDetail>
         <trackTrending>false</trackTrending>
         <type>MasterDetail</type>
         <writeRequiresMasterRead>false</writeRequiresMasterRead>


### PR DESCRIPTION
# Critical Changes

# Changes
- We've enabled reparentable Course Offerings. This will allow updating the Course field of the Course Offering with a new record. 
# Issues Closed
- Fixes #644
# New Metadata

# Deleted Metadata

# Testing Notes
1. Create Course *x*
2. Create Course Offering *y*
3. Create new Course *z*
4. Reparent Course Offering *x* with Course *z*

