### PR TITLE
fix: labels for Non-Degree translations match case of field

### DIFF
--- a/force-app/main/default/objectTranslations/Opportunity-ca/Desired_Degree_Level__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Opportunity-ca/Desired_Degree_Level__c.fieldTranslation-meta.xml
@@ -1,22 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help><!-- The level of the desired degree related to this Opportunity. --></help>
-    <label><!-- Desired Degree Level --></label>
-    <name>Desired_Degree_Level__c</name>
-    <picklistValues>
-        <masterLabel>Certification</masterLabel>
-        <translation><!-- Certification --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Graduate</masterLabel>
-        <translation><!-- Graduate --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Non-degree</masterLabel>
-        <translation><!-- Non-degree --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Undergraduate</masterLabel>
-        <translation><!-- Undergraduate --></translation>
-    </picklistValues>
+  <help>
+    <!-- The level of the desired degree related to this Opportunity. -->
+  </help>
+  <label>
+    <!-- Desired Degree Level -->
+  </label>
+  <name>Desired_Degree_Level__c</name>
+  <picklistValues>
+    <masterLabel>Certification</masterLabel>
+    <translation>
+      <!-- Certification -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Graduate</masterLabel>
+    <translation>
+      <!-- Graduate -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Non-Degree</masterLabel>
+    <translation>
+      <!-- Non-degree -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Undergraduate</masterLabel>
+    <translation>
+      <!-- Undergraduate -->
+    </translation>
+  </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Opportunity-de/Desired_Degree_Level__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Opportunity-de/Desired_Degree_Level__c.fieldTranslation-meta.xml
@@ -1,22 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help><!-- The level of the desired degree related to this Opportunity. --></help>
-    <label><!-- Desired Degree Level --></label>
-    <name>Desired_Degree_Level__c</name>
-    <picklistValues>
-        <masterLabel>Certification</masterLabel>
-        <translation><!-- Certification --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Graduate</masterLabel>
-        <translation><!-- Graduate --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Non-degree</masterLabel>
-        <translation><!-- Non-degree --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Undergraduate</masterLabel>
-        <translation><!-- Undergraduate --></translation>
-    </picklistValues>
+  <help>
+    <!-- The level of the desired degree related to this Opportunity. -->
+  </help>
+  <label>
+    <!-- Desired Degree Level -->
+  </label>
+  <name>Desired_Degree_Level__c</name>
+  <picklistValues>
+    <masterLabel>Certification</masterLabel>
+    <translation>
+      <!-- Certification -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Graduate</masterLabel>
+    <translation>
+      <!-- Graduate -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Non-Degree</masterLabel>
+    <translation>
+      <!-- Non-degree -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Undergraduate</masterLabel>
+    <translation>
+      <!-- Undergraduate -->
+    </translation>
+  </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Opportunity-en_GB/Desired_Degree_Level__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Opportunity-en_GB/Desired_Degree_Level__c.fieldTranslation-meta.xml
@@ -1,22 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help><!-- The level of the desired degree related to this Opportunity. --></help>
-    <label><!-- Desired Degree Level --></label>
-    <name>Desired_Degree_Level__c</name>
-    <picklistValues>
-        <masterLabel>Certification</masterLabel>
-        <translation><!-- Certification --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Graduate</masterLabel>
-        <translation><!-- Graduate --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Non-degree</masterLabel>
-        <translation><!-- Non-degree --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Undergraduate</masterLabel>
-        <translation><!-- Undergraduate --></translation>
-    </picklistValues>
+  <help>
+    <!-- The level of the desired degree related to this Opportunity. -->
+  </help>
+  <label>
+    <!-- Desired Degree Level -->
+  </label>
+  <name>Desired_Degree_Level__c</name>
+  <picklistValues>
+    <masterLabel>Certification</masterLabel>
+    <translation>
+      <!-- Certification -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Graduate</masterLabel>
+    <translation>
+      <!-- Graduate -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Non-Degree</masterLabel>
+    <translation>
+      <!-- Non-degree -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Undergraduate</masterLabel>
+    <translation>
+      <!-- Undergraduate -->
+    </translation>
+  </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Opportunity-es/Desired_Degree_Level__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Opportunity-es/Desired_Degree_Level__c.fieldTranslation-meta.xml
@@ -1,22 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help><!-- The level of the desired degree related to this Opportunity. --></help>
-    <label><!-- Desired Degree Level --></label>
-    <name>Desired_Degree_Level__c</name>
-    <picklistValues>
-        <masterLabel>Certification</masterLabel>
-        <translation><!-- Certification --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Graduate</masterLabel>
-        <translation><!-- Graduate --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Non-degree</masterLabel>
-        <translation><!-- Non-degree --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Undergraduate</masterLabel>
-        <translation><!-- Undergraduate --></translation>
-    </picklistValues>
+  <help>
+    <!-- The level of the desired degree related to this Opportunity. -->
+  </help>
+  <label>
+    <!-- Desired Degree Level -->
+  </label>
+  <name>Desired_Degree_Level__c</name>
+  <picklistValues>
+    <masterLabel>Certification</masterLabel>
+    <translation>
+      <!-- Certification -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Graduate</masterLabel>
+    <translation>
+      <!-- Graduate -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Non-Degree</masterLabel>
+    <translation>
+      <!-- Non-degree -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Undergraduate</masterLabel>
+    <translation>
+      <!-- Undergraduate -->
+    </translation>
+  </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Opportunity-es_MX/Desired_Degree_Level__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Opportunity-es_MX/Desired_Degree_Level__c.fieldTranslation-meta.xml
@@ -1,22 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help><!-- The level of the desired degree related to this Opportunity. --></help>
-    <label><!-- Desired Degree Level --></label>
-    <name>Desired_Degree_Level__c</name>
-    <picklistValues>
-        <masterLabel>Certification</masterLabel>
-        <translation><!-- Certification --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Graduate</masterLabel>
-        <translation><!-- Graduate --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Non-degree</masterLabel>
-        <translation><!-- Non-degree --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Undergraduate</masterLabel>
-        <translation><!-- Undergraduate --></translation>
-    </picklistValues>
+  <help>
+    <!-- The level of the desired degree related to this Opportunity. -->
+  </help>
+  <label>
+    <!-- Desired Degree Level -->
+  </label>
+  <name>Desired_Degree_Level__c</name>
+  <picklistValues>
+    <masterLabel>Certification</masterLabel>
+    <translation>
+      <!-- Certification -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Graduate</masterLabel>
+    <translation>
+      <!-- Graduate -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Non-Degree</masterLabel>
+    <translation>
+      <!-- Non-degree -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Undergraduate</masterLabel>
+    <translation>
+      <!-- Undergraduate -->
+    </translation>
+  </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Opportunity-fi/Desired_Degree_Level__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Opportunity-fi/Desired_Degree_Level__c.fieldTranslation-meta.xml
@@ -1,22 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help><!-- The level of the desired degree related to this Opportunity. --></help>
-    <label><!-- Desired Degree Level --></label>
-    <name>Desired_Degree_Level__c</name>
-    <picklistValues>
-        <masterLabel>Certification</masterLabel>
-        <translation><!-- Certification --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Graduate</masterLabel>
-        <translation><!-- Graduate --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Non-degree</masterLabel>
-        <translation><!-- Non-degree --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Undergraduate</masterLabel>
-        <translation><!-- Undergraduate --></translation>
-    </picklistValues>
+  <help>
+    <!-- The level of the desired degree related to this Opportunity. -->
+  </help>
+  <label>
+    <!-- Desired Degree Level -->
+  </label>
+  <name>Desired_Degree_Level__c</name>
+  <picklistValues>
+    <masterLabel>Certification</masterLabel>
+    <translation>
+      <!-- Certification -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Graduate</masterLabel>
+    <translation>
+      <!-- Graduate -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Non-Degree</masterLabel>
+    <translation>
+      <!-- Non-degree -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Undergraduate</masterLabel>
+    <translation>
+      <!-- Undergraduate -->
+    </translation>
+  </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Opportunity-fr/Desired_Degree_Level__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Opportunity-fr/Desired_Degree_Level__c.fieldTranslation-meta.xml
@@ -1,22 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help><!-- The level of the desired degree related to this Opportunity. --></help>
-    <label><!-- Desired Degree Level --></label>
-    <name>Desired_Degree_Level__c</name>
-    <picklistValues>
-        <masterLabel>Certification</masterLabel>
-        <translation><!-- Certification --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Graduate</masterLabel>
-        <translation><!-- Graduate --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Non-degree</masterLabel>
-        <translation><!-- Non-degree --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Undergraduate</masterLabel>
-        <translation><!-- Undergraduate --></translation>
-    </picklistValues>
+  <help>
+    <!-- The level of the desired degree related to this Opportunity. -->
+  </help>
+  <label>
+    <!-- Desired Degree Level -->
+  </label>
+  <name>Desired_Degree_Level__c</name>
+  <picklistValues>
+    <masterLabel>Certification</masterLabel>
+    <translation>
+      <!-- Certification -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Graduate</masterLabel>
+    <translation>
+      <!-- Graduate -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Non-Degree</masterLabel>
+    <translation>
+      <!-- Non-degree -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Undergraduate</masterLabel>
+    <translation>
+      <!-- Undergraduate -->
+    </translation>
+  </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Opportunity-ja/Desired_Degree_Level__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Opportunity-ja/Desired_Degree_Level__c.fieldTranslation-meta.xml
@@ -1,22 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help><!-- The level of the desired degree related to this Opportunity. --></help>
-    <label><!-- Desired Degree Level --></label>
-    <name>Desired_Degree_Level__c</name>
-    <picklistValues>
-        <masterLabel>Certification</masterLabel>
-        <translation><!-- Certification --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Graduate</masterLabel>
-        <translation><!-- Graduate --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Non-degree</masterLabel>
-        <translation><!-- Non-degree --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Undergraduate</masterLabel>
-        <translation><!-- Undergraduate --></translation>
-    </picklistValues>
+  <help>
+    <!-- The level of the desired degree related to this Opportunity. -->
+  </help>
+  <label>
+    <!-- Desired Degree Level -->
+  </label>
+  <name>Desired_Degree_Level__c</name>
+  <picklistValues>
+    <masterLabel>Certification</masterLabel>
+    <translation>
+      <!-- Certification -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Graduate</masterLabel>
+    <translation>
+      <!-- Graduate -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Non-Degree</masterLabel>
+    <translation>
+      <!-- Non-degree -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Undergraduate</masterLabel>
+    <translation>
+      <!-- Undergraduate -->
+    </translation>
+  </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Opportunity-nl_NL/Desired_Degree_Level__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Opportunity-nl_NL/Desired_Degree_Level__c.fieldTranslation-meta.xml
@@ -1,22 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help><!-- The level of the desired degree related to this Opportunity. --></help>
-    <label><!-- Desired Degree Level --></label>
-    <name>Desired_Degree_Level__c</name>
-    <picklistValues>
-        <masterLabel>Certification</masterLabel>
-        <translation><!-- Certification --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Graduate</masterLabel>
-        <translation><!-- Graduate --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Non-degree</masterLabel>
-        <translation><!-- Non-degree --></translation>
-    </picklistValues>
-    <picklistValues>
-        <masterLabel>Undergraduate</masterLabel>
-        <translation><!-- Undergraduate --></translation>
-    </picklistValues>
+  <help>
+    <!-- The level of the desired degree related to this Opportunity. -->
+  </help>
+  <label>
+    <!-- Desired Degree Level -->
+  </label>
+  <name>Desired_Degree_Level__c</name>
+  <picklistValues>
+    <masterLabel>Certification</masterLabel>
+    <translation>
+      <!-- Certification -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Graduate</masterLabel>
+    <translation>
+      <!-- Graduate -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Non-Degree</masterLabel>
+    <translation>
+      <!-- Non-degree -->
+    </translation>
+  </picklistValues>
+  <picklistValues>
+    <masterLabel>Undergraduate</masterLabel>
+    <translation>
+      <!-- Undergraduate -->
+    </translation>
+  </picklistValues>
 </CustomFieldTranslation>


### PR DESCRIPTION
Translations `masterLabel` for Desired_Degree_Level__c are had `Non-Degree` while the picklist had Non-degree` so that they throw deploy errors.

This could have also been fixed by changing the picklist's label instead of making all the translations match, but that has more potential for breaking other things.

# Critical Changes

# Changes
- We fixed a bug that was causing deploy errors due to translations for Desired_Degree_Level__c not matching the case of the picklist options.

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
