### PR TITLE
Do not update the Affiliation status to Former when there other Program Enrollment records attached

### DIFF
--- a/src/classes/PREN_Affiliation_TDTM.cls
+++ b/src/classes/PREN_Affiliation_TDTM.cls
@@ -124,11 +124,12 @@ public class PREN_Affiliation_TDTM extends TDTM_Runnable {
             }
             dmlWrapper.objectsToDelete.addAll((List<SObject>)afflsToUpdateDel);
         } else {
+            String affiliationStatusOnPEDelete = UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Del_Status__c;
             List<Affiliation__c> potentialAffiliationsToUpdate = [SELECT Id, Status__c FROM Affiliation__c WHERE ID IN :afflsToUpdateDelIDs];
             for(Affiliation__c affl : potentialAffiliationsToUpdate) {
                 //Only update the Affiliation if there are no other Program Enrollment records associated to it.
                 if (!affiliationIdsToIgnore.contains(affl.Id)) {
-                    affl.Status__c = UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Del_Status__c;
+                    affl.Status__c = affiliationStatusOnPEDelete;
                     afflsToUpdateDel.add(affl);
                 }
             }

--- a/src/classes/PREN_Affiliation_TDTM.cls
+++ b/src/classes/PREN_Affiliation_TDTM.cls
@@ -109,13 +109,13 @@ public class PREN_Affiliation_TDTM extends TDTM_Runnable {
     private void updateDeleteRelatedAffls(List<ID> afflsToUpdateDelIDs, List<SObject> oldlist, DmlWrapper dmlWrapper) {
         //Delete or update related affiliations when Program Enrollment records are deleted.
         List<Affiliation__c> afflsToUpdateDel = new List<Affiliation__c>();
+        
+        List<Program_Enrollment__c> otherProgramEnrollments = [SELECT Id, Affiliation__c FROM Program_Enrollment__c WHERE Affiliation__c IN :afflsToUpdateDelIDs AND Id NOT IN :oldList];
+        Set<Id> affiliationIdsToIgnore = new Set<Id>();
+        for(Program_Enrollment__c otherProgramEnrollment : otherProgramEnrollments) {
+            affiliationIdsToIgnore.add(otherProgramEnrollment.Affiliation__c);
+        }
         if(UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Del__c) {
-            List<Program_Enrollment__c> otherProgramEnrollments = [SELECT Id, Affiliation__c FROM Program_Enrollment__c WHERE Affiliation__c IN :afflsToUpdateDelIDs AND Id NOT IN :oldList];
-            Set<Id> affiliationIdsToIgnore = new Set<Id>();
-            for(Program_Enrollment__c otherProgramEnrollment : otherProgramEnrollments) {
-                affiliationIdsToIgnore.add(otherProgramEnrollment.Affiliation__c);
-            }
-
             for(ID affiliationId : afflsToUpdateDelIDs) {
                 //Only delete the Affiliation if there are no other Program Enrollment records associated to it.
                 if (!affiliationIdsToIgnore.contains(affiliationId)) {
@@ -124,9 +124,13 @@ public class PREN_Affiliation_TDTM extends TDTM_Runnable {
             }
             dmlWrapper.objectsToDelete.addAll((List<SObject>)afflsToUpdateDel);
         } else {
-            afflsToUpdateDel = [SELECT Status__c FROM Affiliation__c WHERE ID IN :afflsToUpdateDelIDs];
-            for(Affiliation__c affl : afflsToUpdateDel) {
-                affl.Status__c = UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Del_Status__c;
+            List<Affiliation__c> potentialAffiliationsToUpdate = [SELECT Id, Status__c FROM Affiliation__c WHERE ID IN :afflsToUpdateDelIDs];
+            for(Affiliation__c affl : potentialAffiliationsToUpdate) {
+                //Only update the Affiliation if there are no other Program Enrollment records associated to it.
+                if (!affiliationIdsToIgnore.contains(affl.Id)) {
+                    affl.Status__c = UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Del_Status__c;
+                    afflsToUpdateDel.add(affl);
+                }
             }
             dmlWrapper.objectsToUpdate.addAll((List<SObject>)afflsToUpdateDel);
         }

--- a/src/classes/PREN_Affiliation_TDTM.cls
+++ b/src/classes/PREN_Affiliation_TDTM.cls
@@ -56,6 +56,7 @@ public class PREN_Affiliation_TDTM extends TDTM_Runnable {
         if(oldlist != null && oldlist.size() > 0) {
             updateDeleteRelatedAffls(getDeletedPEsAfflIDs(oldlist, triggerAction), oldlist, dmlWrapper);
         }
+        
         return dmlWrapper;
     }
 
@@ -88,6 +89,7 @@ public class PREN_Affiliation_TDTM extends TDTM_Runnable {
             TDTM_ProcessControl.turnOffRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Insert);
             //We manually insert the affiliations because we need the IDs, in order to link the Program Enrollments with the Affls.
             insert newAffls;
+            
             for(Integer i = 0; i < newAffls.size(); i++) {
                 Program_Enrollment__c enrollment = (Program_Enrollment__c)newlist[i];
                 enrollment.Affiliation__c = newAffls[i].ID;
@@ -100,13 +102,16 @@ public class PREN_Affiliation_TDTM extends TDTM_Runnable {
         List<ID> afflsToUpdateDelIDs = new List<ID>();
         //Only need to loop through the list when deleting Program Enrollment records
         if(triggerAction == TDTM_Runnable.Action.AfterDelete) {  
+            
             for (SObject so : oldlist) {            
                 Program_Enrollment__c oldEnrollment = (Program_Enrollment__c)so;
+                
                 if(oldEnrollment.Affiliation__c != null) {
                     //Get related Affls ids
                     afflsToUpdateDelIDs.add(oldEnrollment.Affiliation__c);
                 }
             }
+            
         }
         return afflsToUpdateDelIDs;
     }
@@ -117,20 +122,25 @@ public class PREN_Affiliation_TDTM extends TDTM_Runnable {
         
         List<Program_Enrollment__c> otherProgramEnrollments = [SELECT Id, Affiliation__c FROM Program_Enrollment__c WHERE Affiliation__c IN :afflsToUpdateDelIDs AND Id NOT IN :oldList];
         Set<Id> affiliationIdsToIgnore = new Set<Id>();
+        
         for(Program_Enrollment__c otherProgramEnrollment : otherProgramEnrollments) {
             affiliationIdsToIgnore.add(otherProgramEnrollment.Affiliation__c);
         }
+        
         if(UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Del__c) {
+            
             for(ID affiliationId : afflsToUpdateDelIDs) {
                 //Only delete the Affiliation if there are no other Program Enrollment records associated to it.
                 if (!affiliationIdsToIgnore.contains(affiliationId)) {
                     afflsToUpdateDel.add(new Affiliation__c(ID = affiliationId));
                 }
             }
+            
             dmlWrapper.objectsToDelete.addAll((List<SObject>)afflsToUpdateDel);
         } else {
             String affiliationStatusOnPEDelete = UTIL_CustomSettingsFacade.getSettings().Affl_ProgEnroll_Del_Status__c;
             List<Affiliation__c> potentialAffiliationsToUpdate = [SELECT Id, Status__c FROM Affiliation__c WHERE ID IN :afflsToUpdateDelIDs];
+            
             for(Affiliation__c affl : potentialAffiliationsToUpdate) {
                 //Only update the Affiliation if there are no other Program Enrollment records associated to it.
                 if (!affiliationIdsToIgnore.contains(affl.Id)) {
@@ -138,6 +148,7 @@ public class PREN_Affiliation_TDTM extends TDTM_Runnable {
                     afflsToUpdateDel.add(affl);
                 }
             }
+            
             dmlWrapper.objectsToUpdate.addAll((List<SObject>)afflsToUpdateDel);
         }
     }

--- a/src/classes/PREN_Affiliation_TEST.cls
+++ b/src/classes/PREN_Affiliation_TEST.cls
@@ -61,12 +61,12 @@ public with sharing class PREN_Affiliation_TEST {
         Test.stopTest();
         
         //An Affiliation should have been automatically created fron the Program Enrollment
-        List<Affiliation__c> affls = [SELECT Contact__c, Account__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
+        List<Affiliation__c> affls = [SELECT Contact__c, Account__c FROM Affiliation__c WHERE Account__c = :acc.ID];
         System.assertEquals(1, affls.size());
         
         //The Program Enrollment record should be related to the Affiliation just created
-        enrollment = [SELECT Affiliation__r.ID FROM Program_Enrollment__c WHERE ID = :enrollment.ID];
-        System.assertEquals(affls[0].ID, enrollment.Affiliation__r.ID);
+        enrollment = [SELECT Affiliation__c FROM Program_Enrollment__c WHERE ID = :enrollment.ID];
+        System.assertEquals(affls[0].ID, enrollment.Affiliation__c);
     }
     
     /*********************************************************************************************************
@@ -96,7 +96,7 @@ public with sharing class PREN_Affiliation_TEST {
         Test.stopTest();
         
         //An Affiliation should have been automatically created fron the Program Enrollment
-        List<Affiliation__c> affls = [SELECT EndDate__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
+        List<Affiliation__c> affls = [SELECT EndDate__c FROM Affiliation__c WHERE Account__c = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertEquals(testDate, affls[0].EndDate__c);
     }
@@ -128,7 +128,7 @@ public with sharing class PREN_Affiliation_TEST {
         Test.stopTest();
         
         //An Affiliation should have been automatically created fron the Program Enrollment
-        List<Affiliation__c> affls = [SELECT EndDate__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
+        List<Affiliation__c> affls = [SELECT EndDate__c FROM Affiliation__c WHERE Account__c = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertEquals(null, affls[0].EndDate__c);
     }
@@ -160,7 +160,7 @@ public with sharing class PREN_Affiliation_TEST {
         Test.stopTest();
         
         //An Affiliation should have been automatically created fron the Program Enrollment
-        List<Affiliation__c> affls = [SELECT StartDate__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
+        List<Affiliation__c> affls = [SELECT StartDate__c FROM Affiliation__c WHERE Account__c = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertEquals(testDate, affls[0].StartDate__c);
     }
@@ -192,7 +192,7 @@ public with sharing class PREN_Affiliation_TEST {
         Test.stopTest();
         
         //An Affiliation should have been automatically created fron the Program Enrollment
-        List<Affiliation__c> affls = [SELECT StartDate__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
+        List<Affiliation__c> affls = [SELECT StartDate__c FROM Affiliation__c WHERE Account__c = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertNotEquals(testDate, affls[0].StartDate__c);
     }
@@ -221,7 +221,7 @@ public with sharing class PREN_Affiliation_TEST {
         Test.stopTest();
         
         //An Affiliation should have been automatically created fron the Program Enrollment
-        List<Affiliation__c> affls = [SELECT Role__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
+        List<Affiliation__c> affls = [SELECT Role__c FROM Affiliation__c WHERE Account__c = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertEquals('Student', affls[0].Role__c);
     }
@@ -250,7 +250,7 @@ public with sharing class PREN_Affiliation_TEST {
         Test.stopTest();
         
         //An Affiliation should have been automatically created fron the Program Enrollment
-        List<Affiliation__c> affls = [SELECT Role__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
+        List<Affiliation__c> affls = [SELECT Role__c FROM Affiliation__c WHERE Account__c = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertEquals(null, affls[0].Role__c);
     }
@@ -279,7 +279,7 @@ public with sharing class PREN_Affiliation_TEST {
         Test.stopTest();
         
         //An Affiliation should have been automatically created fron the Program Enrollment
-        List<Affiliation__c> affls = [SELECT Status__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
+        List<Affiliation__c> affls = [SELECT Status__c FROM Affiliation__c WHERE Account__c = :acc.ID];
         System.assertEquals(1, affls.size());
         System.assertEquals('Former', affls[0].Status__c);
     }
@@ -306,13 +306,13 @@ public with sharing class PREN_Affiliation_TEST {
         insert enrollment;
         
         //An Affiliation should have been automatically created fron the Program Enrollment
-        List<Affiliation__c> affls = [SELECT Contact__c, Account__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
+        List<Affiliation__c> affls = [SELECT Contact__c, Account__c FROM Affiliation__c WHERE Account__c = :acc.ID];
         System.assertEquals(1, affls.size());
         
         //The Program Enrollment record should be related to the Affiliation just created
-        enrollment = [SELECT Affiliation__r.ID FROM Program_Enrollment__c WHERE ID = :enrollment.ID];
-        System.assertEquals(affls[0].ID, enrollment.Affiliation__r.ID);
-        ID enrollmentAfflID = enrollment.Affiliation__r.ID; //Storing it to use it in next query
+        enrollment = [SELECT Affiliation__c FROM Program_Enrollment__c WHERE ID = :enrollment.ID];
+        System.assertEquals(affls[0].ID, enrollment.Affiliation__c);
+        ID enrollmentAfflID = enrollment.Affiliation__c; //Storing it to use it in next query
 
         //Create additional Program Enrollment
         Program_Enrollment__c enrollment2 = new Program_Enrollment__c(Contact__c = contact.ID, Account__c = acc.ID, Affiliation__c = enrollmentAfflID);
@@ -350,13 +350,13 @@ public with sharing class PREN_Affiliation_TEST {
         insert enrollment;
         
         //An Affiliation should have been automatically created fron the Program Enrollment
-        List<Affiliation__c> affls = [SELECT Contact__c, Account__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
+        List<Affiliation__c> affls = [SELECT Contact__c, Account__c FROM Affiliation__c WHERE Account__c = :acc.ID];
         System.assertEquals(1, affls.size());
         
         //The Program Enrollment record should be related to the Affiliation just created
-        enrollment = [SELECT Affiliation__r.ID FROM Program_Enrollment__c WHERE ID = :enrollment.ID];
-        System.assertEquals(affls[0].ID, enrollment.Affiliation__r.ID);
-        ID enrollmentAfflID = enrollment.Affiliation__r.ID; //Storing it to use it in next query
+        enrollment = [SELECT Affiliation__c FROM Program_Enrollment__c WHERE ID = :enrollment.ID];
+        System.assertEquals(affls[0].ID, enrollment.Affiliation__c);
+        ID enrollmentAfflID = enrollment.Affiliation__c; //Storing it to use it in next query
 
         //Create additional Program Enrollment
         Program_Enrollment__c enrollment2 = new Program_Enrollment__c(Contact__c = contact.ID, Account__c = acc.ID, Affiliation__c = enrollmentAfflID);
@@ -396,14 +396,14 @@ public with sharing class PREN_Affiliation_TEST {
         insert enrollment;
         
         //An Affiliation should have been automatically created fron the Program Enrollment
-        List<Affiliation__c> affls = [SELECT Contact__c, Account__c FROM Affiliation__c WHERE Account__r.ID = :acc.ID];
+        List<Affiliation__c> affls = [SELECT Contact__c, Account__c FROM Affiliation__c WHERE Account__c = :acc.ID];
         System.assertEquals(1, affls.size());
         
         //The Program Enrollment record should be related to the Affiliation just created
-        enrollment = [SELECT Affiliation__r.ID FROM Program_Enrollment__c WHERE ID = :enrollment.ID];
-        System.assertEquals(affls[0].ID, enrollment.Affiliation__r.ID);
+        enrollment = [SELECT Affiliation__c FROM Program_Enrollment__c WHERE ID = :enrollment.ID];
+        System.assertEquals(affls[0].ID, enrollment.Affiliation__c);
         
-        ID enrollmentAfflID = enrollment.Affiliation__r.ID; //Storing it to use it in next query
+        ID enrollmentAfflID = enrollment.Affiliation__c; //Storing it to use it in next query
         
         //Delete Program Enrollment
         Test.startTest();
@@ -414,5 +414,56 @@ public with sharing class PREN_Affiliation_TEST {
         affls = [SELECT Status__c FROM Affiliation__c WHERE ID = :enrollmentAfflID];
         System.assertEquals(1, affls.size());
         System.assertEquals(afflStatus, affls[0].Status__c);
+    }
+
+    /*********************************************************************************************************
+    * @description Deleting a Program Enrollment doesn't delete the related Affiliation when Affl_ProgEnroll_Del__c setting
+    * is set to false, nor does it change the status to what is defined in Affl_ProgEnroll_Del_Status__c when there are
+    * other Program Enrollments that are associated to the same Affiliation.
+    */
+    @isTest
+    public static void deletePEnrollDelAfflNo_existingPEPreventsAffiliationDeletion() {
+        STG_InstallScript.insertMappings();
+
+        String afflStatus = 'Former';
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Affl_ProgEnroll_Del__c = false, 
+        Affl_ProgEnroll_Del_Status__c = afflStatus));
+
+        Contact contact = UTIL_UnitTestData_TEST.getContact();
+        insert contact;
+
+        //Create account of Business Organization record type
+        Account acc = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe_API.getBizAccRecTypeID())[0];
+        insert acc;
+        
+        //Create Program Enrollment
+        Program_Enrollment__c enrollment = new Program_Enrollment__c(Contact__c = contact.ID, Account__c = acc.ID);
+        insert enrollment;
+        
+        //An Affiliation should have been automatically created fron the Program Enrollment
+        List<Affiliation__c> affls = [SELECT Contact__c, Account__c, Status__c FROM Affiliation__c WHERE Account__c = :acc.ID];
+        System.assertEquals(1, affls.size());
+        
+        //The Program Enrollment record should be related to the Affiliation just created
+        enrollment = [SELECT Affiliation__c FROM Program_Enrollment__c WHERE ID = :enrollment.ID];
+        System.assertEquals(affls[0].ID, enrollment.Affiliation__c);
+        
+        ID enrollmentAfflID = enrollment.Affiliation__c; //Storing it to use it in next query
+        String createdStatus = affls[0].Status__c;
+
+        //Create additional Program Enrollment
+        Program_Enrollment__c enrollment2 = new Program_Enrollment__c(Contact__c = contact.ID, Account__c = acc.ID, Affiliation__c = enrollmentAfflID);
+        insert enrollment2;
+        
+        //Delete Program Enrollment
+        Test.startTest();
+        delete enrollment;
+        Test.stopTest();
+        
+        //Related Affiliation status should NOT have been automatically updated
+        affls = [SELECT Status__c FROM Affiliation__c WHERE ID = :enrollmentAfflID];
+        System.assertEquals(1, affls.size());
+        System.assertNotEquals(afflStatus, affls[0].Status__c);
+        System.assertEquals(createdStatus, affls[0].Status__c);
     }
 }


### PR DESCRIPTION
# Critical Changes

# Changes
* When deleting a Program Enrollment, if its related Affiliation's Status is updated (instead of the Affiliation being deleted), the Status is now updated only if the Affiliation isn't related to any other existing Program Enrollment records. In other words, if "Delete Related Affiliation When Deleting Program Enrollment" is disabled in HEDA Settings | Affiliations | Settings, the value in "Status Specified for Affiliation Not Deleted" does not apply unless the related Affiliation has no other Program Enrollments related to it.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
1. Ensure that the "Delete Related Affiliation When Deleting Program Enrollment" setting is false.
2. Create a Program Enrollment for a Contact.
3. Go to the Program Enrollment Affiliation record that was automatically created.
4. On the Program Enrollment related list, create another Program Enrollment (into the same Program) for the Affiliation.
5. Delete the Program Enrollment record. The Program Enrollment record will be deleted, but the Affiliation record (& the other Program Enrollment record) will still exist. The Affiliation's Status will NOT be updated to the "Status of Affiliation Related to Deleted Program Enrollment" setting.
6. Delete the remaining Program Enrollment record. The Affiliation's Status will be updated to the "Status of Affiliation Related to Deleted Program Enrollment" setting.