### PR TITLE
Feature/rheadley/bugfix for prenaffl

### DIFF
--- a/src/aura/CMP_Picklist_Dropdown/CMP_Picklist_Dropdown.cmp
+++ b/src/aura/CMP_Picklist_Dropdown/CMP_Picklist_Dropdown.cmp
@@ -6,14 +6,21 @@
     <aura:attribute name="picklistLabel" type="String" />
     <aura:attribute name="picklistValue" type="String" />
     <aura:attribute name="picklistEntries" type="Object[]" />
-    <aura:attribute name="dropdownDisabled" type="boolean" default="false" />
+    <aura:attribute name="dropdownDisabled" type="Boolean" default="false" />
+    <aura:attribute name="enableNoneOption" type="Boolean" default="false" />
 
     <aura:attribute name="setting" type="String" />
 
     <aura:if isTrue="{!v.isView}">
-        <ui:outputText aura:id="picklistLabel" class="{!v.class + '-output-text'}" value="{!v.picklistLabel}"/>
+        <aura:if isTrue="{!and(or(v.picklistValue == '', v.picklistValue == null), v.enableNoneOption)}">
+            <ui:outputText aura:id="picklistLabel" class="{!v.class + '-output-text'}" value="--None--" />    
+        <aura:set attribute="else">
+            <ui:outputText aura:id="picklistLabel" class="{!v.class + '-output-text'}" value="{!v.picklistLabel}"/>
+        </aura:set>
+        </aura:if>
     <aura:set attribute="else">
         <ui:inputSelect aura:id="picklistDropDown" class="{!v.class + '-input-select'}" change="{!c.onSelectChange}" disabled="{!v.dropdownDisabled}">
+            <ui:inputSelectOption label="--None--" text="" class="picklist-input" value="{!v.picklistValue == '' ? true : false}" />
             <aura:iteration items="{!v.picklistEntries}" var="picklistItem">
                 <ui:inputSelectOption label="{!picklistItem.picklistLabel}" text="{!picklistItem.picklistValue}" class="picklist-input"
                     value="{!v.picklistValue == picklistItem.picklistValue ? true : false}" />

--- a/src/aura/CMP_Picklist_Dropdown/CMP_Picklist_Dropdown.cmp
+++ b/src/aura/CMP_Picklist_Dropdown/CMP_Picklist_Dropdown.cmp
@@ -13,14 +13,14 @@
 
     <aura:if isTrue="{!v.isView}">
         <aura:if isTrue="{!and(or(v.picklistValue == '', v.picklistValue == null), v.enableNoneOption)}">
-            <ui:outputText aura:id="picklistLabel" class="{!v.class + '-output-text'}" value="--None--" />    
+            <ui:outputText aura:id="picklistLabel" class="{!v.class + '-output-text'}" value="{!$Label.c.NoneOption}" />    
         <aura:set attribute="else">
             <ui:outputText aura:id="picklistLabel" class="{!v.class + '-output-text'}" value="{!v.picklistLabel}"/>
         </aura:set>
         </aura:if>
     <aura:set attribute="else">
         <ui:inputSelect aura:id="picklistDropDown" class="{!v.class + '-input-select'}" change="{!c.onSelectChange}" disabled="{!v.dropdownDisabled}">
-            <ui:inputSelectOption label="--None--" text="" class="picklist-input" value="{!v.picklistValue == '' ? true : false}" />
+            <ui:inputSelectOption label="{!$Label.c.NoneOption}" text="" class="picklist-input" value="{!v.picklistValue == '' ? true : false}" />
             <aura:iteration items="{!v.picklistEntries}" var="picklistItem">
                 <ui:inputSelectOption label="{!picklistItem.picklistLabel}" text="{!picklistItem.picklistValue}" class="picklist-input"
                     value="{!v.picklistValue == picklistItem.picklistValue ? true : false}" />

--- a/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp
+++ b/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp
@@ -106,6 +106,7 @@
                         picklistLabel="{!v.affiliationStatusDeleteMapLabel}"
                         picklistEntries="{!v.affiliationStatusPicklistEntries}" 
                         dropdownDisabled="(!!v.hierarchySettings.Affl_ProgEnroll_Del__c)"
+                        enableNoneOption="true"
                       />
                     </div>
                 </div>
@@ -165,6 +166,7 @@
                         picklistValue="{!v.affiliationRoleMapValue}"
                         picklistLabel="{!v.affiliationRoleMapLabel}"
                         picklistEntries="{!v.affiliationRolePicklistEntries}"
