### PR TITLE
Add metadeploy install plan config

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -274,3 +274,25 @@ orgs:
         dev_namespaced:
             config_file: orgs/dev.json
             namespaced: True
+
+plans:
+    install:
+        slug: install
+        title: Install
+        tier: primary
+        steps:
+            1:
+                flow: dependencies
+                ui_options:
+                    deploy_pre:
+                        acc_record_types:
+                            name: HEDA - Account Record Types
+                        contact_key_affl_fields:
+                            name: HEDA - Contact Key Affiliation Fields
+            2:
+                task: install_managed
+            3:
+                task: deploy_post
+                ui_options:
+                    course_connection_record_types:
+                        name: Course Connection Record Types for HEDA


### PR DESCRIPTION
This adds configuration in cumulusci.yml for a MetaDeploy installation plan.

Using this configuration currently requires the unmerged changes in https://github.com/SFDO-Tooling/CumulusCI/pull/1020

You can try out the resulting installer at https://metadeploy.herokuapp.com/products/heda

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
