### PR TITLE
Avoid duplicate program enrollment when custom settings match Auto Enrollment settings

### DIFF
--- a/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp
+++ b/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp
@@ -128,7 +128,6 @@
                     <ui:outputText value="{!$Label.c.stgHelpAfflCreateFromProgramEnrollmentInfo}" class="slds-text-body--small" />
                 </div>
 
-                <aura:if isTrue="0 > 1"><!-- comment for bugfixes -->
                 <div class="slds-col slds-grid slds-size--1-of-1 slds-m-top--medium">
                     <div class="slds-col slds-size--1-of-2">
                         <ui:outputText value="{!$Label.c.stgAfflProgEnrollSetRole}"/>
@@ -171,8 +170,6 @@
                 <div class="slds-col slds-size--1-of-2">
                     <ui:outputText value="{!$Label.c.stgHelpAfflProgEnrollSetRoleValue}" class="slds-text-body--small" />
                 </div>
-                </aura:if><!-- end comment for bugfixes -->
-
 
                 <div class="slds-col slds-grid slds-size--1-of-1 slds-m-top--medium">
                     <div class="slds-col slds-size--1-of-2">

--- a/src/classes/PREN_Affiliation_TDTM.cls
+++ b/src/classes/PREN_Affiliation_TDTM.cls
@@ -58,29 +58,34 @@ public class PREN_Affiliation_TDTM extends TDTM_Runnable {
         }
         return dmlWrapper;
     }
