### PR TITLE
Contact "Primary Language" Updates Contact Language Record

### DIFF
--- a/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
+++ b/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
@@ -2,6 +2,10 @@
 
     <aura:handler event="c:STG_EVT_Edit" action="{!c.toggleIsView}"/>
 
+    <aura:attribute name="defaultContactLanguageFluencyValue" type="String" />
+    <aura:attribute name="defaultContactLanguageFluencyLabel" type="String" />
+    <aura:attribute name="fluencyPicklistEntries" type="Map" />
+
     <aura:attribute name="accTypesToDeleteSelected" type="Object[]" />
     <aura:attribute name="accTypesAddrSelected" type="Object[]" />
 
@@ -12,6 +16,25 @@
     <aura:attribute name="adminAccRecTypeId" type="String" />
 
     <div class="slds-grid slds-wrap">
+
+        <div class="slds-col slds-size--1-of-2">
+            <ui:outputText value="{!$Label.c.stgDefaultContactLanguageFluency}" />
+        </div>
+        <div class="slds-col slds-size--1-of-2">
+            <c:CMP_Picklist_Dropdown class="contact-language-fluency-picklist"
+                setting="{!v.hierarchySettings.Default_Contact_Language_Fluency__c}"
+                isView="{!v.isView}"
+                picklistValue="{!v.defaultContactLanguageFluencyValue}"
+                picklistLabel="{!v.defaultContactLanguageFluencyLabel}"
+                picklistEntries="{!v.fluencyPicklistEntries}"
+                enableNoneOption="true" />
+        </div>
+        <div class="slds-col slds-size--1-of-1">
+            <ui:outputText value="{!$Label.c.stgHelpDefaultContactLanguageFluency}" class="slds-text-body--small" />
+        </div>
+
+        <hr class="slds-border--top slds-m-top--medium slds-m-bottom--medium" style="width:100%;" />
+
         <div class="slds-col slds-size--1-of-2">
             <ui:outputText value="{!$Label.c.stgDisablePreferredEmailEnforcement}"/>
         </div>

--- a/src/aura/STG_CMP_Tabs/STG_CMP_Tabs.cmp
+++ b/src/aura/STG_CMP_Tabs/STG_CMP_Tabs.cmp
@@ -3,6 +3,10 @@
 
     <aura:attribute name="save" type="Boolean" default="true"/>
 
+    <aura:attribute name="defaultContactLanguageFluencyValue" type="String" />
+    <aura:attribute name="defaultContactLanguageFluencyLabel" type="String" />
+    <aura:attribute name="fluencyPicklistEntries" type="Map" />
+
     <aura:attribute name="accRecTypes" type="Map" />
     <aura:attribute name="courseConnectionRecTypes" type="Map" />
 
@@ -82,13 +86,15 @@
         </div>
         <div aura:id="addrTabContent" class="site-code--content slds-scrollable--x slds-tabs__content" role="tabpanel">
             <c:STG_CMP_Addr hierarchySettings="{!v.hierarchySettings}" isView="{!v.isView}" namespacePrefix="{!v.namespacePrefix}"
-             accTypesToDeleteSelected="{!v.accTypesToDeleteSelected}" accTypesAddrSelected="{!v.accTypesAddrSelected}"
-             accRecTypes="{!v.accRecTypes}" householdRecTypeId="{!v.householdRecTypeId}" householdRecTypeName="{!v.householdRecTypeName}"
-             adminAccRecTypeId="{!v.adminAccRecTypeId}" adminAccRecTypeName="{!v.adminAccRecTypeName}"  />
+                defaultContactLanguageFluencyValue="{!v.defaultContactLanguageFluencyValue}" defaultContactLanguageFluencyLabel="{!v.defaultContactLanguageFluencyLabel}" 
+                fluencyPicklistEntries="{!v.fluencyPicklistEntries}" accTypesToDeleteSelected="{!v.accTypesToDeleteSelected}" accTypesAddrSelected="{!v.accTypesAddrSelected}"
+                accRecTypes="{!v.accRecTypes}" householdRecTypeId="{!v.householdRecTypeId}" householdRecTypeName="{!v.householdRecTypeName}"
+                adminAccRecTypeId="{!v.adminAccRecTypeId}" adminAccRecTypeName="{!v.adminAccRecTypeName}"  />
         </div>
         <div aura:id="systemTabContent" class="site-code--content slds-scrollable--x slds-tabs__content" role="tabpanel">
-             <c:STG_CMP_System hierarchySettings="{!v.hierarchySettings}" isView="{!v.isView}" namespacePrefix="{!v.namespacePrefix}"
-             accRecTypes="{!v.accRecTypes}" accRecTypeId="{!v.accRecTypeId}" accRecTypeName="{!v.accRecTypeName}"  hhNameFormat="{!v.hhNameFormat}" adminNameFormat="{!v.adminNameFormat}" adminOtherDisplay="{!v.adminOtherDisplay}" hhOtherDisplay="{!v.hhOtherDisplay}"/>
+            <c:STG_CMP_System hierarchySettings="{!v.hierarchySettings}" isView="{!v.isView}" namespacePrefix="{!v.namespacePrefix}"
+                accRecTypes="{!v.accRecTypes}" accRecTypeId="{!v.accRecTypeId}" accRecTypeName="{!v.accRecTypeName}"  
+                hhNameFormat="{!v.hhNameFormat}" adminNameFormat="{!v.adminNameFormat}" adminOtherDisplay="{!v.adminOtherDisplay}" hhOtherDisplay="{!v.hhOtherDisplay}"/>
         </div>
     </div>
 </aura:component>

--- a/src/aura/STG_CMP_Tabs/STG_CMP_TabsHelper.js
+++ b/src/aura/STG_CMP_Tabs/STG_CMP_TabsHelper.js
@@ -30,26 +30,29 @@
 			    component.set("v.adminAccRecTypeId", settingsNoPrefix.Administrative_Account_Record_Type__c);
 			    component.set("v.studentRecTypeId", settingsNoPrefix.Student_RecType__c);
 		        component.set("v.facultyRecTypeId", settingsNoPrefix.Faculty_RecType__c);
-                component.set("v.affiliationRoleMapValue",settingsNoPrefix.Affl_ProgEnroll_Role_Map__c);
-                component.set("v.affiliationStatusMapValue",settingsNoPrefix.Affl_ProgEnroll_Status_Map__c);
-                component.set("v.affiliationStatusDeleteMapValue",settingsNoPrefix.Affl_ProgEnroll_Del_Status__c);
+                component.set("v.affiliationRoleMapValue", settingsNoPrefix.Affl_ProgEnroll_Role_Map__c);
+                component.set("v.affiliationStatusMapValue", settingsNoPrefix.Affl_ProgEnroll_Status_Map__c);
+                component.set("v.affiliationStatusDeleteMapValue", settingsNoPrefix.Affl_ProgEnroll_Del_Status__c);
+                component.set("v.defaultContactLanguageFluencyValue", settingsNoPrefix.Default_Contact_Language_Fluency__c);
 
 		        component.set("v.adminNameFormat", settingsNoPrefix.Admin_Account_Naming_Format__c);
 		        component.set("v.hhNameFormat", settingsNoPrefix.Household_Account_Naming_Format__c);
