### PR TITLE
Updating AfflProgEnrollDeleted label

### DIFF
--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -14,7 +14,7 @@
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>AfflProgEnrollDeleted</shortDescription>
-        <value>If selected, when deleting a Program Enrollment, delete its related Affiliation. Otherwise, keep the Affiliation and set its Status to the value defined in Status of Affiliation Related to Deleted Program Enrollment.</value>
+        <value>If selected, when deleting a Program Enrollment, delete its related Affiliation. Otherwise, keep the Affiliation and set its Status to the value defined in Status Specified for Affiliations Not Deleted.</value>
     </labels>
     <labels>
         <fullName>AutoCreateFieldError</fullName>


### PR DESCRIPTION
# Critical Changes

# Changes
* We've changed the description in HEDA Settings for "Delete Related Affiliation When Deleting Program Enrollment" to reflect that leaving the box unchecked matches the Affiliation's status to the value for the setting below it in the UI, "Specified for Affiliations Not Deleted."

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
