### PR TITLE
Add a prerelease org config

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -280,6 +280,8 @@ orgs:
         dev_namespaced:
             config_file: orgs/dev.json
             namespaced: True
+        prerelease:
+            config_file: orgs/prerelease.json
 
 plans:
     install:

--- a/orgs/prerelease.json
+++ b/orgs/prerelease.json
@@ -1,0 +1,12 @@
+{
+  "orgName": "HEDA - Prerelease Dev Workspace",
+  "edition": "Developer",
+  "instance": "CS46",
+  "orgPreferences" : {
+    "enabled": [
+      "S1DesktopEnabled",
+      "Translation",
+      "ChatterEnabled"
+    ]
+  }
+}

--- a/orgs/prerelease.json
+++ b/orgs/prerelease.json
@@ -1,5 +1,5 @@
 {
-  "orgName": "HEDA - Prerelease Dev Workspace",
+  "orgName": "EDA - Prerelease Dev Workspace",
   "edition": "Developer",
   "instance": "CS46",
   "orgPreferences" : {


### PR DESCRIPTION
This makes it possible to get a scratch org on the prerelease version of Salesforce by using `--org prerelease`.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