+                        enableNoneOption="true"
                       />
                     </div>
                 </div>
@@ -185,6 +187,7 @@
                         picklistValue="{!v.affiliationStatusMapValue}"
                         picklistLabel="{!v.affiliationStatusMapLabel}"
                         picklistEntries="{!v.affiliationStatusPicklistEntries}"
+                        enableNoneOption="true"
                       />
                     </div>
                 </div>

--- a/src/aura/STG_CMP_Affl/STG_CMP_AfflHelper.js
+++ b/src/aura/STG_CMP_Affl/STG_CMP_AfflHelper.js
@@ -1,101 +1,108 @@
 ({
-	init : function(component) {
-		component.set("v.isView", true);
+    init : function(component) {
+        component.set("v.isView", true);
+        $A.util.addClass(component.find("settsTab"), "slds-active");
+        $A.util.addClass(component.find("settsTabContent"), "slds-show");
+        $A.util.addClass(component.find("mappingsTabContent"), "slds-hide");
+        this.loadAfflMappings(component);
+    },
 
-		$A.util.addClass(component.find("settsTab"), "slds-active");
+    loadAfflMappings : function(component) {
+        var prefix = component.get("v.namespacePrefix");
+        var action = component.get("c.getAfflMappings");
+        
+        action.setCallback(this, function(response) {
+            
+            if(response.getState() === "SUCCESS") {
+                
+                var settings = response.getReturnValue();
+                if(settings.length === 0) {
+                    this.setMessageLabel(component, "v.noAfflMappings", prefix, "noAfflMappings");
+                }
 
-		$A.util.addClass(component.find("settsTabContent"), "slds-show");
-		$A.util.addClass(component.find("mappingsTabContent"), "slds-hide");
+                component.set("v.afflMappings", this.removePrefixListSettings(settings, prefix));
+            
+            } else if(response.getState() === "ERROR") {
+                this.displayError(response);
+            }
+            
+        });
 
-		this.loadAfflMappings(component);
-	},
+        $A.enqueueAction(action);
+    },
 
-	loadAfflMappings : function(component) {
-		var prefix = component.get("v.namespacePrefix");
-		var action = component.get("c.getAfflMappings");
-		action.setCallback(this, function(response) {
-			if(response.getState() === "SUCCESS") {
-				var settings = response.getReturnValue();
-				if(settings.length === 0) {
-					this.setMessageLabel(component, "v.noAfflMappings", prefix, "noAfflMappings");
-				}
-				component.set("v.afflMappings", this.removePrefixListSettings(settings, prefix));
-	    	} else if(response.getState() === "ERROR") {
-	    		this.displayError(response);
-	    	}
-		});
-		$A.enqueueAction(action);
-	},
+    settsLinkClicked : function(component) {
+        $A.util.addClass(component.find("settsTab"), "slds-active");
+        $A.util.removeClass(component.find("mappingsTab"), "slds-active");
 
-	settsLinkClicked : function(component) {
-		$A.util.addClass(component.find("settsTab"), "slds-active");
-		$A.util.removeClass(component.find("mappingsTab"), "slds-active");
+        var settsTabContent = component.find("settsTabContent");
+        $A.util.removeClass(settsTabContent, "slds-hide");
+        $A.util.addClass(settsTabContent, "slds-show");
 
-		var settsTabContent = component.find("settsTabContent");
-		$A.util.removeClass(settsTabContent, "slds-hide");
-		$A.util.addClass(settsTabContent, "slds-show");
+        this.hideTabContent(component, "mappingsTabContent");
+    },
 
-		this.hideTabContent(component, "mappingsTabContent");
-	},
+    mappingsLinkClicked : function(component) {
+        $A.util.removeClass(component.find("settsTab"), "slds-active");
+        $A.util.addClass(component.find("mappingsTab"), "slds-active");
 
-	mappingsLinkClicked : function(component) {
-		$A.util.removeClass(component.find("settsTab"), "slds-active");
-		$A.util.addClass(component.find("mappingsTab"), "slds-active");
+        this.hideTabContent(component, "settsTabContent");
 
-		this.hideTabContent(component, "settsTabContent");
+        var mappingsTabContent = component.find("mappingsTabContent");
+        $A.util.removeClass(mappingsTabContent, "slds-hide");
+        $A.util.addClass(mappingsTabContent, "slds-show");
+    },
 
-		var mappingsTabContent = component.find("mappingsTabContent");
-		$A.util.removeClass(mappingsTabContent, "slds-hide");
-		$A.util.addClass(mappingsTabContent, "slds-show");
-	},
+    resetSettings : function(component) {
+        this.loadAfflMappings(component);
+    },
 
-	resetSettings : function(component) {
-		this.loadAfflMappings(component);
-	},
+    saveMappings : function(component) {
+        var saveAction = component.get("c.saveAfflMappings");
+        var settings = this.addPrefixListSettings(component.get("v.afflMappings"), component.get("v.namespacePrefix"));
+        
+        saveAction.setParams({"mappings" : settings});
+        saveAction.setCallback(this, function(response) {
+            if(response.getState() === "ERROR") {
+                this.displayError(response);
+            }
+        });
 
-	saveMappings : function(component) {
-		var saveAction = component.get("c.saveAfflMappings");
-		var settings = this.addPrefixListSettings(component.get("v.afflMappings"), component.get("v.namespacePrefix"));
-		saveAction.setParams({"mappings" : settings});
-		saveAction.setCallback(this, function(response) {
-			if(response.getState() === "ERROR") {
-				this.displayError(response);
-			}
-		});
-		$A.enqueueAction(saveAction);
-	},
+        $A.enqueueAction(saveAction);
+    },
 
-	newAfflMapping : function(component) {
-		var accRecType = component.find("accRecType").get("v.value");
-		var primaryField = component.find("primaryField").get("v.value");
-		var autoEnroll = component.find("autoEnroll").get("v.value");
-		var autoEnrollStatus = component.find("autoEnrollStatus").get("v.value");
-		var autoEnrollRole = component.find("autoEnrollRole").get("v.value");
+    newAfflMapping : function(component) {
+        var accRecType = component.find("accRecType").get("v.value");
+        var primaryField = component.find("primaryField").get("v.value");
+        var autoEnroll = component.find("autoEnroll").get("v.value");
+        var autoEnrollStatus = component.find("autoEnrollStatus").get("v.value");
+        var autoEnrollRole = component.find("autoEnrollRole").get("v.value");
 
-		var newMappingAction = component.get("c.newAfflMpg");
-		newMappingAction.setParams({ "accRecType" : accRecType, "primaryField" : primaryField, "autoEnroll" : autoEnroll,
-			"autoEnrollStatus" : autoEnrollStatus, "autoEnrollRole" : autoEnrollRole });
-		newMappingAction.setCallback(this, function(response) {
-			if(response.getState() === "SUCCESS") {
-				component.set("v.noAfflMappings", "");
-				var afflMappings = component.get("v.afflMappings");
-				afflMappings.push({ "Id" : response.getReturnValue(), "Account_Record_Type__c" : accRecType, "Primary_Affl_Field__c" : primaryField,
-								"Auto_Program_Enrollment__c" : autoEnroll, "Auto_Program_Enrollment_Status__c" : autoEnrollStatus,
-								"Auto_Program_Enrollment_Role__c" : autoEnrollRole });
-				component.set("v.afflMappings", afflMappings);
-				this.clearNewStgBoxes(component, ["accRecType", "primaryField", "autoEnroll", "autoEnrollStatus", "autoEnrollRole"]);
-				
-				// Re-Disable Add Setting button after successful completion
-				component.find("newAfflMappingBtn").set("v.disabled", true);
-			} else if(response.getState() === "ERROR") {
-				this.displayError(response);
-			}
-		});
-		$A.enqueueAction(newMappingAction);
-	},
+        var newMappingAction = component.get("c.newAfflMpg");
+        newMappingAction.setParams({ "accRecType" : accRecType, "primaryField" : primaryField, "autoEnroll" : autoEnroll,
+            "autoEnrollStatus" : autoEnrollStatus, "autoEnrollRole" : autoEnrollRole });
+        
+        newMappingAction.setCallback(this, function(response) {
+            if(response.getState() === "SUCCESS") {
+                component.set("v.noAfflMappings", "");
+                var afflMappings = component.get("v.afflMappings");
+                afflMappings.push({ "Id" : response.getReturnValue(), "Account_Record_Type__c" : accRecType, "Primary_Affl_Field__c" : primaryField,
+                                "Auto_Program_Enrollment__c" : autoEnroll, "Auto_Program_Enrollment_Status__c" : autoEnrollStatus,
+                                "Auto_Program_Enrollment_Role__c" : autoEnrollRole });
+                component.set("v.afflMappings", afflMappings);
+                this.clearNewStgBoxes(component, ["accRecType", "primaryField", "autoEnroll", "autoEnrollStatus", "autoEnrollRole"]);
+                
+                // Re-Disable Add Setting button after successful completion
+                component.find("newAfflMappingBtn").set("v.disabled", true);
+            } else if(response.getState() === "ERROR") {
+                this.displayError(response);
+            }
+        });
+        $A.enqueueAction(newMappingAction);
+    },
 
-	deleteAfflMappingRow : function(component, id, position) {
-		this.deleteRow(component, "c.deleteAfflMappingRecord", "v.afflMappings", id, position, "v.noAfflMappings", "noAfflMappings",
-				component.get("v.namespacePrefix"));
-	}
+    deleteAfflMappingRow : function(component, id, position) {
+        this.deleteRow(component, "c.deleteAfflMappingRecord", "v.afflMappings", id, position, "v.noAfflMappings", "noAfflMappings",
+                component.get("v.namespacePrefix"));
+    }
 })