-		        component.set("v.adminOtherDisplay",this.getOtherDisplay(component, settingsNoPrefix.Admin_Account_Naming_Format__c));
-		        component.set("v.hhOtherDisplay",this.getOtherDisplay(component, settingsNoPrefix.Household_Account_Naming_Format__c));
+		        component.set("v.adminOtherDisplay", this.getOtherDisplay(component, settingsNoPrefix.Admin_Account_Naming_Format__c));
+		        component.set("v.hhOtherDisplay", this.getOtherDisplay(component, settingsNoPrefix.Household_Account_Naming_Format__c));
 
 	    		//Get account record types
 	    		this.getAccountRecordTypes(component, settingsNoPrefix.Accounts_to_Delete__c,
 	    		        settingsNoPrefix.Accounts_Addresses_Enabled__c, settingsNoPrefix.Account_Processor__c,
 	    		        settingsNoPrefix.Household_Addresses_RecType__c, settingsNoPrefix.Administrative_Account_Record_Type__c);
                 // Get Affiliation Role Picklist
-                this.getAffiliationRolePicklistEntries(component,settingsNoPrefix.Affl_ProgEnroll_Role_Map__c);
+                this.getAffiliationRolePicklistEntries(component, settingsNoPrefix.Affl_ProgEnroll_Role_Map__c);
                 // Get Affiliation Status Picklist
-                this.getAffiliationStatusPicklistEntries(component,settingsNoPrefix.Affl_ProgEnroll_Status_Map__c,settingsNoPrefix.Affl_ProgEnroll_Del_Status__c);
+                this.getAffiliationStatusPicklistEntries(component, settingsNoPrefix.Affl_ProgEnroll_Status_Map__c, settingsNoPrefix.Affl_ProgEnroll_Del_Status__c);
                 // Get Course Connection Record Types
 	    		this.getCourseConnectionRecordTypes(component, settingsNoPrefix.Student_RecType__c,
-	    		        settingsNoPrefix.Faculty_RecType__c);
+                        settingsNoPrefix.Faculty_RecType__c);
+                // Get Contact Language Fluency Picklist
+                this.getFluencyPicklistEntries(component, settingsNoPrefix.Default_Contact_Language_Fluency__c);
 	    	} else if(response.getState() === "ERROR") {
 	    		this.displayError(response);
 			}
@@ -199,6 +202,38 @@
 
             } else if(response.getState() === "ERROR") {
               this.displayError(response);
+            }
+        });
+        $A.enqueueAction(action);
+    },
+
+    getFluencyPicklistEntries : function(component, fluencyValue) {
+        //Get all active Contact Language Fluency picklist entries
+        var action = component.get("c.getPicklistActiveValuesMap");
+        var prefix = component.get("v.namespacePrefix");
+        var objectName = prefix + 'Contact_Language__c';
+        var fieldName = prefix + 'Fluency__c';
+        
+        action.setParams({ "objectName" : objectName,"fieldName" : fieldName});
+        action.setCallback(this, function(response) {
+            if(response.getState() === "SUCCESS") {
+                var picklistValues = response.getReturnValue();
+                var fluencyPicklistEntries = [];
+                
+                for(var property in picklistValues) {
+                    if (picklistValues.hasOwnProperty(property)) {
+                        fluencyPicklistEntries.push({picklistLabel: property, picklistValue : picklistValues[property]});
+                        
+                        if(property.indexOf(fluencyValue) > -1) {
+                            component.set("v.defaultContactLanguageFluencyLabel", property);
+                        }   
+                    }
+                }
+
+                component.set("v.fluencyPicklistEntries", fluencyPicklistEntries);
+
+            } else if(response.getState() === "ERROR") {
+                this.displayError(response);
             }
         });
         $A.enqueueAction(action);

--- a/src/classes/CLAN_PrimaryLanguage_TDTM.cls
+++ b/src/classes/CLAN_PrimaryLanguage_TDTM.cls
@@ -56,7 +56,11 @@ public with sharing class CLAN_PrimaryLanguage_TDTM extends TDTM_Runnable {
 
         DmlWrapper dmlWrapper = new DmlWrapper();
 
-        if (TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CLAN_PrimaryLanguage_TDTM)) {
+        // Exit early if this trigger or the CON_PrimaryLanguage_TDTM trigger is currently running - the work
+        // was already done!
+        if (TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CLAN_PrimaryLanguage_TDTM) 
+            || TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryLanguage_TDTM)) {
+            
             return dmlWrapper;
         }
 
@@ -137,13 +141,14 @@ public with sharing class CLAN_PrimaryLanguage_TDTM extends TDTM_Runnable {
             }
         }
 
-        // Add Contact records to dmlWrapper to be updated by the TDTM_TriggerHandler class
+        // Add Contact records to dmlWrapper
         dmlWrapper.objectsToUpdate.addAll((List<SObject>)contactsToUpdate.values());
 
-        // Are there any Contact Language records to update? Update them now so that we prevent trigger recursion.
-        if (contactLanguagesToUpdate.size() > 0) {
-            update contactLanguagesToUpdate.values();
-        }
+        // Add Contact Languages to the dmlWrapper
+        dmlWrapper.objectsToUpdate.addAll((List<SObject>)contactLanguagesToUpdate.values());
+
+        TDTM_TriggerHandler.processDML(dmlWrapper, true);
+        dmlWrapper = null;
 
         // We're done with our updates, unset the recursion flag.
         TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CLAN_PrimaryLanguage_TDTM, false);

