### PR TITLE
CON_Preferred_TDTM fix for batch sizes over 200 records

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -129,13 +129,14 @@ private class ACCT_IndividualAccounts_TEST {
         mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = 'Primary Household'));
         insert mappings;
 
-        Contact con = UTIL_UnitTestData_API.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         con = [select AccountId from Contact where id=:con.id];
         Id accountId = con.AccountId;
 
-        Contact con2 = UTIL_UnitTestData_API.getContact();
+        Contact con2 = contacts[1];
         con2.AccountId = accountId;
 
         Test.startTest();
@@ -156,13 +157,14 @@ private class ACCT_IndividualAccounts_TEST {
     public static void contactUpdatedToExistingAcc() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID()));
 
-        Contact con = UTIL_UnitTestData_API.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         Contact[] insertedContacts = [Select Account.Name, AccountId from Contact where id=:con.id];
         Id accountId = insertedContacts[0].AccountId;
 
-        Contact con2 = UTIL_UnitTestData_API.getContact();
+        Contact con2 = contacts[1];
         con2.AccountId = null;
         insert con2;
 
@@ -387,14 +389,15 @@ private class ACCT_IndividualAccounts_TEST {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
                 Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household', Automatic_Household_Naming__c = true));
 
-        Contact con = UTIL_UnitTestData_API.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         Account assertAccount = [SELECT Id, RecordType.Name, Name FROM Account limit 1];
         system.assertEquals('Household Account', assertAccount.RecordType.Name);
         system.assertEquals(con.FirstName + ' ' + con.LastName + ' Household', assertAccount.Name);
 
-        Contact con2 = UTIL_UnitTestData_API.getContact();
+        Contact con2 = contacts[1];
         con2.AccountId = assertAccount.Id;
         con2.LastName = con.LastName + '2';
         con2.FirstName = 'Test2';
@@ -419,14 +422,15 @@ private class ACCT_IndividualAccounts_TEST {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
                 Household_Account_Naming_Format__c = '{!LastName} ({!FirstName}) Household', Automatic_Household_Naming__c = true));
 
-        Contact con = UTIL_UnitTestData_API.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         Account assertAccount = [SELECT Id, RecordType.Name, Name FROM Account limit 1];
         system.assertEquals('Household Account', assertAccount.RecordType.Name);
         system.assertEquals(con.LastName + ' (' + con.FirstName + ') Household', assertAccount.Name);
 
-        Contact con2 = UTIL_UnitTestData_API.getContact();
+        Contact con2 = contacts[1];
         con2.FirstName = 'Test2';
         con2.LastName = con.LastName;
         con2.AccountId = assertAccount.id;
