### PR TITLE
Do not auto delete Affiliation records if there are other Program Enrollment records tied to them.

### DIFF
--- a/src/classes/PREN_Affiliation_TDTM.cls
+++ b/src/classes/PREN_Affiliation_TDTM.cls
@@ -54,7 +54,7 @@ public class PREN_Affiliation_TDTM extends TDTM_Runnable {
         }
         
         if(oldlist != null && oldlist.size() > 0) {
-            updateDeleteRelatedAffls(getDeletedPEsAfflIDs(oldlist, triggerAction), dmlWrapper);
+            updateDeleteRelatedAffls(getDeletedPEsAfflIDs(oldlist, triggerAction), oldlist, dmlWrapper);
         }
         return dmlWrapper;
     }
@@ -93,10 +93,10 @@ public class PREN_Affiliation_TDTM extends TDTM_Runnable {
     
     private List<ID> getDeletedPEsAfflIDs(List<SObject> oldlist, TDTM_Runnable.Action triggerAction) {
         List<ID> afflsToUpdateDelIDs = new List<ID>();
-        for (SObject so : oldlist) {
-            Program_Enrollment__c oldEnrollment = (Program_Enrollment__c)so;
-            
-            if(triggerAction == TDTM_Runnable.Action.AfterDelete) {   
+        //Only need to loop through the list when deleting Program Enrollment records
+        if(triggerAction == TDTM_Runnable.Action.AfterDelete) {  
+            for (SObject so : oldlist) {            
+                Program_Enrollment__c oldEnrollment = (Program_Enrollment__c)so;
                 if(oldEnrollment.Affiliation__c != null) {
                     //Get related Affls ids
                     afflsToUpdateDelIDs.add(oldEnrollment.Affiliation__c);
@@ -106,16 +106,25 @@ public class PREN_Affiliation_TDTM extends TDTM_Runnable {
         return afflsToUpdateDelIDs;
     }
     
-    private void updateDeleteRelatedAffls(List<ID> afflsToUpdateDelIDs, DmlWrapper dmlWrapper) {
+    private void updateDeleteRelatedAffls(List<ID> afflsToUpdateDelIDs, List<SObject> oldlist, DmlWrapper dmlWrapper) {
         //Delete or update related affiliations when Program Enrollment records are deleted.
         List<Affiliation__c> afflsToUpdateDel = new List<Affiliation__c>();
         if(UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Del__c) {
-            for(ID id : afflsToUpdateDelIDs) {
-                afflsToUpdateDel.add(new Affiliation__c(ID = id));
+            List<Program_Enrollment__c> otherProgramEnrollments = [SELECT Id, Affiliation__c FROM Program_Enrollment__c WHERE Affiliation__c IN :afflsToUpdateDelIDs AND Id NOT IN :oldList];
+            Set<Id> affiliationIdsToIgnore = new Set<Id>();
+            for(Program_Enrollment__c otherProgramEnrollment : otherProgramEnrollments) {
+                affiliationIdsToIgnore.add(otherProgramEnrollment.Affiliation__c);
+            }
+
+            for(ID affiliationId : afflsToUpdateDelIDs) {
+                //Only delete the Affiliation if there are no other Program Enrollment records associated to it.
+                if (!affiliationIdsToIgnore.contains(affiliationId)) {
+                    afflsToUpdateDel.add(new Affiliation__c(ID = affiliationId));
+                }
             }
             dmlWrapper.objectsToDelete.addAll((List<SObject>)afflsToUpdateDel);
         } else {
-            afflsToUpdateDel = [select Status__c from Affiliation__c where ID in :afflsToUpdateDelIDs];
+            afflsToUpdateDel = [SELECT Status__c FROM Affiliation__c WHERE ID IN :afflsToUpdateDelIDs];
             for(Affiliation__c affl : afflsToUpdateDel) {
                 affl.Status__c = UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Del_Status__c;
             }

--- a/src/classes/PREN_Affiliation_TEST.cls
+++ b/src/classes/PREN_Affiliation_TEST.cls
@@ -50,7 +50,7 @@ public with sharing class PREN_Affiliation_TEST {
         
         ID orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
         
-        //Craete account of Business Organization record type
+        //Create account of Business Organization record type
         Account acc = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
         insert acc;
         
@@ -82,7 +82,7 @@ public with sharing class PREN_Affiliation_TEST {
         
         ID orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
         
-        //Craete account of Business Organization record type
+        //Create account of Business Organization record type
         Account acc = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
         insert acc;
         
@@ -114,7 +114,7 @@ public with sharing class PREN_Affiliation_TEST {
         
         ID orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
         
-        //Craete account of Business Organization record type
+        //Create account of Business Organization record type
         Account acc = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
         insert acc;
         
@@ -146,7 +146,7 @@ public with sharing class PREN_Affiliation_TEST {
         
         ID orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
         
-        //Craete account of Business Organization record type
+        //Create account of Business Organization record type
         Account acc = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
         insert acc;
         
@@ -178,7 +178,7 @@ public with sharing class PREN_Affiliation_TEST {
         
         ID orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
         
-        //Craete account of Business Organization record type
+        //Create account of Business Organization record type
         Account acc = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
         insert acc;
         
@@ -210,7 +210,7 @@ public with sharing class PREN_Affiliation_TEST {
         
         ID orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
         
-        //Craete account of Business Organization record type
+        //Create account of Business Organization record type
         Account acc = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
         insert acc;
         
@@ -239,7 +239,7 @@ public with sharing class PREN_Affiliation_TEST {
         
         ID orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
         
-        //Craete account of Business Organization record type
+        //Create account of Business Organization record type
         Account acc = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
         insert acc;
         
@@ -268,7 +268,7 @@ public with sharing class PREN_Affiliation_TEST {
         
         ID orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
         
-        //Craete account of Business Organization record type
+        //Create account of Business Organization record type
         Account acc = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
         insert acc;
         
@@ -297,7 +297,7 @@ public with sharing class PREN_Affiliation_TEST {
         Contact contact = UTIL_UnitTestData_TEST.getContact();
         insert contact;
 
-        //Craete account of Business Organization record type
+        //Create account of Business Organization record type
         Account acc = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe_API.getBizAccRecTypeID())[0];
         insert acc;
         
@@ -313,15 +313,63 @@ public with sharing class PREN_Affiliation_TEST {
         enrollment = [SELECT Affiliation__r.ID FROM Program_Enrollment__c WHERE ID = :enrollment.ID];
         System.assertEquals(affls[0].ID, enrollment.Affiliation__r.ID);
         ID enrollmentAfflID = enrollment.Affiliation__r.ID; //Storing it to use it in next query
+
+        //Create additional Program Enrollment
+        Program_Enrollment__c enrollment2 = new Program_Enrollment__c(Contact__c = contact.ID, Account__c = acc.ID, Affiliation__c = enrollmentAfflID);
+        insert enrollment2;
+        
+        //Delete both Program Enrollments
+        Test.startTest();
+        delete new List<Program_Enrollment__c>{ enrollment, enrollment2 };
+        Test.stopTest();
+        
+        //Related Affiliation should have been automatically deleted
+        affls = [SELECT ID FROM Affiliation__c WHERE ID = :enrollmentAfflID];
+        System.assertEquals(0, affls.size());
+    }
+
+    /*********************************************************************************************************
+    * @description Deleting a Program Enrollment does not delete the related Affiliation when Affl_ProgEnroll_Del__c setting
+    * is set to true but other Program Enrollments are associated to the same Affiliation.
+    */
+    @isTest
+    public static void deletePEnrollDelAfflYes_existingPEPreventsAffiliationDeletion() {
+        STG_InstallScript.insertMappings();
+
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Affl_ProgEnroll_Del__c = true));
+        
+        Contact contact = UTIL_UnitTestData_TEST.getContact();
+        insert contact;
+
+        //Create account of Business Organization record type
+        Account acc = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe_API.getBizAccRecTypeID())[0];
+        insert acc;
+        
+        //Create Program Enrollment
+        Program_Enrollment__c enrollment = new Program_Enrollment__c(Contact__c = contact.ID, Account__c = acc.ID);
+        insert enrollment;
+        
+        //An Affiliation should have been automatically created fron the Program Enrollment
+        List<Affiliation__c> affls = [SELECT Contact__c, Account__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
+        System.assertEquals(1, affls.size());
+        
+        //The Program Enrollment record should be related to the Affiliation just created
+        enrollment = [SELECT Affiliation__r.ID FROM Program_Enrollment__c WHERE ID = :enrollment.ID];
+        System.assertEquals(affls[0].ID, enrollment.Affiliation__r.ID);
+        ID enrollmentAfflID = enrollment.Affiliation__r.ID; //Storing it to use it in next query
+
+        //Create additional Program Enrollment
+        Program_Enrollment__c enrollment2 = new Program_Enrollment__c(Contact__c = contact.ID, Account__c = acc.ID, Affiliation__c = enrollmentAfflID);
+        insert enrollment2;
         
         //Delete Program Enrollment
         Test.startTest();
         delete enrollment;
         Test.stopTest();
         
-        //Related Affiliation should have been automatically deleted
+        //Related Affiliation should have NOT been automatically deleted
         affls = [SELECT ID FROM Affiliation__c WHERE ID = :enrollmentAfflID];
-        System.assertEquals(0, affls.size());
+        System.assertEquals(1, affls.size());
     }
     
     /*********************************************************************************************************
@@ -339,7 +387,7 @@ public with sharing class PREN_Affiliation_TEST {
         Contact contact = UTIL_UnitTestData_TEST.getContact();
         insert contact;
 
-        //Craete account of Business Organization record type
+        //Create account of Business Organization record type
         Account acc = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe_API.getBizAccRecTypeID())[0];
         insert acc;
         


### PR DESCRIPTION
# Critical Changes

# Changes
- When "Delete Related Affiliation When Deleting Program Enrollment" is enabled in HEDA Settings | Affiliations | Settings, the related Affiliation is now deleted only if it has no other existing Program Enrollment records related to it.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes

1. Ensure that the "Delete Related Affiliation When Deleting Program Enrollment" setting is true.
2. Create a Program Enrollment for a Contact.
3. Go to the Program Enrollment Affiliation record that was automatically created.
4. On the Program Enrollment related list, create another Program Enrollment for the Affiliation.
5. Delete the Program Enrollment record. The Program Enrollment record will be deleted, but the Affiliation record (& the other Program Enrollment record) will still exist.