--- a/src/classes/CON_PrimaryLanguage_TDTM.cls
+++ b/src/classes/CON_PrimaryLanguage_TDTM.cls
@@ -1,0 +1,165 @@
+/*
+    Copyright (c) 2019, Salesforce.org
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2019
+* @group Languages
+* @group-content ../../ApexDocContent/Languages.htm
+* @description Creates or modifies existing Contact Language records when the Contact's "Primary Language" 
+* lookup field is manually changed.
+*/
+public with sharing class CON_PrimaryLanguage_TDTM extends TDTM_Runnable {
+
+    private List<Contact_Language__c> contactLanguagesToUpdate = new List<Contact_Language__c>();
+    private List<Contact_Language__c> contactLanguagesToInsert = new List<Contact_Language__c>();
+    private Map<Id, Id> primaryLanguageByContact = new Map<Id, Id>();
+
+    /*******************************************************************************************************
+    * @description Iterates over all Contact records being inserted, updated, or deleted and ensures that if
+    * a Primary Language is set, updated, or cleared, the corresponding Contact Language record is created or
+    * updated accordingly.
+    * @param listNew the list of Contacts from trigger new.
+    * @param listOld the list of Contacts from trigger old.
+    * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.).
+    * @param objResult the describe for Contact.
+    * @return dmlWrapper Any Contact Language records that need to be inserted or updated.
+    ********************************************************************************************************/
+    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist,
+        TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
+
+        DmlWrapper dmlWrapper = new DmlWrapper();
+
+        // If this trigger is running as a result of the Contact Language trigger, just exit early - that trigger
+        // already did the work for us!
+        if (TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CLAN_PrimaryLanguage_TDTM)) {
+            return dmlWrapper;
+        }
+
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryLanguage_TDTM, true);
+
+        if (newlist != null && newlist.size() > 0) {
+
+            // After Insert
+            if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
+                for (Contact newContact : (List<Contact>)newlist) {
+                    if (newContact.Primary_Language__c == null) { 
+                        // No Primary Language, so let's continue.
+                        continue;
+                    }
+
+                    primaryLanguageByContact.put(newContact.Id, newContact.Primary_Language__c);
+                }
+            } 
+
+            // After Update
+            else if (triggerAction == TDTM_Runnable.Action.AfterUpdate && oldlist != null && oldlist.size() > 0) {
+                for (Integer i = 0; i < newlist.size(); i++) {
+                    Contact newContact = (Contact)newlist[i];
+                    Contact oldContact = (Contact)oldlist[i];
+
+                    if (newContact.Primary_Language__c == oldContact.Primary_Language__c) {
+                        // The Primary Language field isn't changing, so let's continue.
+                        continue;
+                    }
+
+                    primaryLanguageByContact.put(newContact.Id, newContact.Primary_Language__c);
+                }
+            }
+        }
+
+        syncPrimaryContactLanguageRecords();
+
+        dmlWrapper.objectsToUpdate.addAll((List<SObject>)contactLanguagesToUpdate);
+        dmlWrapper.objectsToInsert.addAll((List<SObject>)contactLanguagesToInsert);
+
+        TDTM_TriggerHandler.processDML(dmlWrapper, true);
+        dmlWrapper = null;
+
+        // We're done with our updates, unset the recursion flag.
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryLanguage_TDTM, false);
+
+        return dmlWrapper;
+    }
+
+    private void syncPrimaryContactLanguageRecords() {
+        if (primaryLanguageByContact == null || primaryLanguageByContact.size() == 0) {
+            return;
+        }
+
+        Set<Id> contactsWithPrimaryContactLanguages = new Set<Id>();
+
+        // Query for all existing Contact Language records that are for the given Contacts and Primary Languages,
+        // or any Contact Language records that are marked as Primary that may need to be updated.
+        List<Contact_Language__c> existingContactLanguages = [SELECT Id, Language__c, Contact__c, Primary_Language__c
+            FROM Contact_Language__c
+            WHERE Contact__c IN :primaryLanguageByContact.keySet()
+                AND (Language__c IN :primaryLanguageByContact.values() OR Primary_Language__c = true)];
+
+        // Iterate over all existing Contact Languages and verify that the appropriate records are set as the Primary Language.
+        for (Contact_Language__c existingContactLanguage : existingContactLanguages) {
+            Id primaryLanguageId = primaryLanguageByContact.get(existingContactLanguage.Contact__c);
+            
+            if (existingContactLanguage.Language__c == primaryLanguageId) {
+                // A Contact Language record was found matching the Primary Language on the Contact, so we won't need to create a new record.
+                contactsWithPrimaryContactLanguages.add(existingContactLanguage.Contact__c);
+
+                if(!existingContactLanguage.Primary_Language__c) {
+                    // This Contact Language record needs to be updated to be the Primary Language.
+                    contactLanguagesToUpdate.add(new Contact_Language__c(Id = existingContactLanguage.Id, Primary_Language__c = true));
+                }
+
+            } else if (existingContactLanguage.Language__c != primaryLanguageId && existingContactLanguage.Primary_Language__c) {
+                // This Contact Language record needs to be updated to no longer be the Primary Language.
+                contactLanguagesToUpdate.add(new Contact_Language__c(Id = existingContactLanguage.Id, Primary_Language__c = false));
+
+            }
+        }
+
+        // Create new Contact Language records for Contacts that don't have one yet.
+        // We don't need to create Contact Language records for Contacts that already have a Primary Contact Language record.
+        Set<Id> contactsToEvaluate = primaryLanguageByContact.keySet();
+        contactsToEvaluate.removeAll(contactsWithPrimaryContactLanguages);
+
+        if (contactsToEvaluate.size() == 0) {
+            return;
+        }
+
+        String fluencyValue = UTIL_CustomSettingsFacade.getSettings().Default_Contact_Language_Fluency__c;
+        for (Id contactId : primaryLanguageByContact.keySet()) {
+            Id primaryLanguageId = primaryLanguageByContact.get(contactId);
+
+            // This shouldn't happen, but just in case - don't create a Contact Language record for a blank Language
+            if (primaryLanguageId == null) {
+                continue;
+            }
+
+            contactLanguagesToInsert.add(new Contact_Language__c(
+                Language__c = primaryLanguageId, Contact__c = contactId, Fluency__c = fluencyValue, Primary_Language__c = true
+            ));
+        }
+    }
+}