-    
-    private void createRelatedAffls(List<SObject> newlist, TDTM_Runnable.Action triggerAction) {
 
+    private void createRelatedAffls(List<SObject> newlist, TDTM_Runnable.Action triggerAction) {
         List<Affiliation__c> newAffls = new List<Affiliation__c>();
 
         for (SObject so : newlist) {
             Program_Enrollment__c enrollment = (Program_Enrollment__c)so;
-            
-            if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
 
+            if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
                 //Automatically create an Affiliation record if a Program Enrollment record has been created without an affiliation.
                 if(enrollment.Contact__c != null && enrollment.Account__c != null && enrollment.Affiliation__c == null) {
                     Date afflEndDate = (UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Copy_End_Date__c == true ? enrollment.End_Date__c : null);
                     Date afflStartDate = (UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Copy_Start_Date__c == true ? enrollment.Start_Date__c : null);
                     String afflRole = (UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Set_Role__c == true ? UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Role_Map__c : null);
 
-                    Affiliation__c affl = new Affiliation__c(Contact__c = enrollment.Contact__c, Account__c = enrollment.Account__c, EndDate__c = afflEndDate, StartDate__c = afflStartDate, Role__c = afflRole, Status__c = UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Status_Map__c);
+                    Affiliation__c affl = new Affiliation__c(Contact__c = enrollment.Contact__c,
+                                                            Account__c = enrollment.Account__c,
+                                                            EndDate__c = afflEndDate,
+                                                            StartDate__c = afflStartDate,
+                                                            Status__c = UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Status_Map__c,
+                                                            Role__c = afflRole);
                     newAffls.add(affl);
                 }
             }
         }
         
         if(newAffls.size() > 0) {
+            //Turn off AFFL_MultiRecordType_TDTM_After_Insert so HEDA won't create duplicate program enrollment
+            TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Insert);
             //We manually insert the affiliations because we need the IDs, in order to link the Program Enrollments with the Affls.
             insert newAffls;
             for(Integer i = 0; i < newAffls.size(); i++) {

--- a/src/classes/PREN_Affiliation_TEST.cls
+++ b/src/classes/PREN_Affiliation_TEST.cls
@@ -67,6 +67,10 @@ public with sharing class PREN_Affiliation_TEST {
         //The Program Enrollment record should be related to the Affiliation just created
         enrollment = [SELECT Affiliation__r.ID FROM Program_Enrollment__c WHERE ID = :enrollment.ID];
         System.assertEquals(affls[0].ID, enrollment.Affiliation__r.ID);
+
+        //Only should one program enrollment exist
+        List<Program_Enrollment__c> assertProgramEnrollments = [SELECT Id FROM Program_Enrollment__c];
+        System.assertEquals(1, assertProgramEnrollments.size());
     }
     
     /*********************************************************************************************************
@@ -99,6 +103,10 @@ public with sharing class PREN_Affiliation_TEST {
         List<Affiliation__c> affls = [SELECT EndDate__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertEquals(testDate, affls[0].EndDate__c);
+
+        //Only should one program enrollment exist
+        List<Program_Enrollment__c> assertProgramEnrollments = [SELECT Id FROM Program_Enrollment__c];
+        System.assertEquals(1, assertProgramEnrollments.size());
     }
     
     /*********************************************************************************************************
@@ -131,6 +139,10 @@ public with sharing class PREN_Affiliation_TEST {
         List<Affiliation__c> affls = [SELECT EndDate__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertEquals(null, affls[0].EndDate__c);
+
+        //Only should one program enrollment exist
+        List<Program_Enrollment__c> assertProgramEnrollments = [SELECT Id FROM Program_Enrollment__c];
+        System.assertEquals(1, assertProgramEnrollments.size());
     }
     
     /*********************************************************************************************************
@@ -163,6 +175,10 @@ public with sharing class PREN_Affiliation_TEST {
         List<Affiliation__c> affls = [SELECT StartDate__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertEquals(testDate, affls[0].StartDate__c);
+
+        //Only should one program enrollment exist
+        List<Program_Enrollment__c> assertProgramEnrollments = [SELECT Id FROM Program_Enrollment__c];
+        System.assertEquals(1, assertProgramEnrollments.size());
     }
     
     /*********************************************************************************************************
@@ -195,6 +211,10 @@ public with sharing class PREN_Affiliation_TEST {
         List<Affiliation__c> affls = [SELECT StartDate__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertNotEquals(testDate, affls[0].StartDate__c);
+
+        //Only should one program enrollment exist
+        List<Program_Enrollment__c> assertProgramEnrollments = [SELECT Id FROM Program_Enrollment__c];
+        System.assertEquals(1, assertProgramEnrollments.size());
     }
     
     /*********************************************************************************************************
@@ -224,6 +244,10 @@ public with sharing class PREN_Affiliation_TEST {
         List<Affiliation__c> affls = [SELECT Role__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertEquals('Student', affls[0].Role__c);
+
+        //Only should one program enrollment exist
+        List<Program_Enrollment__c> assertProgramEnrollments = [SELECT Id FROM Program_Enrollment__c];
+        System.assertEquals(1, assertProgramEnrollments.size());
     }
     
     /*********************************************************************************************************
@@ -253,6 +277,10 @@ public with sharing class PREN_Affiliation_TEST {
         List<Affiliation__c> affls = [SELECT Role__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertEquals(null, affls[0].Role__c);
+
+        //Only should one program enrollment exist
+        List<Program_Enrollment__c> assertProgramEnrollments = [SELECT Id FROM Program_Enrollment__c];
+        System.assertEquals(1, assertProgramEnrollments.size());
     }
     
     /*********************************************************************************************************
@@ -282,8 +310,47 @@ public with sharing class PREN_Affiliation_TEST {
         List<Affiliation__c> affls = [SELECT Status__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertEquals('Former', affls[0].Status__c);
+
+        //Only should one program enrollment exist
+        List<Program_Enrollment__c> assertProgramEnrollments = [SELECT Id FROM Program_Enrollment__c];
+        System.assertEquals(1, assertProgramEnrollments.size());
     }
-    
+
+    /*********************************************************************************************************
+    * @description Creating a Program Enrollment sets the related Affiliation Role when
+    * Affl_ProgEnroll_Set_Role__c setting is set to true and sets the related Affiliation Status
+    * to Affiliation_Program_Enrollment_Stat_Map
+    */
+    @isTest
+    public static void setAfflFromProgramEnrollmentRoleYesStatus() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Affl_ProgEnroll_Set_Role__c = true,
+                                                                                Affl_ProgEnroll_Role_Map__c='Student',
+                                                                                Affl_ProgEnroll_Status_Map__c='Current'));
+
+        STG_InstallScript.insertMappings();
+
+        Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
+        insert contact;
+
+        //Craete account of Business Organization record type
+        Account acc = new Account(Name='Acme', RecordTypeId = UTIL_Describe_API.getAcademicAccRecTypeID());
+        insert acc;
+
+        //Create Program Enrollment
+        Program_Enrollment__c enrollment = new Program_Enrollment__c(Contact__c = contact.ID, Account__c = acc.ID);
+        Test.startTest();
+        insert enrollment;
+        Test.stopTest();
+
+        //An Affiliation should have been automatically created fron the Program Enrollment
+        List<Affiliation__c> affls = [SELECT Role__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
+        System.assertEquals(1, affls.size());
+        System.assertEquals('Student', affls[0].Role__c);
+
+        //Only should one program enrollment exist
+        List<Program_Enrollment__c> assertProgramEnrollments = [SELECT Id FROM Program_Enrollment__c];
+        System.assertEquals(1, assertProgramEnrollments.size());
+    }
     /*********************************************************************************************************
     * @description Deleting a Program Enrollment deletes the related Affiliation when Affl_ProgEnroll_Del__c setting
     * is set to true.

--- a/src/classes/UTIL_Describe_API.cls
+++ b/src/classes/UTIL_Describe_API.cls
@@ -245,6 +245,14 @@ global class UTIL_Describe_API {
 	}
 
     /*******************************************************************************************************
+     * @description Returns the ID of the Academic Program record type, if it exists.
+     * @return String The ID of the Academic Program Account record type as a String.
+     */
+    global static String getAcademicAccRecTypeID() {
+        return UTIL_Describe.getAcademicAccRecTypeID();
+    }
+
+    /*******************************************************************************************************
      * @description Returns the ID of the Default Course Connection record type, if it exists. This record
      * type should only be used in testing.
      * @return String The ID of the Default Course Connection record type as a String.


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
[W-030891](https://foundation.lightning.force.com/lightning/r/agf__ADM_Work__c/a2x1E000007fQxxQAE/view)

# New Metadata

# Deleted Metadata

# Testing Notes
1. Go to HEDA setting page -> Affiliations -> Affiliation Mappings
2. Set the Academic Program/Primary Academic program Auto Enrollment checkbox to true
3. Set the Status to Current
4. Set the Role to Student
5. Go to Affiliations->Settings tab
6. Set the Status to Current
7. Set the Role to Student
8. Create a contact
9. Create a program enrollment of that contact
10. Make sure that only one program enrollment is created