@@ -449,14 +453,15 @@ private class ACCT_IndividualAccounts_TEST {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
                 Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household', Automatic_Household_Naming__c = true));
 
-        Contact con = UTIL_UnitTestData_API.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         Account assertAccount = [SELECT Id, RecordType.Name, Name FROM Account limit 1];
         system.assertEquals('Household Account', assertAccount.RecordType.Name);
         system.assertEquals(con.FirstName + ' ' + con.LastName + ' Household', assertAccount.Name);
 
-        Contact con2 = UTIL_UnitTestData_API.getContact();
+        Contact con2 = contacts[1];
         con2.AccountId = assertAccount.Id;
         con2.LastName = con.LastName;
         con2.FirstName = 'Test2';
@@ -480,14 +485,15 @@ private class ACCT_IndividualAccounts_TEST {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
                 Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household', Automatic_Household_Naming__c = true));
 
-        Contact con = UTIL_UnitTestData_API.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         Account assertAccount = [SELECT Id, RecordType.Name, Name FROM Account limit 1];
         system.assertEquals('Household Account', assertAccount.RecordType.Name);
         system.assertEquals(con.FirstName + ' ' + con.LastName + ' Household', assertAccount.Name);
 
-        Contact con2 = UTIL_UnitTestData_API.getContact();
+        Contact con2 = contacts[1];
         con2.AccountId = assertAccount.Id;
         con2.FirstName = 'Test2';
         con2.LastName = con.LastName + '2';
@@ -520,14 +526,15 @@ private class ACCT_IndividualAccounts_TEST {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
                 Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household', Automatic_Household_Naming__c = false));
 
-        Contact con = UTIL_UnitTestData_API.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         Account assertAccount = [SELECT Id, RecordType.Name, Name FROM Account limit 1];
         system.assertEquals('Household Account', assertAccount.RecordType.Name);
         system.assertEquals(con.FirstName + ' ' + con.LastName + ' Household', assertAccount.Name);
 
-        Contact con2 = UTIL_UnitTestData_API.getContact();
+        Contact con2 = contacts[1];
         con2.AccountId = assertAccount.Id;
         con2.FirstName = 'Test2';
         con2.LastName = con.LastName + '2';
@@ -550,14 +557,15 @@ private class ACCT_IndividualAccounts_TEST {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
                 Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household', Automatic_Household_Naming__c = true));
 
-        Contact con = UTIL_UnitTestData_API.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         Account assertAccount = [SELECT Id, RecordType.Name, Name FROM Account limit 1];
         system.assertEquals('Household Account', assertAccount.RecordType.Name);
         system.assertEquals(con.FirstName + ' ' + con.LastName + ' Household', assertAccount.Name);
 
-        Contact con2 = UTIL_UnitTestData_API.getContact();
+        Contact con2 = contacts[1];
         con2.AccountId = assertAccount.Id;
         con2.FirstName = 'Test2';
         con2.LastName = con.LastName + '2';
@@ -589,14 +597,15 @@ private class ACCT_IndividualAccounts_TEST {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
                 Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household', Automatic_Household_Naming__c = false));
 
-        Contact con = UTIL_UnitTestData_API.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         Account assertAccount = [SELECT Id, RecordType.Name, Name FROM Account limit 1];
         system.assertEquals('Household Account', assertAccount.RecordType.Name);
         system.assertEquals(con.FirstName + ' ' + con.LastName + ' Household', assertAccount.Name);
 
-        Contact con2 = UTIL_UnitTestData_API.getContact();
+        Contact con2 = contacts[1];
         con2.AccountId = assertAccount.Id;
         con2.FirstName = 'Test2';
         con2.LastName = con.LastName + '2';
@@ -629,14 +638,15 @@ private class ACCT_IndividualAccounts_TEST {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
                 Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household', Automatic_Household_Naming__c = true));
 
-        Contact con = UTIL_UnitTestData_API.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         Account assertAccount = [SELECT Id, RecordType.Name, Name FROM Account limit 1];
         system.assertEquals('Household Account', assertAccount.RecordType.Name);
         system.assertEquals(con.FirstName + ' ' + con.LastName + ' Household', assertAccount.Name);
 
-        Contact con2 = UTIL_UnitTestData_API.getContact();
+        Contact con2 = contacts[1];
         con2.AccountId = assertAccount.Id;
         con2.FirstName = 'Test2';
         con2.LastName = con.LastName + '2';
@@ -667,14 +677,15 @@ private class ACCT_IndividualAccounts_TEST {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
                 Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household', Automatic_Household_Naming__c = true));
 
-        Contact con = UTIL_UnitTestData_API.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         Account assertAccount = [SELECT Id, RecordType.Name, Name FROM Account limit 1];
         system.assertEquals('Household Account', assertAccount.RecordType.Name);
         system.assertEquals(con.FirstName + ' ' + con.LastName + ' Household', assertAccount.Name);
 
-        Contact con2 = UTIL_UnitTestData_API.getContact();
+        Contact con2 = contacts[1];
         con2.AccountId = assertAccount.Id;
         con2.FirstName = 'Test2';
         con2.LastName = con.LastName + '2';
@@ -707,14 +718,15 @@ private class ACCT_IndividualAccounts_TEST {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
                 Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household', Automatic_Household_Naming__c = true));
 
-        Contact con = UTIL_UnitTestData_API.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         Account assertAccount = [SELECT Id, RecordType.Name, Name FROM Account limit 1];
         system.assertEquals('Household Account', assertAccount.RecordType.Name);
         system.assertEquals(con.FirstName + ' ' + con.LastName + ' Household', assertAccount.Name);
 
-        Contact con2 = UTIL_UnitTestData_API.getContact();
+        Contact con2 = contacts[1];
         con2.AccountId = assertAccount.Id;
         con2.FirstName = 'Test2';
         con2.LastName = con.LastName + '2';
@@ -765,12 +777,13 @@ private class ACCT_IndividualAccounts_TEST {
     public static void hhAccountNewChildContactNotResetPrimaryContact() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe.getHhAccRecTypeID()));
 
-        Contact con = UTIL_UnitTestData_TEST.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         Account acc = [SELECT Id FROM Account LIMIT 1];
 
-        Contact con2 = UTIL_UnitTestData_TEST.getContact();
+        Contact con2 = contacts[1];
         insert con2;
 
         Test.startTest();
@@ -793,12 +806,13 @@ private class ACCT_IndividualAccounts_TEST {
     public static void hhAccountSwitchChildContactResetPrimaryContact() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe.getHhAccRecTypeID()));
 
-        Contact con = UTIL_UnitTestData_TEST.getContact();
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        Contact con = contacts[0];
         insert con;
 
         Account acc = [SELECT Id FROM Account LIMIT 1];
 
-        Contact con2 = UTIL_UnitTestData_TEST.getContact();
+        Contact con2 = contacts[1];
         insert con2;
 
         Account acc2 = [SELECT Id FROM Account where Id != :acc.Id LIMIT 1];

--- a/src/classes/CON_Email.cls
+++ b/src/classes/CON_Email.cls
@@ -192,15 +192,17 @@ public class CON_Email {
                 }
             }
 
-            for(String fieldName : contactEmailFieldMap.keySet() ) {
+            for(String fieldName : contactEmailFieldMap.keySet()) {
+                String fieldLabel = contactEmailFieldMap.get(fieldName).getLabel();
+                
                 //If the field is not a standard email field and it is not duplicate with HEDA email, then add it to the list
-                if ( fieldName != emailLabel && !(hedaEmailField.get(contactEmailFieldMap.get(fieldName).getLabel()) != null &&
-                                fieldName != hedaEmailField.get(contactEmailFieldMap.get(fieldName).getLabel()))) {
+                if (fieldName != emailLabel && 
+                        !(hedaEmailField.get(fieldLabel) != null && fieldName != hedaEmailField.get(fieldLabel))) {
                     String emailField = (String)contact.get(fieldName);
 
-                    allFields.add( new CON_EmailField( emailField, contactEmailFieldMap.get(fieldName).getLabel(), fieldName ) );
+                    allFields.add(new CON_EmailField(emailField, fieldLabel, fieldName));
                     if(String.isNotBlank(emailField)) {
-                        valuedFields.add( new CON_EmailField( emailField, contactEmailFieldMap.get(fieldName).getLabel(), fieldName ) );
+                        valuedFields.add(new CON_EmailField(emailField, fieldLabel, fieldName));
                     }
                 }
             }

--- a/src/classes/CON_Email.cls
+++ b/src/classes/CON_Email.cls
@@ -162,6 +162,8 @@ public class CON_Email {
         }
     }
 
+    private static Map<String, Schema.DescribeFieldResult> contactEmailFieldMap;
+
     /*******************************************************************************************************
     * @description An inner wrapper class to contain a list of email fields and perform functions on them
     * @param Contact the contact to build list from.
@@ -176,26 +178,29 @@ public class CON_Email {
 
             this.allFields = new List<CON_EmailField>();
             this.valuedFields = new List<CON_EmailField>();
-            Map<String, Schema.DescribeFieldResult> fieldMap = UTIL_Describe.getFieldsOfType('Contact', 'EMAIL');
-            this.emailLabel = fieldMap.get('Email').getLabel();
+
+            if (contactEmailFieldMap == null) {
+                contactEmailFieldMap = UTIL_Describe.getFieldsOfType('Contact', 'EMAIL');
+            }
+            this.emailLabel = contactEmailFieldMap.get('Email').getLabel();
 
             Map<String, String> hedaEmailField = new Map<String, String>();
             //build map for HEDA email field map (Label, API Name)
-            for(String fieldName : fieldMap.keySet() ) {
+            for(String fieldName : contactEmailFieldMap.keySet() ) {
                 if(String.isNotBlank(UTIL_Namespace.getNamespace()) && fieldName.startsWithIgnoreCase(UTIL_Namespace.getNamespace())) {
-                    hedaEmailField.put(fieldMap.get(fieldName).getLabel(), fieldName);
+                    hedaEmailField.put(contactEmailFieldMap.get(fieldName).getLabel(), fieldName);
                 }
             }
 
-            for(String fieldName : fieldMap.keySet() ) {
+            for(String fieldName : contactEmailFieldMap.keySet() ) {
                 //If the field is not a standard email field and it is not duplicate with HEDA email, then add it to the list
-                if ( fieldName != emailLabel && !(hedaEmailField.get(fieldMap.get(fieldName).getLabel()) != null &&
-                                fieldName != hedaEmailField.get(fieldMap.get(fieldName).getLabel()))) {
+                if ( fieldName != emailLabel && !(hedaEmailField.get(contactEmailFieldMap.get(fieldName).getLabel()) != null &&
+                                fieldName != hedaEmailField.get(contactEmailFieldMap.get(fieldName).getLabel()))) {
                     String emailField = (String)contact.get(fieldName);
 
-                    allFields.add( new CON_EmailField( emailField, fieldMap.get(fieldName).getLabel(), fieldName ) );
+                    allFields.add( new CON_EmailField( emailField, contactEmailFieldMap.get(fieldName).getLabel(), fieldName ) );
                     if(String.isNotBlank(emailField)) {
-                        valuedFields.add( new CON_EmailField( emailField, fieldMap.get(fieldName).getLabel(), fieldName ) );
+                        valuedFields.add( new CON_EmailField( emailField, contactEmailFieldMap.get(fieldName).getLabel(), fieldName ) );
                     }
                 }
             }

--- a/src/classes/CON_Email_TEST.cls
+++ b/src/classes/CON_Email_TEST.cls
@@ -159,9 +159,7 @@ private class CON_Email_TEST {
         	contacts[0].WorkEmail__c = null;
         }
 
-        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, false);
-
-		Test.startTest();
+        Test.startTest();
         update contacts;
 		Test.stopTest();
 

--- a/src/classes/CON_Preferred_TDTM.cls
+++ b/src/classes/CON_Preferred_TDTM.cls
@@ -43,8 +43,10 @@ public class CON_Preferred_TDTM extends TDTM_Runnable {
     public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
         TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
              
-        if( !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM) && (triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) && newlist != null) {
+        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM) 
+            && (triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) && newlist != null) {
 
+            // While this logic is not performing any DML currently, the recursion flag is utilized here to be ready for any future logic changes.
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, true);
 
             for(SObject so : newlist) {
@@ -66,6 +68,8 @@ public class CON_Preferred_TDTM extends TDTM_Runnable {
                     }
                 }
             }
+
+            TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, false);
         }
          
         return null;

--- a/src/classes/CON_Preferred_TEST.cls
+++ b/src/classes/CON_Preferred_TEST.cls
@@ -98,8 +98,7 @@ public with sharing class CON_Preferred_TEST {
 		contact3.PreferredPhone__c = 'Other';
 		contact4.PreferredPhone__c = 'Mobile';
 
-        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, false);
-		Test.startTest();
+        Test.startTest();
 		update contacts;
 		Test.stopTest();
 				

--- a/src/classes/TDTM_DMLgt200_TEST.cls
+++ b/src/classes/TDTM_DMLgt200_TEST.cls
@@ -69,19 +69,10 @@ private class TDTM_DMLgt200_TEST {
         UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID()));
 
         String newContactMailingStreet = '123 Elm St';
-
-		List<Contact> testContacts = new List<Contact>();
-
+		List<Contact> testContacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(inputSize);
 		for (Integer i = 0; i < inputSize; i++) {
-        	Contact con = new Contact(
-            FirstName='Test',
-            LastName='Contact_forTests',
-            MailingStreet = newContactMailingStreet,
-            WorkEmail__c = 'junk@test.net',
-            Preferred_Email__c = 'Work',
-            WorkPhone__c = '206-777-8888',
-            PreferredPhone__c = 'Work');
-            testContacts.add(con);
+            testContacts[i].OtherCity = null;
+            testContacts[i].MailingStreet = newContactMailingStreet;
         }
         insert testContacts;
 
@@ -123,18 +114,7 @@ private class TDTM_DMLgt200_TEST {
                     Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID(),
                     Accounts_to_Delete__c = UTIL_Describe_API.getAdminAccRecTypeID()));
 
-		 List<Contact> testContacts = new List<Contact>();
-         for (Integer i = 0; i < inputSize; i++) {
-	        Contact con = new Contact(
-	            FirstName='Test',
-	            LastName='Contact_forTests',
-	            MailingStreet = '123 Elm St',
-	            WorkEmail__c = 'junk@test.net',
-	            Preferred_Email__c = 'Work',
-	            WorkPhone__c = '206-777-8888',
-	            PreferredPhone__c = 'Work');
-	        testContacts.add(con);
-	     }
+		 List<Contact> testContacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(inputSize);
          insert testContacts;
 
          List<Account> insertedAccounts = [Select Id from Account];

--- a/src/classes/TDTM_DMLgt200_TEST.cls
+++ b/src/classes/TDTM_DMLgt200_TEST.cls
@@ -85,23 +85,25 @@ private class TDTM_DMLgt200_TEST {
         }
         insert testContacts;
 
-        List<Contact> insertedContacts = [Select FirstName, LastName, AccountId, Account.Name,Account.Primary_Contact__c,MailingStreet,
-        									   Account.BillingStreet 
-        							    	from Contact];
+        List<Contact> insertedContacts = [SELECT FirstName, LastName, AccountId, Account.Name, Account.Primary_Contact__c, WorkEmail__c, WorkPhone__c, Email, Phone
+        							    	FROM Contact];
 
-        //one contact should have been created
+        //many contacts should have been created
         system.assertEquals(inputSize, insertedContacts.size());
 
         //relationship should be bi-directional
         for (Contact con : insertedContacts) {
-	        system.assertEquals(con.id, con.Account.Primary_Contact__c);   
+	        system.assertEquals(con.id, con.Account.Primary_Contact__c);
+            system.assertEquals(con.WorkEmail__c, con.Email);
+            system.assertEquals(con.WorkPhone__c, con.Phone);
+
             con.LastName = 'Contact_forTestsChange';
         	con.OtherCity = 'Seattle';  
         }
         update insertedContacts;
 
-        List<Contact> updatedContacts = [Select FirstName, LastName, AccountId, Account.Name,Account.Primary_Contact__c
-                                         from Contact];
+        List<Contact> updatedContacts = [SELECT FirstName, LastName, AccountId, Account.Name, Account.Primary_Contact__c
+                                           FROM Contact];
 
         //relationship should be bi-directional
         for (Contact con : updatedContacts) {


### PR DESCRIPTION
# Critical Changes

# Changes
- When inserting or updating more than 200 Contact records at a time, _all_ records now have their standard Email and Phone fields populated based on their Preferred Email and Preferred Phone values. Previously, only the first 200 records were populated.

# Issues Closed
- Fixes #639

# New Metadata

# Deleted Metadata

# Testing Notes