--- a/src/classes/CON_PrimaryLanguage_TDTM.cls-meta.xml
+++ b/src/classes/CON_PrimaryLanguage_TDTM.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>45.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/CON_PrimaryLanguage_TEST.cls
+++ b/src/classes/CON_PrimaryLanguage_TEST.cls
@@ -38,7 +38,7 @@ private class CON_PrimaryLanguage_TEST {
     private static Contact contact;
     private static Language__c language;
     private static Contact_Language__c contactLanguage;
-    private static final String DEFAULT_FLUENCY = 'Fluent';
+    private static final String DEFAULT_FLUENCY = Label.stgFluent;
 
     /*******************************************************************************************************
     * @description Inserts a new Language and Contact record for testing.

--- a/src/classes/CON_PrimaryLanguage_TEST.cls
+++ b/src/classes/CON_PrimaryLanguage_TEST.cls
@@ -1,0 +1,213 @@
+/*
+    Copyright (c) 2019, Salesforce.org
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2019
+* @group Languages
+* @group-content ../../ApexDocContent/Languages.htm
+* @description Tests specific to testing the logic around creating and modifying Contact Language records when
+* the Contact's "Primary Language" lookup field is manually changed.
+*/
+@isTest
+private class CON_PrimaryLanguage_TEST {
+
+    private static Contact contact;
+    private static Language__c language;
+    private static Contact_Language__c contactLanguage;
+    private static final String DEFAULT_FLUENCY = 'Fluent';
+
+    /*******************************************************************************************************
+    * @description Inserts a new Language and Contact record for testing.
+    * @param insertContact If true, inserts a new Contact record. Otherwise, a Contact is instantiated but
+    * not inserted.
+    ********************************************************************************************************/
+    private static void setup(Boolean insertContact) {
+        language = UTIL_UnitTestData_TEST.createLanguage('English');
+
+        contact = UTIL_UnitTestData_TEST.getContact();
+        if (insertContact) {
+            insert contact;
+        }
+    }
+
+    /*******************************************************************************************************
+    * @description Verifies/asserts that the Contact Language record for the Language and Contact exists with
+    * the expected values.
+    * @param isPrimaryLanguage If true, the Primary Language checkbox is expected to be checked.
+    * @param expectedFluency The expected value of the Contact Language's Fluency.
+    * @param expectedLanguageId The expected value of the Contact Language's Language.
+    * @param expectedContactLanguageId The expected value of the Contact Language's ID. May be null, in which
+    * case the record was created by the process and did not already exist.
+    ********************************************************************************************************/
+    private static void assertContactLanguageRecord(Boolean isPrimaryLanguage, String expectedFluency, 
+            Id expectedLanguageId, Id expectedContactLanguageId) {
+        List<Contact_Language__c> queriedContactLanguages = [SELECT Id, Primary_Language__c, Fluency__c
+            FROM Contact_Language__c
+            WHERE Language__c = :expectedLanguageId 
+                AND Contact__c = :contact.Id];
+
+        System.assertEquals(1, queriedContactLanguages.size(), 'The expected Contact Language was not found.');
+
+        contactLanguage = queriedContactLanguages[0];
+        if (expectedContactLanguageId != null) {
+            System.assertEquals(expectedContactLanguageId, contactLanguage.Id, 'The ID does not match the expected Contact Language ID.');
+        }
+
+        System.assertEquals(isPrimaryLanguage, contactLanguage.Primary_Language__c, 'The Primary Language value does not match the expected Primary Language value.');
+        System.assertEquals(expectedFluency, contactLanguage.Fluency__c, 'The Fluency value does not match the expected Fluency value.');
+    }
+
+    /*******************************************************************************************************
+    * @description Tests that when the Primary Language is set on a Contact when a new Contact is inserted,
+    * a corresponding Primary Language Contact Language record is also created.
+    ********************************************************************************************************/
+    @isTest
+    private static void setPrimaryLanguage() {
+        setup(false); // Don't insert the Contact right away
+
+        Test.startTest();
+        contact.Primary_Language__c = language.Id;
+        insert contact;
+        Test.stopTest();
+
+        assertContactLanguageRecord(true, DEFAULT_FLUENCY, language.Id, null);
+    }
+
+    /*******************************************************************************************************
+    * @description Tests that when the Primary Language is set on a Contact when a Contact is updated, a
+    * corresponding Primary Language Contact Language record is created if one doesn't already exist.
+    ********************************************************************************************************/
+    @isTest
+    private static void setPrimaryLanguageOnUpdate() {
+        setup(true);
+
+        Test.startTest();
+        contact.Primary_Language__c = language.Id;
+        update contact;
+        Test.stopTest();
+
+        assertContactLanguageRecord(true, DEFAULT_FLUENCY, language.Id, null);
+    }
+
+    /*******************************************************************************************************
+    * @description Tests that when the Primary Language is set on a Contact when a Contact is updated, a
+    * corresponding Primary Language Contact Language record is not created if one already exists for the
+    * Contact and Language. The existing record is updated as the Primary Language.
+    ********************************************************************************************************/
+    @isTest
+    private static void setPrimaryLanguageWhenContactLanguageRecordExists() {
+        setup(true);
+
+        Contact_Language__c existingContactLanguage = 
+            new Contact_Language__c(
+                Language__c = language.Id, 
+                Contact__c = contact.Id, 
+                Fluency__c = DEFAULT_FLUENCY, 
+                Primary_Language__c = false
+            );
+        insert existingContactLanguage;
+
+        Test.startTest();
+        contact.Primary_Language__c = language.Id;
+        update contact;
+        Test.stopTest();
+
+        assertContactLanguageRecord(true, DEFAULT_FLUENCY, language.Id, existingContactLanguage.Id);
+    }
+
+    /*******************************************************************************************************
+    * @description Tests that when the Primary Language is set on a Contact when a Contact is updated, a
+    * corresponding Primary Language Contact Language record is created if one doesn't already exist. If a 
+    * different value for default Fluency is set in the HEDA Settings, that value is used for the Fluency.
+    ********************************************************************************************************/
+    @isTest
+    private static void setPrimaryLanguageWithDifferentFluencyValue() {
+        String fluencyValue = 'Intermediate';
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Default_Contact_Language_Fluency__c = fluencyValue));
+        
+        setup(false); // Don't insert the Contact right away
+
+        Test.startTest();
+        contact.Primary_Language__c = language.Id;
+        insert contact;
+        Test.stopTest();
+
+        assertContactLanguageRecord(true, fluencyValue, language.Id, null);
+    }
+
+    /*******************************************************************************************************
+    * @description Tests that when the Primary Language is unset on a Contact, the corresponding Contact
+    * Language record is updated to no longer be the Primary Language.
+    ********************************************************************************************************/
+    @isTest
+    private static void unsetPrimaryLanguage() {
+        setup(false); // Don't insert the Contact right away
+
+        contact.Primary_Language__c = language.Id;
+        insert contact;
+        assertContactLanguageRecord(true, DEFAULT_FLUENCY, language.Id, null);
+
+        System.assert(contactLanguage != null, 'Expected the contactLanguage variable to be set.');
+
+        Test.startTest();
+        contact.Primary_Language__c = null;
+        update contact;
+        Test.stopTest();
+
+        // Assert that the Contact Language record is no longer the Primary Language.
+        assertContactLanguageRecord(false, DEFAULT_FLUENCY, language.Id, contactLanguage.Id);
+    }
+
+    /*******************************************************************************************************
+    * @description Tests that when the Primary Language is set on a Contact to a different value, the previous
+    * Contact Language record is updated to no longer be the Primary Language and a new Contact Language record
+    * is created for the new Primary Language.
+    ********************************************************************************************************/
+    @isTest
+    private static void swapPrimaryLanguage() {
+        setup(false); // Don't insert the Contact right away
+
+        contact.Primary_Language__c = language.Id;
+        insert contact;
+        assertContactLanguageRecord(true, DEFAULT_FLUENCY, language.Id, null);
+
+        System.assert(contactLanguage != null, 'Expected the contactLanguage variable to be set.');
+
+        Language__c newLanguage = UTIL_UnitTestData_TEST.createLanguage('Spanish');
+
+        Test.startTest();
+        contact.Primary_Language__c = newLanguage.Id;
+        update contact;
+        Test.stopTest();
+
+        // Assert that the old Contact Language record is no longer the Primary Language.
+        assertContactLanguageRecord(false, DEFAULT_FLUENCY, language.Id, contactLanguage.Id);
+
+        // Assert that there's a new Contact Language record for the new Primary Language.
+        assertContactLanguageRecord(true, DEFAULT_FLUENCY, newLanguage.Id, null);
+    }
+}

