### PR TITLE
Missing class attribute in CMP_Acc_Naming_Dropdown

### DIFF
--- a/src/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_Dropdown.cmp
+++ b/src/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_Dropdown.cmp
@@ -10,6 +10,8 @@
     <aura:attribute name="otherDisplay" type="boolean" default="false"/>   
     <aura:attribute name="setting" type="String" />
     <aura:attribute name="otherSetting" type="String" />
+    <aura:attribute name="class" type="String" />
+    
     <aura:if isTrue="{!v.isView}">
         <ui:outputText aura:id="nameFormatText" class="{!v.class + '-output-text'}" value="{!v.nameFormat}"/>
         <aura:if isTrue="{!v.otherDisplay}">

--- a/src/aura/STG_CMP_System/STG_CMP_System.cmp
+++ b/src/aura/STG_CMP_System/STG_CMP_System.cmp
@@ -200,7 +200,9 @@
         </div>
         
         <div class="slds-col slds-size--1-of-2" >
-            <c:CMP_Acc_Naming_Dropdown isView="{!v.isView}"
+            <c:CMP_Acc_Naming_Dropdown 
+                class="admin-account-naming"
+                isView="{!v.isView}"
                 setting="{!v.hierarchySettings.Admin_Account_Naming_Format__c}"
                 nameFormat="{!v.adminNameFormat}"
                 targetSetting="Admin_Account_Naming_Format__c"
@@ -218,7 +220,9 @@
         </div>
         
         <div class="slds-col slds-size--1-of-2">
-            <c:CMP_Acc_Naming_Dropdown isView="{!v.isView}"
+            <c:CMP_Acc_Naming_Dropdown 
+                class="household-account-naming"
+                isView="{!v.isView}"
                 setting="{!v.hierarchySettings.Household_Account_Naming_Format__c}"
                 nameFormat="{!v.hhNameFormat}"
                 targetSetting="Household_Account_Naming_Format__c"


### PR DESCRIPTION
# Critical Changes

# Changes
* An error is no longer displayed when viewing the HEDA Settings with Lightning Debug Mode enabled.

# Issues Closed
Fixes #757 

# New Metadata

# Deleted Metadata

# Testing Notes
* If Lightning Debug Mode is enabled for a user, that user would see an error at the bottom of the HEDA Settings page. The error was also displayed in a red toast message if the user saved the settings.
  * When the user navigates to the HEDA Settings, an error should no longer display. Settings should save successfully.