### PR TITLE
Custom settings modification and batch jobs now require the Customize Application permission.

### DIFF
--- a/force-app/main/default/classes/STG_Base_CTRL.cls
+++ b/force-app/main/default/classes/STG_Base_CTRL.cls
@@ -77,7 +77,7 @@ public with sharing class STG_Base_CTRL {
      **/
     @AuraEnabled
     public static void saveHierarchySettings(Hierarchy_Settings__c hierarchySettings) {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         /* sfca-disable-next-line ApexFlsViolationRule */
         upsert hierarchySettings;
     }
@@ -89,7 +89,7 @@ public with sharing class STG_Base_CTRL {
      **/
     @AuraEnabled
     public static void saveAfflMappings(List<Affl_Mappings__c> mappings) {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         //upsert afflMappings; We cannot do this because apparently the type information gets lost when called from the client.
         List<Affl_Mappings__c> toInsert = new List<Affl_Mappings__c>();
         List<Affl_Mappings__c> toUpdate = new List<Affl_Mappings__c>();
@@ -113,7 +113,7 @@ public with sharing class STG_Base_CTRL {
      **/
     @AuraEnabled
     public static void saveReciprocalSettings(List<Relationship_Lookup__c> reciprocalSettings) {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         //upsert reciprocalSettings; We cannot do this because apparently the type information gets lost when called from the client.
         List<Relationship_Lookup__c> toInsert = new List<Relationship_Lookup__c>();
         List<Relationship_Lookup__c> toUpdate = new List<Relationship_Lookup__c>();
@@ -137,7 +137,7 @@ public with sharing class STG_Base_CTRL {
      **/
     @AuraEnabled
     public static void saveAutoCreateSettings(List<Relationship_Auto_Create__c> autoCreateSettings) {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         //upsert autoCreateSettings; We cannot do this because apparently the type information gets lost when called from the client.
         List<Relationship_Auto_Create__c> toInsert = new List<Relationship_Auto_Create__c>();
         List<Relationship_Auto_Create__c> toUpdate = new List<Relationship_Auto_Create__c>();
@@ -171,7 +171,7 @@ public with sharing class STG_Base_CTRL {
         String autoEnrollStatus,
         String autoEnrollRole
     ) {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         Affl_Mappings__c newMapping = new Affl_Mappings__c(
             Name = accRecType,
             Account_Record_Type__c = accRecType,
@@ -198,7 +198,7 @@ public with sharing class STG_Base_CTRL {
      **/
     @AuraEnabled
     public static String newReciprocalSetting(String name, String male, String female, String neutral, Boolean active) {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         Relationship_Lookup__c newSetting = new Relationship_Lookup__c(
             Name = name,
             Female__c = female,
@@ -223,7 +223,7 @@ public with sharing class STG_Base_CTRL {
      **/
     @AuraEnabled
     public static String newAutoCreateSetting(String obj, String field, String relType, String campaigns) {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         Relationship_Auto_Create__c newSetting = new Relationship_Auto_Create__c(
             Name = 'AutoCreateRel-' + system.now(),
             Object__c = obj,
@@ -244,7 +244,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static void deleteAfflMappingRecord(String idString) {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         ID idType = ID.valueOf(IdString);
         /* sfca-disable-next-line ApexFlsViolationRule */
         delete [SELECT Id FROM Affl_Mappings__c WHERE Id = :idType];
@@ -264,7 +264,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static void deleteRecSettingRecord(String idString) {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         ID idType = ID.valueOf(IdString);
         /* sfca-disable-next-line ApexFlsViolationRule */
         delete [SELECT Id FROM Relationship_Lookup__c WHERE Id = :idType];
@@ -284,7 +284,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static void deleteAutoCreateRecord(String idString) {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         ID idType = ID.valueOf(IdString);
         /* sfca-disable-next-line ApexFlsViolationRule */
         delete [SELECT Id FROM Relationship_Auto_Create__c WHERE Id = :idType];
@@ -304,7 +304,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static Id executeEthnicityRaceBatch() {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         CON_EthnicityRace_BATCH contbatch = new CON_EthnicityRace_BATCH();
         Id jobId = Database.executeBatch(contbatch, 200);
         if (jobId == null) {
@@ -320,7 +320,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static Id executePreferredEmailCleanUpBatch() {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         CON_Email_BATCH contbatch = new CON_Email_BATCH(null);
         Id jobId = Database.executeBatch(contbatch, 200);
         if (jobId == null) {
@@ -336,7 +336,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static Id executeRefreshHouseholdAccountBatch() {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         Boolean automaticHHNamingEnabled = UTIL_CustomSettingsFacade.getSettings().Automatic_Household_Naming__c;
         if (!automaticHHNamingEnabled) {
             Hierarchy_Settings__c orgSettings = UTIL_CustomSettingsFacade.getSettings();
@@ -360,7 +360,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static Id executeRefreshAdminAccountBatch() {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         ACCT_AdministrativeNameRefresh_BATCH accountRefresh = new ACCT_AdministrativeNameRefresh_BATCH();
         Id jobId = Database.executeBatch(accountRefresh, 200);
         if (jobId == null) {

--- a/force-app/main/default/classes/STG_Base_CTRL.cls
+++ b/force-app/main/default/classes/STG_Base_CTRL.cls
@@ -77,6 +77,7 @@ public with sharing class STG_Base_CTRL {
      **/
     @AuraEnabled
     public static void saveHierarchySettings(Hierarchy_Settings__c hierarchySettings) {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         /* sfca-disable-next-line ApexFlsViolationRule */
         upsert hierarchySettings;
     }
@@ -88,6 +89,7 @@ public with sharing class STG_Base_CTRL {
      **/
     @AuraEnabled
     public static void saveAfflMappings(List<Affl_Mappings__c> mappings) {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         //upsert afflMappings; We cannot do this because apparently the type information gets lost when called from the client.
         List<Affl_Mappings__c> toInsert = new List<Affl_Mappings__c>();
         List<Affl_Mappings__c> toUpdate = new List<Affl_Mappings__c>();
@@ -111,6 +113,7 @@ public with sharing class STG_Base_CTRL {
      **/
     @AuraEnabled
     public static void saveReciprocalSettings(List<Relationship_Lookup__c> reciprocalSettings) {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         //upsert reciprocalSettings; We cannot do this because apparently the type information gets lost when called from the client.
         List<Relationship_Lookup__c> toInsert = new List<Relationship_Lookup__c>();
         List<Relationship_Lookup__c> toUpdate = new List<Relationship_Lookup__c>();
@@ -134,6 +137,7 @@ public with sharing class STG_Base_CTRL {
      **/
     @AuraEnabled
     public static void saveAutoCreateSettings(List<Relationship_Auto_Create__c> autoCreateSettings) {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         //upsert autoCreateSettings; We cannot do this because apparently the type information gets lost when called from the client.
         List<Relationship_Auto_Create__c> toInsert = new List<Relationship_Auto_Create__c>();
         List<Relationship_Auto_Create__c> toUpdate = new List<Relationship_Auto_Create__c>();
@@ -167,6 +171,7 @@ public with sharing class STG_Base_CTRL {
         String autoEnrollStatus,
         String autoEnrollRole
     ) {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         Affl_Mappings__c newMapping = new Affl_Mappings__c(
             Name = accRecType,
             Account_Record_Type__c = accRecType,
@@ -193,6 +198,7 @@ public with sharing class STG_Base_CTRL {
      **/
     @AuraEnabled
     public static String newReciprocalSetting(String name, String male, String female, String neutral, Boolean active) {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         Relationship_Lookup__c newSetting = new Relationship_Lookup__c(
             Name = name,
             Female__c = female,
@@ -217,6 +223,7 @@ public with sharing class STG_Base_CTRL {
      **/
     @AuraEnabled
     public static String newAutoCreateSetting(String obj, String field, String relType, String campaigns) {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         Relationship_Auto_Create__c newSetting = new Relationship_Auto_Create__c(
             Name = 'AutoCreateRel-' + system.now(),
             Object__c = obj,
@@ -237,6 +244,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static void deleteAfflMappingRecord(String idString) {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         ID idType = ID.valueOf(IdString);
         /* sfca-disable-next-line ApexFlsViolationRule */
         delete [SELECT Id FROM Affl_Mappings__c WHERE Id = :idType];
@@ -256,6 +264,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static void deleteRecSettingRecord(String idString) {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         ID idType = ID.valueOf(IdString);
         /* sfca-disable-next-line ApexFlsViolationRule */
         delete [SELECT Id FROM Relationship_Lookup__c WHERE Id = :idType];
@@ -275,6 +284,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static void deleteAutoCreateRecord(String idString) {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         ID idType = ID.valueOf(IdString);
         /* sfca-disable-next-line ApexFlsViolationRule */
         delete [SELECT Id FROM Relationship_Auto_Create__c WHERE Id = :idType];
@@ -294,6 +304,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static Id executeEthnicityRaceBatch() {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         CON_EthnicityRace_BATCH contbatch = new CON_EthnicityRace_BATCH();
         Id jobId = Database.executeBatch(contbatch, 200);
         if (jobId == null) {
@@ -309,6 +320,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static Id executePreferredEmailCleanUpBatch() {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         CON_Email_BATCH contbatch = new CON_Email_BATCH(null);
         Id jobId = Database.executeBatch(contbatch, 200);
         if (jobId == null) {
@@ -324,6 +336,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static Id executeRefreshHouseholdAccountBatch() {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         Boolean automaticHHNamingEnabled = UTIL_CustomSettingsFacade.getSettings().Automatic_Household_Naming__c;
         if (!automaticHHNamingEnabled) {
             Hierarchy_Settings__c orgSettings = UTIL_CustomSettingsFacade.getSettings();
@@ -347,6 +360,7 @@ public with sharing class STG_Base_CTRL {
      */
     @AuraEnabled
     public static Id executeRefreshAdminAccountBatch() {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         ACCT_AdministrativeNameRefresh_BATCH accountRefresh = new ACCT_AdministrativeNameRefresh_BATCH();
         Id jobId = Database.executeBatch(accountRefresh, 200);
         if (jobId == null) {
@@ -354,5 +368,14 @@ public with sharing class STG_Base_CTRL {
         } else {
             return jobId;
         }
+    }
+
+    /*****************************************************************************
+     * @description Retrieves an instance of the UserPermissionService.
+     * @return The instance of UserPermissionService.
+     ******************************************************************************/
+    @TestVisible
+    private static UserPermissionService locateUserPermissionService() {
+        return UserPermissionService.getInstance();
     }
 }

--- a/force-app/main/default/classes/STG_Base_CTRL_TEST.cls
+++ b/force-app/main/default/classes/STG_Base_CTRL_TEST.cls
@@ -68,6 +68,8 @@ private class STG_Base_CTRL_TEST {
 
     @isTest
     public static void saveAfflMappings() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
+        
         List<Affl_Mappings__c> afflMappings = new List<Affl_Mappings__c>();
         afflMappings.add(
             new Affl_Mappings__c(
@@ -95,6 +97,8 @@ private class STG_Base_CTRL_TEST {
 
     @isTest
     public static void newAfflMappings() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
+        
         Test.startTest();
         STG_Base_CTRL.newAfflMpg(
             'Educational Institution',
@@ -116,6 +120,8 @@ private class STG_Base_CTRL_TEST {
 
     @isTest
     public static void deleteAfflMappings() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
+        
         STG_Base_CTRL.newAfflMpg(
             'Educational Institution',
             'Primary Educational Institution',
@@ -162,6 +168,8 @@ private class STG_Base_CTRL_TEST {
 
     @isTest
     public static void saveReciprocalSettings() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
+        
         List<Relationship_Lookup__c> reciprocalSettings = new List<Relationship_Lookup__c>();
         reciprocalSettings.add(
             new Relationship_Lookup__c(
@@ -190,6 +198,8 @@ private class STG_Base_CTRL_TEST {
 
     @isTest
     public static void newDeleteReciprocalSetting() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
+        
         Test.startTest();
         STG_Base_CTRL.newReciprocalSetting('test' + system.now(), 'husband', 'wife', 'spouse', true);
         Test.stopTest();
@@ -229,6 +239,8 @@ private class STG_Base_CTRL_TEST {
 
     @isTest
     public static void saveAutoCreateSettings() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
+        
         List<Relationship_Auto_Create__c> autoCreateSettings = new List<Relationship_Auto_Create__c>();
         autoCreateSettings.add(
             new Relationship_Auto_Create__c(
@@ -251,6 +263,8 @@ private class STG_Base_CTRL_TEST {
 
     @isTest
     public static void newDeleteAutoCreateSetting() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
+        
         Test.startTest();
         STG_Base_CTRL.newAutoCreateSetting('Contact', 'coworker__c', 'coworker', '');
         Test.stopTest();
@@ -273,6 +287,8 @@ private class STG_Base_CTRL_TEST {
 
     @isTest
     public static void saveHierarchySettings() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
+        
         recTypesSetup();
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c();
         hs.Account_Processor__c = 'Administrative';
@@ -294,6 +310,8 @@ private class STG_Base_CTRL_TEST {
     /*** Ethnicity Race batch ***/
     @isTest
     public static void executeEthnicityRaceBatch() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
+        
         Test.startTest();
         Id batchId = STG_Base_CTRL.executeEthnicityRaceBatch();
         Test.stopTest();
@@ -305,6 +323,8 @@ private class STG_Base_CTRL_TEST {
     /*** Ethnicity Race batch ***/
     @isTest
     public static void executePreferredEmailCleanUpBatch() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
+        
         Test.startTest();
         Id batchId = STG_Base_CTRL.executePreferredEmailCleanUpBatch();
         Test.stopTest();
@@ -318,6 +338,8 @@ private class STG_Base_CTRL_TEST {
      */
     @isTest
     public static void checkRefreshHouseholdAccountBatch() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
+        
         Hierarchy_Settings__c hs = UTIL_CustomSettingsFacade.getSettingsForTests(
             new Hierarchy_Settings__c(
                 Account_Processor__c = UTIL_Describe.getHhAccRecTypeID(),
@@ -339,6 +361,8 @@ private class STG_Base_CTRL_TEST {
      */
     @isTest
     public static void checkRefreshAdministrativeAccountBatch() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
+        
         UTIL_CustomSettingsFacade.getSettingsForTests(
             new Hierarchy_Settings__c(
                 Account_Processor__c = UTIL_Describe.getCustomAdminAccRecTypeID(),
@@ -357,5 +381,18 @@ private class STG_Base_CTRL_TEST {
         String[] parts = String.valueOf(STG_Base_CTRL.class).split('\\.', 2);
         String testNamespace = parts.size() == 2 ? parts[0] : '';
         Assert.areEqual(testNamespace, STG_Base_CTRL.getNamespace());
+    }
+
+    /***********************************************************************************************************************************
+     ****************************************************** STUBS ***********************************************************************
+     ***********************************************************************************************************************************/
+
+    /**************************************************************************************************************************************
+     * @description Stub class to simulate the response from UserPermissionService to return true
+     **************************************************************************************************************************************/
+    private class STUB_UserPermissionServiceTrue extends UserPermissionService {
+        public override Boolean checkCustomizeApplicationForCurrentUser() {
+            return true;
+        }
     }
 }

--- a/force-app/main/default/classes/STG_CourseConnections.cls
+++ b/force-app/main/default/classes/STG_CourseConnections.cls
@@ -40,7 +40,7 @@ public class STG_CourseConnections {
     */
     @AuraEnabled
     public static Id getEnqueueCourseConnectionsBackfill() {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         CCON_ConnectionBackfill_BATCH batch = new CCON_ConnectionBackfill_BATCH();
         Id ApexJobId = Database.executeBatch(batch, 200);
         return ApexJobId;

--- a/force-app/main/default/classes/STG_CourseConnections.cls
+++ b/force-app/main/default/classes/STG_CourseConnections.cls
@@ -40,8 +40,18 @@ public class STG_CourseConnections {
     */
     @AuraEnabled
     public static Id getEnqueueCourseConnectionsBackfill() {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
         CCON_ConnectionBackfill_BATCH batch = new CCON_ConnectionBackfill_BATCH();
         Id ApexJobId = Database.executeBatch(batch, 200);
         return ApexJobId;
+    }
+
+    /*****************************************************************************
+     * @description Retrieves an instance of the UserPermissionService.
+     * @return The instance of UserPermissionService.
+     ******************************************************************************/
+    @TestVisible
+    private static UserPermissionService locateUserPermissionService() {
+        return UserPermissionService.getInstance();
     }
 }

--- a/force-app/main/default/classes/STG_CourseConnections_TEST.cls
+++ b/force-app/main/default/classes/STG_CourseConnections_TEST.cls
@@ -37,7 +37,21 @@
 public with sharing class STG_CourseConnections_TEST {
     @isTest
     public static void checkGetEnqueueCourseConnectionsBackfill() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
         Id apexJobId = STG_CourseConnections.getEnqueueCourseConnectionsBackfill();
         System.assertNotEquals(null, apexJobId);
+    }
+
+    /***********************************************************************************************************************************
+     ****************************************************** STUBS ***********************************************************************
+     ***********************************************************************************************************************************/
+
+    /**************************************************************************************************************************************
+     * @description Stub class to simulate the response from UserPermissionService to return true
+     **************************************************************************************************************************************/
+    private class STUB_UserPermissionServiceTrue extends UserPermissionService {
+        public override Boolean checkCustomizeApplicationForCurrentUser() {
+            return true;
+        }
     }
 }

--- a/force-app/main/default/classes/STG_Courses.cls
+++ b/force-app/main/default/classes/STG_Courses.cls
@@ -41,6 +41,8 @@ public class STG_Courses {
     */
     @AuraEnabled
     public static Id getCourseDescriptionCopyId() {
+        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        
         COUR_DescriptionCopy_BATCH contbatch = new COUR_DescriptionCopy_BATCH();
         Id jobId = Database.executeBatch( contbatch , 200 );
         if(jobId == null) {
@@ -48,5 +50,14 @@ public class STG_Courses {
         } else {
             return jobId;
         }
+    }
+
+    /*****************************************************************************
+     * @description Retrieves an instance of the UserPermissionService.
+     * @return The instance of UserPermissionService.
+     ******************************************************************************/
+    @TestVisible
+    private static UserPermissionService locateUserPermissionService() {
+        return UserPermissionService.getInstance();
     }
 }

--- a/force-app/main/default/classes/STG_Courses.cls
+++ b/force-app/main/default/classes/STG_Courses.cls
@@ -41,7 +41,7 @@ public class STG_Courses {
     */
     @AuraEnabled
     public static Id getCourseDescriptionCopyId() {
-        locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+        locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
         
         COUR_DescriptionCopy_BATCH contbatch = new COUR_DescriptionCopy_BATCH();
         Id jobId = Database.executeBatch( contbatch , 200 );

--- a/force-app/main/default/classes/STG_Courses_TEST.cls
+++ b/force-app/main/default/classes/STG_Courses_TEST.cls
@@ -37,7 +37,21 @@
 public with sharing class STG_Courses_TEST {
     @isTest
     public static void checkCourseDescriptionCopy() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
         Id apexJobId = STG_Courses.getCourseDescriptionCopyId();
         System.assertNotEquals(null, apexJobId);
+    }
+
+    /***********************************************************************************************************************************
+     ****************************************************** STUBS ***********************************************************************
+     ***********************************************************************************************************************************/
+
+    /**************************************************************************************************************************************
+     * @description Stub class to simulate the response from UserPermissionService to return true
+     **************************************************************************************************************************************/
+    private class STUB_UserPermissionServiceTrue extends UserPermissionService {
+        public override Boolean checkCustomizeApplicationForCurrentUser() {
+            return true;
+        }
     }
 }

--- a/force-app/main/default/classes/VersionCleanupBatchJobController.cls
+++ b/force-app/main/default/classes/VersionCleanupBatchJobController.cls
@@ -40,6 +40,7 @@ public with sharing class VersionCleanupBatchJobController {
     @AuraEnabled
     public static Boolean runEthnicityAndRaceBackfillJob() {
         try {
+            locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
             Boolean batchJobSuccessful = VersionCleanupBatchJobController.locateVersionCleanUpBatchJobService()
                 .runEthnicityAndRaceBackfillJob();
             return batchJobSuccessful;
@@ -56,6 +57,7 @@ public with sharing class VersionCleanupBatchJobController {
     @AuraEnabled
     public static Boolean runCourseConnectionBackfillJob() {
         try {
+            locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
             Boolean batchJobSuccessful = VersionCleanupBatchJobController.locateVersionCleanUpBatchJobService()
                 .runCourseConnectionBackfillJob();
             return batchJobSuccessful;
@@ -72,6 +74,7 @@ public with sharing class VersionCleanupBatchJobController {
     @AuraEnabled
     public static Boolean runCourseDescriptionCopyBatchJob() {
         try {
+            locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
             Boolean batchJobSuccessful = VersionCleanupBatchJobController.locateVersionCleanUpBatchJobService()
                 .runCourseDescriptionCopyBatchJob();
             return batchJobSuccessful;
@@ -86,5 +89,14 @@ public with sharing class VersionCleanupBatchJobController {
     @TestVisible
     private static VersionCleanupBatchJobService locateVersionCleanUpBatchJobService() {
         return VersionCleanupBatchJobService.getInstance();
+    }
+
+    /*****************************************************************************
+     * @description Retrieves an instance of the UserPermissionService.
+     * @return The instance of UserPermissionService.
+     ******************************************************************************/
+    @TestVisible
+    private static UserPermissionService locateUserPermissionService() {
+        return UserPermissionService.getInstance();
     }
 }

--- a/force-app/main/default/classes/VersionCleanupBatchJobController.cls
+++ b/force-app/main/default/classes/VersionCleanupBatchJobController.cls
@@ -40,7 +40,7 @@ public with sharing class VersionCleanupBatchJobController {
     @AuraEnabled
     public static Boolean runEthnicityAndRaceBackfillJob() {
         try {
-            locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+            locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
             Boolean batchJobSuccessful = VersionCleanupBatchJobController.locateVersionCleanUpBatchJobService()
                 .runEthnicityAndRaceBackfillJob();
             return batchJobSuccessful;
@@ -57,7 +57,7 @@ public with sharing class VersionCleanupBatchJobController {
     @AuraEnabled
     public static Boolean runCourseConnectionBackfillJob() {
         try {
-            locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+            locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
             Boolean batchJobSuccessful = VersionCleanupBatchJobController.locateVersionCleanUpBatchJobService()
                 .runCourseConnectionBackfillJob();
             return batchJobSuccessful;
@@ -74,7 +74,7 @@ public with sharing class VersionCleanupBatchJobController {
     @AuraEnabled
     public static Boolean runCourseDescriptionCopyBatchJob() {
         try {
-            locateUserPermissionService.checkCustomizeApplicationForCurrentUser();
+            locateUserPermissionService().checkCustomizeApplicationForCurrentUser();
             Boolean batchJobSuccessful = VersionCleanupBatchJobController.locateVersionCleanUpBatchJobService()
                 .runCourseDescriptionCopyBatchJob();
             return batchJobSuccessful;

--- a/force-app/main/default/classes/VersionCleanupBatchJobController_TEST.cls
+++ b/force-app/main/default/classes/VersionCleanupBatchJobController_TEST.cls
@@ -38,6 +38,7 @@ private with sharing class VersionCleanupBatchJobController_TEST {
      ***********************************************************************************************************************************/
     @isTest
     private static void locateVersionCleanUpBatchJobService() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
         Test.startTest();
         VersionCleanupBatchJobService versionCleanupBatchJobServiceInstance = VersionCleanupBatchJobService.getInstance();
         Test.stopTest();
@@ -54,6 +55,7 @@ private with sharing class VersionCleanupBatchJobController_TEST {
      ***********************************************************************************************************************************/
     @isTest
     private static void runEthnicityAndRaceBackfillJobValid() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
         VersionCleanupBatchJobService.instance = new STUB_EthnicityAndRaceBackfillJobServiceValid();
         Test.startTest();
         Boolean batchJobSuccessful = VersionCleanupBatchJobController.runEthnicityAndRaceBackfillJob();
@@ -67,6 +69,7 @@ private with sharing class VersionCleanupBatchJobController_TEST {
      ***********************************************************************************************************************************/
     @isTest
     private static void runEthnicityAndRaceBackfillJobError() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
         VersionCleanupBatchJobService.instance = new STUB_EthnicityAndRaceBackfillJobServiceInvalid();
         try {
             Test.startTest();
@@ -83,6 +86,7 @@ private with sharing class VersionCleanupBatchJobController_TEST {
      ***********************************************************************************************************************************/
     @isTest
     private static void runCourseConnectionBackfillBatchJobValid() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
         VersionCleanupBatchJobService.instance = new STUB_runCourseConnectionBackfillJobServiceValid();
         Test.startTest();
         Boolean batchJobSuccessful = VersionCleanupBatchJobController.runCourseConnectionBackfillJob();
@@ -95,6 +99,7 @@ private with sharing class VersionCleanupBatchJobController_TEST {
      ***********************************************************************************************************************************/
     @isTest
     private static void runCourseDescriptionCopyBatchJobValid() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
         VersionCleanupBatchJobService.instance = new STUB_CopyCourseDescriptionJobServiceValid();
         Test.startTest();
         Boolean batchJobSuccessful = VersionCleanupBatchJobController.runCourseDescriptionCopyBatchJob();
@@ -108,6 +113,7 @@ private with sharing class VersionCleanupBatchJobController_TEST {
      ***********************************************************************************************************************************/
     @isTest
     private static void runCourseConnectionBackfillBatchJobError() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
         VersionCleanupBatchJobService.instance = new STUB_runCourseConnectionBackfillJobServiceInValid();
         try {
             Test.startTest();
@@ -123,6 +129,7 @@ private with sharing class VersionCleanupBatchJobController_TEST {
      ***********************************************************************************************************************************/
     @isTest
     private static void runCourseDescriptionCopyBatchJobError() {
+        UserPermissionService.instance = new STUB_UserPermissionServiceTrue();
         VersionCleanupBatchJobService.instance = new STUB_CopyCourseDescriptionJobServiceInvalid();
         try {
             Test.startTest();
@@ -191,6 +198,15 @@ private with sharing class VersionCleanupBatchJobController_TEST {
     private class STUB_CopyCourseDescriptionJobServiceInvalid extends VersionCleanupBatchJobService {
         public override Boolean runCourseDescriptionCopyBatchJob() {
             throw new AuraHandledException(Label.BatchJobRunningProblem);
+        }
+    }
+
+    /**************************************************************************************************************************************
+     * @description Stub class to simulate the response from UserPermissionService to return true
+     **************************************************************************************************************************************/
+    private class STUB_UserPermissionServiceTrue extends UserPermissionService {
+        public override Boolean checkCustomizeApplicationForCurrentUser() {
+            return true;
         }
     }
 }


### PR DESCRIPTION
# Critical Changes

- STG_Base_CTRL custom settings updates now require the Customize Application permission
- Launching EDA batch jobs from the EDA Settings UI, its dependent classes, and the old setting's dependent classes now requires the Customize Application permission.

# Changes

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