--- a/src/classes/CON_PrimaryLanguage_TEST.cls-meta.xml
+++ b/src/classes/CON_PrimaryLanguage_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>45.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -275,7 +275,7 @@ global without sharing class STG_InstallScript implements InstallHandler {
     * @description Populate Default Contact Language Fluency custom setting when upgrading to 1.75
     * @return void
     */
-    private static void setDefaultContactLanguageFluency(Version previousVersion) {
+    global static void setDefaultContactLanguageFluency(Version previousVersion) {
         if(previousVersion != null && previousVersion.compareTo(new Version(1,75)) < 0) {
             Hierarchy_Settings__c orgSettings = UTIL_CustomSettingsFacade.getSettings();
             if(orgSettings.Default_Contact_Language_Fluency__c == null || orgSettings.Default_Contact_Language_Fluency__c == '') {

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -68,6 +68,8 @@ global without sharing class STG_InstallScript implements InstallHandler {
 
             populateAdminRecordTypeSetting(previousVersion);
 
+            setDefaultContactLanguageFluency(previousVersion);
+
             if(previousVersion != null && previousVersion.compareTo(new Version(1,38)) < 0) {
                 // We need to handle a special case to populate the Owned_by_Namespace__c field for HEDA Orgs before 1.38.
                 populateNamespaceHandlers();
@@ -264,6 +266,20 @@ global without sharing class STG_InstallScript implements InstallHandler {
             Hierarchy_Settings__c orgSettings = UTIL_CustomSettingsFacade.getSettings();
             if(orgSettings.Administrative_Account_Record_Type__c == null || orgSettings.Administrative_Account_Record_Type__c == '') {
                 orgSettings.Administrative_Account_Record_Type__c = UTIL_Describe.getAdminAccRecTypeID();
+            }
+            upsert orgSettings;
+        }
+    }
+    
+    /*******************************************************************************************************
+    * @description Populate Default Contact Language Fluency custom setting when upgrading to 1.74
+    * @return void
+    */
+    private static void setDefaultContactLanguageFluency(Version previousVersion) {
+        if(previousVersion != null && previousVersion.compareTo(new Version(1,74)) < 0) {
+            Hierarchy_Settings__c orgSettings = UTIL_CustomSettingsFacade.getSettings();
+            if(orgSettings.Default_Contact_Language_Fluency__c == null || orgSettings.Default_Contact_Language_Fluency__c == '') {
+                orgSettings.Default_Contact_Language_Fluency__c = 'Fluent';
             }
             upsert orgSettings;
         }

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -272,14 +272,14 @@ global without sharing class STG_InstallScript implements InstallHandler {
     }
     
     /*******************************************************************************************************
-    * @description Populate Default Contact Language Fluency custom setting when upgrading to 1.74
+    * @description Populate Default Contact Language Fluency custom setting when upgrading to 1.75
     * @return void
     */
     private static void setDefaultContactLanguageFluency(Version previousVersion) {
-        if(previousVersion != null && previousVersion.compareTo(new Version(1,74)) < 0) {
+        if(previousVersion != null && previousVersion.compareTo(new Version(1,75)) < 0) {
             Hierarchy_Settings__c orgSettings = UTIL_CustomSettingsFacade.getSettings();
             if(orgSettings.Default_Contact_Language_Fluency__c == null || orgSettings.Default_Contact_Language_Fluency__c == '') {
-                orgSettings.Default_Contact_Language_Fluency__c = 'Fluent';
+                orgSettings.Default_Contact_Language_Fluency__c = Label.stgFluent;
             }
             upsert orgSettings;
         }

--- a/src/classes/STG_InstallScript_TEST.cls
+++ b/src/classes/STG_InstallScript_TEST.cls
@@ -67,7 +67,7 @@ public with sharing class STG_InstallScript_TEST {
 
         // Verify defaults are set on install
         Hierarchy_Settings__c orgSettings = UTIL_CustomSettingsFacade.getSettings();
-        System.assertEquals('Fluent', orgSettings.Default_Contact_Language_Fluency__c);
+        System.assertEquals(Label.stgFluent, orgSettings.Default_Contact_Language_Fluency__c);
 
         // Making sure the Batch process ran successfully
         Contact cont2 = [SELECT Id, Name, Email, AlternateEmail__c, Preferred_Email__c FROM Contact WHERE Id =: cont.Id];
@@ -343,11 +343,11 @@ public with sharing class STG_InstallScript_TEST {
         upsert orgSettings;
         
         Test.startTest();
-        // Run the install script for orgs using HEDA 1.73
-        Test.testInstall(new STG_InstallScript(), new Version(1,73), true);
+        // Run the install script for orgs using HEDA 1.74
+        Test.testInstall(new STG_InstallScript(), new Version(1,74), true);
         Test.stopTest();
 
         Hierarchy_Settings__c updatedSettings = UTIL_CustomSettingsFacade.getSettings();
-        System.assertEquals('Fluent', updatedSettings.Default_Contact_Language_Fluency__c);
+        System.assertEquals(Label.stgFluent, updatedSettings.Default_Contact_Language_Fluency__c);
     }
 }

--- a/src/classes/STG_InstallScript_TEST.cls
+++ b/src/classes/STG_InstallScript_TEST.cls
@@ -44,7 +44,7 @@ public with sharing class STG_InstallScript_TEST {
             LastName = 'Test',
             Email = 'joe@domain.com'
         );
-        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, false);// need to turn off the trigger for this test
+        TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, false); // need to turn off the trigger for this test
         insert cont;
 
         TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, true); // back on for install script
@@ -64,6 +64,10 @@ public with sharing class STG_InstallScript_TEST {
             // Verify Owned by namespace field set on first item in list
             System.assertEquals('hed', h.Owned_by_Namespace__c);
         }
+
+        // Verify defaults are set on install
+        Hierarchy_Settings__c orgSettings = UTIL_CustomSettingsFacade.getSettings();
+        System.assertEquals('Fluent', orgSettings.Default_Contact_Language_Fluency__c);
 
         // Making sure the Batch process ran successfully
         Contact cont2 = [SELECT Id, Name, Email, AlternateEmail__c, Preferred_Email__c FROM Contact WHERE Id =: cont.Id];
@@ -329,6 +333,21 @@ public with sharing class STG_InstallScript_TEST {
         Hierarchy_Settings__c updatedSettings = UTIL_CustomSettingsFacade.getSettings();
         System.assertNotEquals(null, updatedSettings.Administrative_Account_Record_Type__c);
         System.assertNotEquals('', updatedSettings.Administrative_Account_Record_Type__c);
-        system.assertEquals(UTIL_Describe_API.getAdminAccRecTypeID(), orgSettings.Administrative_Account_Record_Type__c);
+        System.assertEquals(UTIL_Describe_API.getAdminAccRecTypeID(), orgSettings.Administrative_Account_Record_Type__c);
+    }
+
+    @isTest
+    private static void setDefaultContactLanguageFluencyOnUpgrade() {
+        Hierarchy_Settings__c orgSettings = UTIL_CustomSettingsFacade.getSettings();
+        orgSettings.Default_Contact_Language_Fluency__c = '';
+        upsert orgSettings;
+        
+        Test.startTest();
+        // Run the install script for orgs using HEDA 1.73
+        Test.testInstall(new STG_InstallScript(), new Version(1,73), true);
+        Test.stopTest();
+
+        Hierarchy_Settings__c updatedSettings = UTIL_CustomSettingsFacade.getSettings();
+        System.assertEquals('Fluent', updatedSettings.Default_Contact_Language_Fluency__c);
     }
 }

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -185,6 +185,10 @@ public without sharing class TDTM_DefaultConfig {
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
                 Class__c = 'CLAN_PrimaryLanguage_TDTM', Load_Order__c = 1, Object__c = 'Contact_Language__c',
                 Owned_by_Namespace__c = 'hed', Trigger_Action__c = 'AfterInsert;AfterUpdate;AfterDelete'));
+
+        handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
+                Class__c = 'CON_PrimaryLanguage_TDTM', Load_Order__c = 5, Object__c = 'Contact',
+                Owned_by_Namespace__c = 'hed', Trigger_Action__c = 'AfterInsert;AfterUpdate'));
         return handlers;
     }
 }

