### PR TITLE
Remove translation workbench from feature orgs

### DIFF
--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -4,7 +4,6 @@
   "orgPreferences" : {
     "enabled": [
       "S1DesktopEnabled",
-      "Translation",
       "ChatterEnabled"
     ]
   }


### PR DESCRIPTION
Because feature tests are intended to approximate client environments
there should not be a dependency on Translation Workbench.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