--- a/src/aura/STG_CMP_Tabs/STG_CMP_TabsHelper.js
+++ b/src/aura/STG_CMP_Tabs/STG_CMP_TabsHelper.js
@@ -110,23 +110,27 @@
         var prefix = component.get("v.namespacePrefix");
         var objectName = prefix + 'Affiliation__c';
         var fieldName = prefix + 'Role__c';
+        
         action.setParams({ "objectName" : objectName,"fieldName" : fieldName});
         action.setCallback(this, function(response) {
             if(response.getState() === "SUCCESS") {
                 var picklistValues = response.getReturnValue();
                 var affiliationRolePicklistEntries = [];
+                
                 for(var property in picklistValues) {
                     if (picklistValues.hasOwnProperty(property)) {
                         affiliationRolePicklistEntries.push({picklistLabel: property, picklistValue : picklistValues[property]});
-                        if(property.indexOf(roleValue) > -1) {
+                        
+                        if(property.indexOf(roleValue) > -1 || property == '--None--') {
                             component.set("v.affiliationRoleMapLabel", property);
-                        }
+                        }   
                     }
                 }
+
                 component.set("v.affiliationRolePicklistEntries", affiliationRolePicklistEntries);
 
             } else if(response.getState() === "ERROR") {
-            this.displayError(response);
+                this.displayError(response);
             }
         });
         $A.enqueueAction(action);