--- a/src/classes/TDTM_ProcessControl.cls
+++ b/src/classes/TDTM_ProcessControl.cls
@@ -67,7 +67,8 @@ public class TDTM_ProcessControl {
         PREN_ProgramPlan_TDTM_Before_Insert,
         PPlan_Primary_TDTM_After_Insert,
         PPlan_Primary_TDTM_After_Update,
-        CLAN_PrimaryLanguage_TDTM
+        CLAN_PrimaryLanguage_TDTM,
+        CON_PrimaryLanguage_TDTM
     }
 
     /*******************************************************************************************************

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -113,7 +113,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         hs.Affl_ProgEnroll_Status_Map__c = 'Current';
         hs.Affiliation_Record_Type_Enforced__c = false;
         hs.Administrative_Account_Record_Type__c = UTIL_Describe.getAdminAccRecTypeID();
-
+        hs.Default_Contact_Language_Fluency__c = 'Fluent';
     }
 
     /*******************************************************************************************************
@@ -153,6 +153,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         settings.Affl_ProgEnroll_Status_Map__c= mySettings.Affl_ProgEnroll_Status_Map__c;
         settings.Affiliation_Record_Type_Enforced__c = mySettings.Affiliation_Record_Type_Enforced__c;
         settings.Administrative_Account_Record_Type__c = mySettings.Administrative_Account_Record_Type__c;
+        settings.Default_Contact_Language_Fluency__c = mySettings.Default_Contact_Language_Fluency__c;
         
         orgSettings = settings;
         return settings;

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -113,7 +113,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         hs.Affl_ProgEnroll_Status_Map__c = 'Current';
         hs.Affiliation_Record_Type_Enforced__c = false;
         hs.Administrative_Account_Record_Type__c = UTIL_Describe.getAdminAccRecTypeID();
-        hs.Default_Contact_Language_Fluency__c = 'Fluent';
+        hs.Default_Contact_Language_Fluency__c = Label.stgFluent;
     }
 
     /*******************************************************************************************************

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -438,7 +438,6 @@ public class UTIL_Describe {
      * SObjectType and field, keyed by picklist label with a value of picklist value.
      * @param objectName Name of the object to retrieve picklist values for.
      * @param fieldName Name of the field to retrieve picklist values for.
-     * False if we want it to be the friendly name.
      * @return Map<String, String> Map of picklist labels to values for the object and field specified.
      */
     @AuraEnabled

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1133,8 +1133,7 @@
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>stgHelpDefaultContactLanguageFluency</shortDescription>
-        <value>The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
-This value overrides any default defined on the Fluency picklist for these automatically created records.</value>
+        <value>The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.</value>
     </labels>
     <labels>
         <fullName>stgHelpDefaultFacultyType</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -944,6 +944,14 @@
         <value>Ethnicity and Race Backfill for Contacts</value>
     </labels>
     <labels>
+        <fullName>stgFluent</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>stgFluent</shortDescription>
+        <value>Fluent</value>
+    </labels>
+    <labels>
         <fullName>stgHelpAccountModel</fullName>
         <categories>Settings</categories>
         <language>en_US</language>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -872,6 +872,14 @@
         <value>Course Description Copy Job Completed with a status of:</value>
     </labels>
     <labels>
+        <fullName>stgDefaultContactLanguageFluency</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>stgDefaultContactLanguageFluency</shortDescription>
+        <value>Default Contact Language Fluency</value>
+    </labels>
+    <labels>
         <fullName>stgDefaultFacultyTypeTitle</fullName>
         <categories>Settings</categories>
         <language>en_US</language>
@@ -1110,6 +1118,14 @@
         <protected>true</protected>
         <shortDescription>stgHelpCoursesDataMigrationUpdatePageLayouts</shortDescription>
         <value>After the process is complete, remember to update page layouts and other areas of the application that refer to the Description fields.</value>
+    </labels>
+    <labels>
+        <fullName>stgHelpDefaultContactLanguageFluency</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>stgHelpDefaultContactLanguageFluency</shortDescription>
+        <value>The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records.</value>
     </labels>
     <labels>
         <fullName>stgHelpDefaultFacultyType</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1133,7 +1133,8 @@
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>stgHelpDefaultContactLanguageFluency</shortDescription>
-        <value>The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records.</value>
+        <value>The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
+This value overrides any default defined on the Fluency picklist for these automatically created records.</value>
     </labels>
     <labels>
         <fullName>stgHelpDefaultFacultyType</fullName>

--- a/src/objectTranslations/Hierarchy_Settings__c-ca.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-ca.objectTranslation
@@ -103,8 +103,7 @@
         <name>Contacts_Addresses_Enabled__c</name>
     </fields>
     <fields>
-        <help><!-- The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
-This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
+        <help><!-- The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact. --></help>
         <label><!-- Default Contact Language Fluency --></label>
         <name>Default_Contact_Language_Fluency__c</name>
     </fields>

--- a/src/objectTranslations/Hierarchy_Settings__c-ca.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-ca.objectTranslation
@@ -103,7 +103,8 @@
         <name>Contacts_Addresses_Enabled__c</name>
     </fields>
     <fields>
-        <help><!-- The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
+        <help><!-- The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
+This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
         <label><!-- Default Contact Language Fluency --></label>
         <name>Default_Contact_Language_Fluency__c</name>
     </fields>

--- a/src/objectTranslations/Hierarchy_Settings__c-ca.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-ca.objectTranslation
@@ -103,6 +103,11 @@
         <name>Contacts_Addresses_Enabled__c</name>
     </fields>
     <fields>
+        <help><!-- The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
+        <label><!-- Default Contact Language Fluency --></label>
+        <name>Default_Contact_Language_Fluency__c</name>
+    </fields>
+    <fields>
         <help>Si es marca, el marc de maneig d&apos;errors de HEDA està desactivat.</help>
         <label>Desactiva el maneig d&apos;errors</label>
         <name>Disable_Error_Handling__c</name>

--- a/src/objectTranslations/Hierarchy_Settings__c-en_US.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-en_US.objectTranslation
@@ -103,8 +103,7 @@
         <name>Contacts_Addresses_Enabled__c</name>
     </fields>
     <fields>
-        <help><!-- The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
-This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
+        <help><!-- The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact. --></help>
         <label><!-- Default Contact Language Fluency --></label>
         <name>Default_Contact_Language_Fluency__c</name>
     </fields>

--- a/src/objectTranslations/Hierarchy_Settings__c-en_US.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-en_US.objectTranslation
@@ -103,6 +103,11 @@
         <name>Contacts_Addresses_Enabled__c</name>
     </fields>
     <fields>
+        <help><!-- The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
+        <label><!-- Default Contact Language Fluency --></label>
+        <name>Default_Contact_Language_Fluency__c</name>
+    </fields>
+    <fields>
         <help><!-- If checked, HEDA&apos;s error handling framework is disabled. --></help>
         <label><!-- Disable Error Handling --></label>
         <name>Disable_Error_Handling__c</name>

