### PR TITLE
Feature/mblanski/total required credits

### DIFF
--- a/src/layouts/Program_Plan__c-HEDA Program Plan Layout.layout
+++ b/src/layouts/Program_Plan__c-HEDA Program Plan Layout.layout
@@ -24,6 +24,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>Total_Required_Credits__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>Description__c</field>
             </layoutItems>
         </layoutColumns>

--- a/src/objectTranslations/Program_Plan__c-ca.objectTranslation
+++ b/src/objectTranslations/Program_Plan__c-ca.objectTranslation
@@ -48,6 +48,11 @@
         </picklistValues>
     </fields>
     <fields>
+        <help><!-- Specify the number of credits a student needs to complete this program plan. --></help>
+        <label><!-- Total Required Credits --></label>
+        <name>Total_Required_Credits__c</name>
+    </fields>
+    <fields>
         <help><!-- The version of the Program Plan. For example, “Spring 2019.” --></help>
         <label><!-- Version --></label>
         <name>Version__c</name>

--- a/src/objectTranslations/Program_Plan__c-ca.objectTranslation
+++ b/src/objectTranslations/Program_Plan__c-ca.objectTranslation
@@ -48,7 +48,7 @@
         </picklistValues>
     </fields>
     <fields>
-        <help><!-- Specify the number of credits a student needs to complete this program plan. --></help>
+        <help><!-- Specify the total number of credits a student must complete to satisfy this program plan. --></help>
         <label><!-- Total Required Credits --></label>
         <name>Total_Required_Credits__c</name>
     </fields>

--- a/src/objectTranslations/Program_Plan__c-en_US.objectTranslation
+++ b/src/objectTranslations/Program_Plan__c-en_US.objectTranslation
@@ -48,6 +48,11 @@
         </picklistValues>
     </fields>
     <fields>
+        <help><!-- Specify the number of credits a student needs to complete this program plan. --></help>
+        <label><!-- Total Required Credits --></label>
+        <name>Total_Required_Credits__c</name>
+    </fields>
+    <fields>
         <help><!-- The version of the Program Plan. For example, “Spring 2019.” --></help>
         <label><!-- Version --></label>
         <name>Version__c</name>

--- a/src/objectTranslations/Program_Plan__c-en_US.objectTranslation
+++ b/src/objectTranslations/Program_Plan__c-en_US.objectTranslation
@@ -48,7 +48,7 @@
         </picklistValues>
     </fields>
     <fields>
-        <help><!-- Specify the number of credits a student needs to complete this program plan. --></help>
+        <help><!-- Specify the total number of credits a student must complete to satisfy this program plan. --></help>
         <label><!-- Total Required Credits --></label>
         <name>Total_Required_Credits__c</name>
     </fields>

--- a/src/objectTranslations/Program_Plan__c-es.objectTranslation
+++ b/src/objectTranslations/Program_Plan__c-es.objectTranslation
@@ -48,6 +48,11 @@
         </picklistValues>
     </fields>
     <fields>
+        <help><!-- Specify the number of credits a student needs to complete this program plan. --></help>
+        <label><!-- Total Required Credits --></label>
+        <name>Total_Required_Credits__c</name>
+    </fields>
+    <fields>
         <help><!-- The version of the Program Plan. For example, “Spring 2019.” --></help>
         <label><!-- Version --></label>
         <name>Version__c</name>

--- a/src/objectTranslations/Program_Plan__c-es.objectTranslation
+++ b/src/objectTranslations/Program_Plan__c-es.objectTranslation
@@ -48,7 +48,7 @@
         </picklistValues>
     </fields>
     <fields>
-        <help><!-- Specify the number of credits a student needs to complete this program plan. --></help>
+        <help><!-- Specify the total number of credits a student must complete to satisfy this program plan. --></help>
         <label><!-- Total Required Credits --></label>
         <name>Total_Required_Credits__c</name>
     </fields>

--- a/src/objectTranslations/Program_Plan__c-fr.objectTranslation
+++ b/src/objectTranslations/Program_Plan__c-fr.objectTranslation
@@ -48,6 +48,11 @@
         </picklistValues>
     </fields>
     <fields>
+        <help><!-- Specify the number of credits a student needs to complete this program plan. --></help>
+        <label><!-- Total Required Credits --></label>
+        <name>Total_Required_Credits__c</name>
+    </fields>
+    <fields>
         <help><!-- The version of the Program Plan. For example, “Spring 2019.” --></help>
         <label><!-- Version --></label>
         <name>Version__c</name>

--- a/src/objectTranslations/Program_Plan__c-fr.objectTranslation
+++ b/src/objectTranslations/Program_Plan__c-fr.objectTranslation
@@ -48,7 +48,7 @@
         </picklistValues>
     </fields>
     <fields>
-        <help><!-- Specify the number of credits a student needs to complete this program plan. --></help>
+        <help><!-- Specify the total number of credits a student must complete to satisfy this program plan. --></help>
         <label><!-- Total Required Credits --></label>
         <name>Total_Required_Credits__c</name>
     </fields>

--- a/src/objects/Program_Plan__c.object
+++ b/src/objects/Program_Plan__c.object
@@ -140,9 +140,9 @@
     </fields>
     <fields>
         <fullName>Total_Required_Credits__c</fullName>
-        <description>The total required credits to complete the program plan.</description>
+        <description>The total number of credits a student must complete to satisfy this Program Plan.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Specify the number of credits a student needs to complete this program plan.</inlineHelpText>
+        <inlineHelpText>Specify the total number of credits a student must complete to satisfy this program plan.</inlineHelpText>
         <label>Total Required Credits</label>
         <precision>6</precision>
         <required>false</required>

--- a/src/objects/Program_Plan__c.object
+++ b/src/objects/Program_Plan__c.object
@@ -139,6 +139,19 @@
         <type>Picklist</type>
     </fields>
     <fields>
+        <fullName>Total_Required_Credits__c</fullName>
+        <description>The total required credits to complete the program plan.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Specify the number of credits a student needs to complete this program plan.</inlineHelpText>
+        <label>Total Required Credits</label>
+        <precision>6</precision>
+        <required>false</required>
+        <scale>3</scale>
+        <trackTrending>false</trackTrending>
+        <type>Number</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>Version__c</fullName>
         <description>The version of the Program Plan. For example, “Spring 2019.”</description>
         <externalId>false</externalId>

--- a/src/package.xml
+++ b/src/package.xml
@@ -358,6 +358,7 @@
         <members>Program_Plan__c.Is_Primary__c</members>
         <members>Program_Plan__c.Start_Date__c</members>
         <members>Program_Plan__c.Status__c</members>
+        <members>Program_Plan__c.Total_Required_Credits__c</members>
         <members>Program_Plan__c.Version__c</members>
         <members>Relationship_Auto_Create__c.Campaign_Types__c</members>
         <members>Relationship_Auto_Create__c.Field__c</members>


### PR DESCRIPTION
# Changes
We've added a new Total Required Credits field to Program Plans and the HEDA Program Plan Layout. Use this field to specify the total number of credits a student must complete to satisfy a given Program Plan.

# Issues Closed
- [Issue 718](https://github.com/SalesforceFoundation/HEDAP/issues/718)

# New Metadata
- Program_Plan__c.Total_Required_Credits__c

# Testing Notes

1. Create a Program Plan for an Account.
2. Ensure that Total Required Credits is a Number (3,3) field that may be updated on the Program Plan.