@@ -138,26 +142,33 @@
         var prefix = component.get("v.namespacePrefix");
         var objectName = prefix + 'Affiliation__c';
         var fieldName = prefix + 'Status__c';
+
         action.setParams({ "objectName" : objectName,"fieldName" : fieldName});
         action.setCallback(this, function(response) {
             if(response.getState() === "SUCCESS") {
                 var picklistValues = response.getReturnValue();
                 var affiliationStatusPicklistEntries = [];
+        
                 for(var property in picklistValues) {
+                    
                     if (picklistValues.hasOwnProperty(property)) {
                         affiliationStatusPicklistEntries.push({picklistLabel: property, picklistValue: picklistValues[property]});
-                        if(property.indexOf(statusValue) > -1) {
+                        
+                        if(property.indexOf(statusValue) > -1 || property == '--None--') { 
                             component.set("v.affiliationStatusMapLabel", property);
                         }
-                        if(property.indexOf(deleteValue) > -1) {
+
+                        if(property.indexOf(deleteValue) > -1 || property == '--None--') { 
                             component.set("v.affiliationStatusDeleteMapLabel", property);
                         }
+
                     }
                 }
+
                 component.set("v.affiliationStatusPicklistEntries", affiliationStatusPicklistEntries);
 
             } else if(response.getState() === "ERROR") {
-            this.displayError(response);
+                this.displayError(response);
             }
         });
         $A.enqueueAction(action);

--- a/src/aura/STG_CMP_Tabs/STG_CMP_TabsHelper.js
+++ b/src/aura/STG_CMP_Tabs/STG_CMP_TabsHelper.js
@@ -121,7 +121,8 @@
                     if (picklistValues.hasOwnProperty(property)) {
                         affiliationRolePicklistEntries.push({picklistLabel: property, picklistValue : picklistValues[property]});
                         
-                        if(property.indexOf(roleValue) > -1 || property == '--None--') {
+                        //if(property.indexOf(roleValue) > -1 || property == '--None--') {
+                        if(property.indexOf(roleValue) > -1) {
                             component.set("v.affiliationRoleMapLabel", property);
                         }   
                     }
@@ -154,11 +155,13 @@
                     if (picklistValues.hasOwnProperty(property)) {
                         affiliationStatusPicklistEntries.push({picklistLabel: property, picklistValue: picklistValues[property]});
                         
-                        if(property.indexOf(statusValue) > -1 || property == '--None--') { 
+                        //if(property.indexOf(statusValue) > -1 || property == '--None--') { 
+                        if(property.indexOf(statusValue) > -1) { 
                             component.set("v.affiliationStatusMapLabel", property);
                         }
 
-                        if(property.indexOf(deleteValue) > -1 || property == '--None--') { 
+                        //if(property.indexOf(deleteValue) > -1 || property == '--None--') { 
+                        if(property.indexOf(deleteValue) > -1) {
                             component.set("v.affiliationStatusDeleteMapLabel", property);
                         }
 

--- a/src/aura/STG_CMP_Tabs/STG_CMP_TabsHelper.js
+++ b/src/aura/STG_CMP_Tabs/STG_CMP_TabsHelper.js
@@ -121,7 +121,6 @@
                     if (picklistValues.hasOwnProperty(property)) {
                         affiliationRolePicklistEntries.push({picklistLabel: property, picklistValue : picklistValues[property]});
                         
-                        //if(property.indexOf(roleValue) > -1 || property == '--None--') {
                         if(property.indexOf(roleValue) > -1) {
                             component.set("v.affiliationRoleMapLabel", property);
                         }   
@@ -155,12 +154,10 @@
                     if (picklistValues.hasOwnProperty(property)) {
                         affiliationStatusPicklistEntries.push({picklistLabel: property, picklistValue: picklistValues[property]});
                         
-                        //if(property.indexOf(statusValue) > -1 || property == '--None--') { 
                         if(property.indexOf(statusValue) > -1) { 
                             component.set("v.affiliationStatusMapLabel", property);
                         }
 
-                        //if(property.indexOf(deleteValue) > -1 || property == '--None--') { 
                         if(property.indexOf(deleteValue) > -1) {
                             component.set("v.affiliationStatusDeleteMapLabel", property);
                         }

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -445,6 +445,8 @@ public class UTIL_Describe {
     public static Map<String, String> getPicklistActiveValuesMap(String objectName, String fieldName) {
         Map<String, String> picklistValues = new Map<String, String>();
         
+        //allow for nothing (probably convert --None-- to a label)
+        picklistValues.put('--None--', '');
         for(Schema.PicklistEntry picklistEntry : getFieldPicklistEntries(objectName, fieldName)) {
             if(picklistEntry.isActive()) {
                 picklistValues.put(picklistEntry.getLabel(), picklistEntry.getValue());

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -445,8 +445,6 @@ public class UTIL_Describe {
     public static Map<String, String> getPicklistActiveValuesMap(String objectName, String fieldName) {
         Map<String, String> picklistValues = new Map<String, String>();
         
-        //allow for nothing (probably convert --None-- to a label)
-        picklistValues.put('--None--', '');
         for(Schema.PicklistEntry picklistEntry : getFieldPicklistEntries(objectName, fieldName)) {
             if(picklistEntry.isActive()) {
                 picklistValues.put(picklistEntry.getLabel(), picklistEntry.getValue());

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -89,6 +89,14 @@
         <value>Male</value>
     </labels>
     <labels>
+        <fullName>NoneOption</fullName>
+        <categories>Picklist Options</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Provides a blank value option to custom built picklists</shortDescription>
+        <value>--None--</value>
+    </labels>
+    <labels>
         <fullName>PreferredEmailMatchMustExist</fullName>
         <categories>Contacts</categories>
         <language>en_US</language>

--- a/src/package.xml
+++ b/src/package.xml
@@ -408,6 +408,7 @@
         <members>Female</members>
         <members>InvalidFilter</members>
         <members>Male</members>
+        <members>NoneOption</members>
         <members>PreferredEmailMatchMustExist</members>
         <members>PreferredEmailMatchNotNull</members>
         <members>PreferredEmailRequiredError</members>


### PR DESCRIPTION
# Critical Changes

# Changes

- added ability for custom picklist component to optionally include '--None--' as an option in order to allow blank values to be set.

# Issues Closed
- Fixes [W-030890](https://foundation.lightning.force.com/lightning/r/agf__ADM_Work__c/a2x1E000007fQxsQAE/view)

# New Metadata

- New CustomLabel call "NoneOption" with a value of '--None--'

# Deleted Metadata

# Testing Notes
- Ensure HEDA Settings -> Affiliations -> Settings tab shows a selected option when in view mode (including when it is set to --None--)
- Create Program Enrollment on a Contact
- Verify Affiliation gets created according to specified settings
- Delete Program Enrollment
- Verify Affiliation is deleted or Status of Affiliation is updated according to settings.