--- a/src/objectTranslations/Hierarchy_Settings__c-en_US.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-en_US.objectTranslation
@@ -103,7 +103,8 @@
         <name>Contacts_Addresses_Enabled__c</name>
     </fields>
     <fields>
-        <help><!-- The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
+        <help><!-- The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
+This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
         <label><!-- Default Contact Language Fluency --></label>
         <name>Default_Contact_Language_Fluency__c</name>
     </fields>

--- a/src/objectTranslations/Hierarchy_Settings__c-es.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-es.objectTranslation
@@ -103,8 +103,7 @@
         <name>Contacts_Addresses_Enabled__c</name>
     </fields>
     <fields>
-        <help><!-- The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
-This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
+        <help><!-- The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact. --></help>
         <label><!-- Default Contact Language Fluency --></label>
         <name>Default_Contact_Language_Fluency__c</name>
     </fields>

--- a/src/objectTranslations/Hierarchy_Settings__c-es.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-es.objectTranslation
@@ -103,6 +103,11 @@
         <name>Contacts_Addresses_Enabled__c</name>
     </fields>
     <fields>
+        <help><!-- The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
+        <label><!-- Default Contact Language Fluency --></label>
+        <name>Default_Contact_Language_Fluency__c</name>
+    </fields>
+    <fields>
         <help>Si se selecciona esta opción, se deshabilita el marco de trabajo de control de errores de HEDA.</help>
         <label>Deshabilitar control de errores</label>
         <name>Disable_Error_Handling__c</name>

--- a/src/objectTranslations/Hierarchy_Settings__c-es.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-es.objectTranslation
@@ -103,7 +103,8 @@
         <name>Contacts_Addresses_Enabled__c</name>
     </fields>
     <fields>
-        <help><!-- The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
+        <help><!-- The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
+This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
         <label><!-- Default Contact Language Fluency --></label>
         <name>Default_Contact_Language_Fluency__c</name>
     </fields>

--- a/src/objectTranslations/Hierarchy_Settings__c-fr.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-fr.objectTranslation
@@ -103,8 +103,7 @@
         <name>Contacts_Addresses_Enabled__c</name>
     </fields>
     <fields>
-        <help><!-- The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
-This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
+        <help><!-- The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact. --></help>
         <label><!-- Default Contact Language Fluency --></label>
         <name>Default_Contact_Language_Fluency__c</name>
     </fields>

--- a/src/objectTranslations/Hierarchy_Settings__c-fr.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-fr.objectTranslation
@@ -103,6 +103,11 @@
         <name>Contacts_Addresses_Enabled__c</name>
     </fields>
     <fields>
+        <help><!-- The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
+        <label><!-- Default Contact Language Fluency --></label>
+        <name>Default_Contact_Language_Fluency__c</name>
+    </fields>
+    <fields>
         <help>Si cette case est cochée, l&apos;infrastructure de gestion des erreurs de l&apos;architecture HEDA est désactivée.</help>
         <label>Désactiver la gestion des erreurs</label>
         <name>Disable_Error_Handling__c</name>

--- a/src/objectTranslations/Hierarchy_Settings__c-fr.objectTranslation
+++ b/src/objectTranslations/Hierarchy_Settings__c-fr.objectTranslation
@@ -103,7 +103,8 @@
         <name>Contacts_Addresses_Enabled__c</name>
     </fields>
     <fields>
-        <help><!-- The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
+        <help><!-- The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
+This value overrides any default defined on the Fluency picklist for these automatically created records. --></help>
         <label><!-- Default Contact Language Fluency --></label>
         <name>Default_Contact_Language_Fluency__c</name>
     </fields>

--- a/src/objects/Hierarchy_Settings__c.object
+++ b/src/objects/Hierarchy_Settings__c.object
@@ -209,11 +209,9 @@
     </fields>
     <fields>
         <fullName>Default_Contact_Language_Fluency__c</fullName>
-        <description>The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
-This value overrides any default defined on the Fluency picklist for these automatically created records.</description>
+        <description>The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.</description>
         <externalId>false</externalId>
-        <inlineHelpText>The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
-This value overrides any default defined on the Fluency picklist for these automatically created records.</inlineHelpText>
+        <inlineHelpText>The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.</inlineHelpText>
         <label>Default Contact Language Fluency</label>
         <length>255</length>
         <required>false</required>

--- a/src/objects/Hierarchy_Settings__c.object
+++ b/src/objects/Hierarchy_Settings__c.object
@@ -208,6 +208,18 @@
         <type>Checkbox</type>
     </fields>
     <fields>
+        <fullName>Default_Contact_Language_Fluency__c</fullName>
+        <description>The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records.</inlineHelpText>
+        <label>Default Contact Language Fluency</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>Disable_Error_Handling__c</fullName>
         <defaultValue>false</defaultValue>
         <description>If checked, HEDA&apos;s error handling framework is disabled.</description>

--- a/src/objects/Hierarchy_Settings__c.object
+++ b/src/objects/Hierarchy_Settings__c.object
@@ -209,9 +209,11 @@
     </fields>
     <fields>
         <fullName>Default_Contact_Language_Fluency__c</fullName>
-        <description>The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records.</description>
+        <description>The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
+This value overrides any default defined on the Fluency picklist for these automatically created records.</description>
         <externalId>false</externalId>
-        <inlineHelpText>The Fluency to set for all Contact Language records automatically created when users set the Primary Language lookup field on the Contact. This value overrides any default defined on the Fluency picklist for these automatically created records.</inlineHelpText>
+        <inlineHelpText>The Fluency value automatically set on newly created Contact Language records when users set the Primary Language lookup field on a Contact.
+This value overrides any default defined on the Fluency picklist for these automatically created records.</inlineHelpText>
         <label>Default Contact Language Fluency</label>
         <length>255</length>
         <required>false</required>

--- a/src/package.xml
+++ b/src/package.xml
@@ -54,6 +54,8 @@
         <members>CON_Preferred_TEST</members>
         <members>CON_PrimaryAffls_TDTM</members>
         <members>CON_PrimaryAffls_TEST</members>
+        <members>CON_PrimaryLanguage_TDTM</members>
+        <members>CON_PrimaryLanguage_TEST</members>
         <members>COUR_DescriptionCopy_BATCH</members>
         <members>COUR_DescriptionCopy_TEST</members>
         <members>ERR_AsyncErrors</members>
@@ -330,6 +332,7 @@
         <members>Hierarchy_Settings__c.Async_Error_Check_Last_Run__c</members>
         <members>Hierarchy_Settings__c.Automatic_Household_Naming__c</members>
         <members>Hierarchy_Settings__c.Contacts_Addresses_Enabled__c</members>
+        <members>Hierarchy_Settings__c.Default_Contact_Language_Fluency__c</members>
         <members>Hierarchy_Settings__c.Disable_Error_Handling__c</members>
         <members>Hierarchy_Settings__c.Disable_Preferred_Email_Enforcement__c</members>
         <members>Hierarchy_Settings__c.Enable_Course_Connections__c</members>
@@ -532,6 +535,7 @@
         <members>stgContactMultiAddressesEnabled</members>
         <members>stgCourseDescriptionCopyEmailBody</members>
         <members>stgCourseDescriptionCopyEmailSubject</members>
+        <members>stgDefaultContactLanguageFluency</members>
         <members>stgDefaultFacultyTypeTitle</members>
         <members>stgDefaultStudentTypeTitle</members>
         <members>stgDisableErrorHandlingTitle</members>
@@ -562,6 +566,7 @@
         <members>stgHelpCoursesDataMigrationCopiesValues</members>
         <members>stgHelpCoursesDataMigrationDontOverwrite</members>
         <members>stgHelpCoursesDataMigrationUpdatePageLayouts</members>
+        <members>stgHelpDefaultContactLanguageFluency</members>
         <members>stgHelpDefaultFacultyType</members>
         <members>stgHelpDefaultStudentType</members>
         <members>stgHelpEnableCourseConnBeforeBackfill</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -544,6 +544,7 @@
         <members>stgErrorNotiTo</members>
         <members>stgErrorNotifRecipientsTitle</members>
         <members>stgEthnicityRaceBackfillContacts</members>
+        <members>stgFluent</members>
         <members>stgHelpAccountModel</members>
         <members>stgHelpAccoutsDeletedIfChildContactsDeleted</members>
         <members>stgHelpAddressAccRecType</members>

--- a/src/translations/ca.translation
+++ b/src/translations/ca.translation
@@ -477,6 +477,10 @@
         <name>stgEthnicityRaceBackfillContacts</name>
     </customLabels>
     <customLabels>
+        <label><!-- stgFluent --></label>
+        <name>stgFluent</name>
+    </customLabels>
+    <customLabels>
         <label>Configuració del model de compte. &quot;Administratiu&quot; és el model recomanat.</label>
         <name>stgHelpAccountModel</name>
     </customLabels>

--- a/src/translations/ca.translation
+++ b/src/translations/ca.translation
@@ -441,6 +441,10 @@
         <name>stgCourseDescriptionCopyEmailSubject</name>
     </customLabels>
     <customLabels>
+        <label><!-- stgDefaultContactLanguageFluency --></label>
+        <name>stgDefaultContactLanguageFluency</name>
+    </customLabels>
+    <customLabels>
         <label>Tipus predeterminat de registre de la facultat:</label>
         <name>stgDefaultFacultyTypeTitle</name>
     </customLabels>
@@ -559,6 +563,10 @@
     <customLabels>
         <label>Un cop finalitzat el procés, recordeu actualitzar els dissenys de pàgines i altres àrees de l&apos;aplicació que fan referència als camps de la descripció.</label>
         <name>stgHelpCoursesDataMigrationUpdatePageLayouts</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- stgHelpDefaultContactLanguageFluency --></label>
+        <name>stgHelpDefaultContactLanguageFluency</name>
     </customLabels>
     <customLabels>
         <label>El tipus de gravació predeterminat quan es creen connexions de curs per a un membre de la facultat.</label>

--- a/src/translations/es.translation
+++ b/src/translations/es.translation
@@ -441,6 +441,10 @@
         <name>stgCourseDescriptionCopyEmailSubject</name>
     </customLabels>
     <customLabels>
+        <label><!-- stgDefaultContactLanguageFluency --></label>
+        <name>stgDefaultContactLanguageFluency</name>
+    </customLabels>
+    <customLabels>
         <label>Tipo de registro de profesor predeterminado:</label>
         <name>stgDefaultFacultyTypeTitle</name>
     </customLabels>
@@ -559,6 +563,10 @@
     <customLabels>
         <label><!-- stgHelpCoursesDataMigrationUpdatePageLayouts --></label>
         <name>stgHelpCoursesDataMigrationUpdatePageLayouts</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- stgHelpDefaultContactLanguageFluency --></label>
+        <name>stgHelpDefaultContactLanguageFluency</name>
     </customLabels>
     <customLabels>
         <label>El tipo de registro predeterminado cuando se crean Conexiones de curso para un profesor.</label>

--- a/src/translations/es.translation
+++ b/src/translations/es.translation
@@ -477,6 +477,10 @@
         <name>stgEthnicityRaceBackfillContacts</name>
     </customLabels>
     <customLabels>
+        <label><!-- stgFluent --></label>
+        <name>stgFluent</name>
+    </customLabels>
+    <customLabels>
         <label>Configuración del modelo de cuenta. Administrativo es el modelo recomendado.</label>
         <name>stgHelpAccountModel</name>
     </customLabels>

--- a/src/translations/fr.translation
+++ b/src/translations/fr.translation
@@ -477,6 +477,10 @@
         <name>stgEthnicityRaceBackfillContacts</name>
     </customLabels>
     <customLabels>
+        <label><!-- stgFluent --></label>
+        <name>stgFluent</name>
+    </customLabels>
+    <customLabels>
         <label>Définition du modèle de compte. Le modèle recommandé est « Administratif ».</label>
         <name>stgHelpAccountModel</name>
     </customLabels>

--- a/src/translations/fr.translation
+++ b/src/translations/fr.translation
@@ -441,6 +441,10 @@
         <name>stgCourseDescriptionCopyEmailSubject</name>
     </customLabels>
     <customLabels>
+        <label><!-- stgDefaultContactLanguageFluency --></label>
+        <name>stgDefaultContactLanguageFluency</name>
+    </customLabels>
+    <customLabels>
         <label>Type d&apos;enregistrement de professeur par défaut :</label>
         <name>stgDefaultFacultyTypeTitle</name>
     </customLabels>
@@ -559,6 +563,10 @@
     <customLabels>
         <label>Une fois le processus terminé, pensez à mettre à jour les présentations de page et les autres zones de l&apos;application qui référencent les champs Description.</label>
         <name>stgHelpCoursesDataMigrationUpdatePageLayouts</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- stgHelpDefaultContactLanguageFluency --></label>
+        <name>stgHelpDefaultContactLanguageFluency</name>
     </customLabels>
     <customLabels>
         <label>Le type d&apos;enregistrement par défaut lors de la création de Connexions aux cours pour un membre professeur.</label>


### PR DESCRIPTION
# Critical Changes

# Changes
## Setting a Primary Contact Language
* When you change the language specified on the "Primary Language" field on a Contact, we also set the Contact Language record that corresponds to the newly selected language to be Primary. If a Contact Language record doesn't exist for that language, one is created and is set to Primary. If a different Contact Language record was previously identified as Primary, we clear the "Primary Language" checkbox on that record.
* When a new Contact Language record is created in this manner, define its "Fluency" value by updating "Default Primary Language Fluency" on the "Accounts and Contacts" tab in the HEDA Settings.
* These updates expand upon the Primary Contact Language functionality we delivered in our last release, 1.74.

# Issues Closed
Closes #746 

# New Metadata
* Class: `CON_PrimaryLanguage_TDTM.cls`
* Class: `CON_PrimaryLanguage_TEST.cls`
* Custom Label: `stgDefaultContactLanguageFluency`
* Custom Label: `stgFluent`
* Custom Label: `stgHelpDefaultContactLanguageFluency`
* New `Hierarchy_Settings__c` field: `Default_Contact_Language_Fluency__c`

# Deleted Metadata

# Testing Notes
